### PR TITLE
TSO command stage 2 execution

### DIFF
--- a/src/main/java/IssueTsoCommandTest.java
+++ b/src/main/java/IssueTsoCommandTest.java
@@ -22,12 +22,12 @@ public class IssueTsoCommandTest {
     private static final Logger LOG = LogManager.getLogger(IssueTsoCommandTest.class);
 
     public static void main(String[] args) {
-        String hostName = "usilCA31.lvn.broadcom.net";
-        String port = "1443";
-        String userName = "FG892105";
-        String password = "dell101D";
-        String command = "status";
-        String accountNumber = "105200000";
+        String hostName = "XXX";
+        String port = "XXX";
+        String userName = "XXX";
+        String password = "XXX";
+        String command = "XXX";
+        String accountNumber = "XXX";
 
         ZOSConnection connection = new ZOSConnection(hostName, port, userName, password);
 

--- a/src/main/java/SubmitJobsTest.java
+++ b/src/main/java/SubmitJobsTest.java
@@ -20,7 +20,7 @@ public class SubmitJobsTest {
 
     private static final Logger LOG = LogManager.getLogger(SubmitJobsTest.class);
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws Exception {
         String hostName = "XXX";
         String port = "XXX";
         String userName = "XXX";
@@ -36,7 +36,7 @@ public class SubmitJobsTest {
         return SubmitJobs.submitJcl(connection, jclString, null, null);
     }
 
-    private static Job tstSubmitJob(ZOSConnection connection, String dsMember) throws IOException {
+    private static Job tstSubmitJob(ZOSConnection connection, String dsMember) throws Exception {
         return SubmitJobs.submitJob(connection, dsMember);
     }
 

--- a/src/main/java/rest/JsonRequest.java
+++ b/src/main/java/rest/JsonRequest.java
@@ -51,6 +51,7 @@ public class JsonRequest implements IZoweRequest {
     private final HttpClient client = HttpClientBuilder.create().build();
     private final ResponseHandler<String> handler = new BasicResponseHandler();
     private HttpContext localContext = new BasicHttpContext();
+    private HttpResponse httpResponse;
 
     // disable end user from calling default constructor
     private JsonRequest() {
@@ -103,16 +104,16 @@ public class JsonRequest implements IZoweRequest {
         if (!headers.isEmpty()) headers.forEach((key, value) -> putRequest.setHeader(key, value));
         putRequest.setEntity(new StringEntity(body.orElse("")));
 
-        HttpResponse response = client.execute(putRequest, localContext);
-        int statusCode = response.getStatusLine().getStatusCode();
+        this.httpResponse = client.execute(putRequest, localContext);
+        int statusCode = httpResponse.getStatusLine().getStatusCode();
 
-        LOG.info("JsonRequest::httpPost - Response statusCode {}, Response {}", response.getStatusLine().getStatusCode(), response.toString());
+        LOG.info("JsonRequest::httpPost - Response statusCode {}, Response {}", httpResponse.getStatusLine().getStatusCode(), httpResponse.toString());
 
         if (statusCode != 200) {
-            return (T) new Response(response.getStatusLine().getReasonPhrase(), statusCode);
+            return (T) new Response(httpResponse.getStatusLine().getReasonPhrase(), statusCode);
         }
 
-        HttpEntity entity = response.getEntity();
+        HttpEntity entity = httpResponse.getEntity();
         if (entity != null) {
             result = EntityUtils.toString(entity);
             LOG.info("JsonRequest::httpPut - result = {}", result);
@@ -132,16 +133,17 @@ public class JsonRequest implements IZoweRequest {
         String result = null;
         if (!headers.isEmpty()) headers.forEach((key, value) -> postRequest.setHeader(key, value));
 
-        HttpResponse response = client.execute(postRequest, localContext);
-        int statusCode = response.getStatusLine().getStatusCode();
+        this.httpResponse = client.execute(postRequest, localContext);
+        int statusCode = httpResponse.getStatusLine().getStatusCode();
 
-        LOG.info("Response statusCode {}, Response {}", response.getStatusLine().getStatusCode(), response.toString());
+        LOG.info("Response statusCode {}, Response {}", httpResponse.getStatusLine().getStatusCode(),
+                httpResponse.toString());
 
         if (statusCode != 200) {
-            return (T) new Response(response.getStatusLine().getReasonPhrase(), statusCode);
+            return (T) new Response(httpResponse.getStatusLine().getReasonPhrase(), statusCode);
         }
 
-        HttpEntity entity = response.getEntity();
+        HttpEntity entity = httpResponse.getEntity();
         if (entity != null) {
             result = EntityUtils.toString(entity);
             LOG.info("Response result {}", result);

--- a/src/main/java/rest/TextRequest.java
+++ b/src/main/java/rest/TextRequest.java
@@ -24,6 +24,7 @@ import utility.Util;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 public class TextRequest implements IZoweRequest {
 
@@ -32,7 +33,7 @@ public class TextRequest implements IZoweRequest {
     private HttpPut putRequest;
     private HttpPut postRequest;
     private HttpDelete deleteRequest;
-    private String body;
+    private Optional<String> body;
     private Map<String, String> headers = new HashMap<>();
     private HttpClient client = HttpClientBuilder.create().build();
     private ResponseHandler<String> handler = new BasicResponseHandler();
@@ -43,14 +44,15 @@ public class TextRequest implements IZoweRequest {
         this.setup();
     }
 
-    public TextRequest(ZOSConnection connection, HttpPut putRequest, String body) {
+    public TextRequest(ZOSConnection connection, HttpPut putRequest, Optional<String> body) {
         this.connection = connection;
         this.putRequest = putRequest;
         this.body = body;
         this.setup();
     }
 
-    private TextRequest() {} // this disables end user from calling default constructor
+    // this disables end user from calling default constructor
+    private TextRequest() {}
 
     @Override
     public <T> T httpGet() throws IOException {
@@ -61,7 +63,7 @@ public class TextRequest implements IZoweRequest {
     @Override
     public <T> T httpPut() throws IOException {
         if (!headers.isEmpty()) headers.forEach((key, value) -> putRequest.setHeader(key, value));
-        putRequest.setEntity(new StringEntity(body));
+        putRequest.setEntity(new StringEntity(body.orElse("")));
 
         return (T) client.execute(putRequest, handler);
     }

--- a/src/main/java/utility/UtilTso.java
+++ b/src/main/java/utility/UtilTso.java
@@ -11,16 +11,11 @@ package utility;
 
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
+import rest.Response;
 import zostso.TsoConstants;
-import zostso.zosmf.TsoMessage;
-import zostso.zosmf.TsoMessages;
-import zostso.zosmf.TsoPromptMessage;
-import zostso.zosmf.ZosmfTsoResponse;
+import zostso.zosmf.*;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 public class UtilTso {
 
@@ -35,7 +30,22 @@ public class UtilTso {
                 .reused((boolean) obj.get("reused")).timeout((boolean) obj.get("timeout")).build();
     }
 
-    public static ZosmfTsoResponse parseJsonTsoResponse(JSONObject result) {
+    public static ZosmfTsoResponse getZosmfTsoResponse(Response response) {
+        Util.checkNullParameter(response == null, "response is null");
+        Util.checkNullParameter(response.getResult() == null, "response result is null");
+        ZosmfTsoResponse result;
+        if (response.getStatusCode() != 200) {
+            String errorMsg = (String) response.getResult();
+            ZosmfMessages zosmfMsg = new ZosmfMessages(Optional.of(errorMsg), Optional.empty(), Optional.empty());
+            result = new ZosmfTsoResponse.Builder().msgData(Arrays.asList(zosmfMsg)).build();
+        } else {
+            result = UtilTso.parseJsonTsoResponse((JSONObject) response.getResult());
+        }
+
+        return result;
+    }
+
+    private static ZosmfTsoResponse parseJsonTsoResponse(JSONObject result) {
         Util.checkNullParameter(result == null, "No results to parse.");
 
         ZosmfTsoResponse response = new ZosmfTsoResponse.Builder().queueId((String) result.get("queueID"))

--- a/src/main/java/zosconsole/IssueCommand.java
+++ b/src/main/java/zosconsole/IssueCommand.java
@@ -22,6 +22,8 @@ import rest.IZoweRequest;
 import rest.JsonRequest;
 import utility.Util;
 
+import java.util.Optional;
+
 public class IssueCommand {
 
     private static final Logger LOG = LogManager.getLogger(IssueCommand.class);
@@ -42,7 +44,7 @@ public class IssueCommand {
         reqBody.put("cmd", commandParms.getCmd().get());
         LOG.debug(reqBody);
 
-        IZoweRequest request = new JsonRequest(connection, new HttpPut(url), reqBody.toString());
+        IZoweRequest request = new JsonRequest(connection, new HttpPut(url), Optional.of(reqBody.toString()));
         JSONObject result = request.httpPut();
 
         if (result == null) {

--- a/src/main/java/zosconsole/IssueCommand.java
+++ b/src/main/java/zosconsole/IssueCommand.java
@@ -12,6 +12,7 @@ package zosconsole;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import rest.Response;
 import zosconsole.zosmf.IssueParms;
 import zosconsole.zosmf.ZosmfIssueParms;
 import zosconsole.zosmf.ZosmfIssueResponse;
@@ -45,21 +46,21 @@ public class IssueCommand {
         LOG.debug(reqBody);
 
         IZoweRequest request = new JsonRequest(connection, new HttpPut(url), Optional.of(reqBody.toString()));
-        JSONObject result = request.httpPut();
-
-        if (result == null) {
+        Response response = request.httpPut();
+        if (response.getResult() == null || response.getStatusCode() != 200) {
             throw new Exception("No results for console command " + reqBody);
         }
-        LOG.debug(result);
+        LOG.debug("Response result {}", response.getResult());
 
-        ZosmfIssueResponse response = new ZosmfIssueResponse();
-        response.setCmdResponseKey((String) result.get("cmd-response-key"));
-        response.setCmdResponseUrl((String) result.get("cmd-response-url"));
-        response.setCmdResponseUri((String) result.get("cmd-response-uri"));
-        response.setCmdResponse((String) result.get("cmd-response"));
-        response.setSolKeyDetected((String) result.get("sol-key-detected"));
+        ZosmfIssueResponse zosmfIssueResponse = new ZosmfIssueResponse();
+        JSONObject result = (JSONObject) response.getResult();
+        zosmfIssueResponse.setCmdResponseKey((String) result.get("cmd-response-key"));
+        zosmfIssueResponse.setCmdResponseUrl((String) result.get("cmd-response-url"));
+        zosmfIssueResponse.setCmdResponseUri((String) result.get("cmd-response-uri"));
+        zosmfIssueResponse.setCmdResponse((String) result.get("cmd-response"));
+        zosmfIssueResponse.setSolKeyDetected((String) result.get("sol-key-detected"));
 
-        return response;
+        return zosmfIssueResponse;
     }
 
     /**

--- a/src/main/java/zosjobs/SubmitJobs.java
+++ b/src/main/java/zosjobs/SubmitJobs.java
@@ -29,6 +29,7 @@ import zosjobs.response.Job;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 public class SubmitJobs {
 
@@ -54,7 +55,7 @@ public class SubmitJobs {
             // TODO..
         }
 
-        IZoweRequest request = new JsonRequest(connection, new HttpPut(url), reqBody.toString());
+        IZoweRequest request = new JsonRequest(connection, new HttpPut(url), Optional.of(reqBody.toString()));
         JSONObject result = request.httpPut();
 
         return UtilJobs.createJobObjFromJson(result);

--- a/src/main/java/zostso/IssueTso.java
+++ b/src/main/java/zostso/IssueTso.java
@@ -32,8 +32,8 @@ public class IssueTso {
 
         IssueResponse response = new IssueResponse(false, null, false, null,
                 null, null);
-        StartStopResponses StartResponse = StartTso.start(connection, accountNumber, startParams);
-        response.setStartResponse(Optional.ofNullable(StartResponse));
+        StartStopResponses startResponse = StartTso.start(connection, accountNumber, startParams);
+        response.setStartResponse(Optional.ofNullable(startResponse));
 
         if (response.getStartResponse().isPresent() && !response.getStartResponse().get().isSuccess()) {
             throw new Exception("TSO address space failed to start. Error: " +
@@ -41,12 +41,13 @@ public class IssueTso {
                     "Unknown error"));
         }
 
-        response.setZosmfResponse(Optional.ofNullable(StartResponse.getZosmfTsoResponse().get()));
+        response.setZosmfResponse(Optional.ofNullable(startResponse.getZosmfTsoResponse().get()));
 
         SendResponse sendResponse = SendTso.sendDataToTSOCollect(connection,
                 response.getStartResponse().get().getServletKey().get(), command);
         response.setSuccess(sendResponse.getSuccess());
-        response.setZosmfResponse(Optional.of(sendResponse.getZosmfResponse().get().get(0)));  // TODO
+        response.setZosmfResponse(Optional.of(sendResponse.getZosmfResponse().get().get(0)));
+        startResponse.setCollectedResponses(sendResponse.getZosmfResponse().get());
         response.setCommandResponses(sendResponse.getCommandResponse());
         response.setStopResponse(Optional.ofNullable(
                 StopTso.stop(connection, response.getStartResponse().get().getServletKey().get())));

--- a/src/main/java/zostso/SendTso.java
+++ b/src/main/java/zostso/SendTso.java
@@ -57,9 +57,11 @@ public class SendTso {
         TsoResponseMessage tsoResponseMessage = new TsoResponseMessage(Optional.of("0100"),
                 Optional.ofNullable(commandParms.getData()));
         String jobObj = getTsoResponseSendMessage(tsoResponseMessage);
-        IZoweRequest request = new JsonRequest(connection, new HttpPut(url), Optional.of(jobObj));
 
+        IZoweRequest request = new JsonRequest(connection, new HttpPut(url), Optional.of(jobObj));
         Response response = request.httpPut();
+        if (response.getResult() == null || response.getStatusCode() != 200)
+            throw new Exception("No results from executing tso command after getting TSO address space.");
 
         return UtilTso.getZosmfTsoResponse(response);
     }
@@ -107,7 +109,11 @@ public class SendTso {
         LOG.info("SendTso::getDataFromTSO - url {}", url);
 
         IZoweRequest request = new JsonRequest(connection, new HttpPut(url), Optional.empty());
-        Response response = request.httpPut();
+        Response response =  request.httpPut();
+
+        if (response.getResult() == null || response.getStatusCode() != 200) {
+            throw new Exception("Follow up TSO Messages from TSO command cannot be retrieved.");
+        }
 
         return UtilTso.getZosmfTsoResponse(response);
     }

--- a/src/main/java/zostso/StartStopResponses.java
+++ b/src/main/java/zostso/StartStopResponses.java
@@ -30,8 +30,8 @@ public class StartStopResponses {
         this.zosmfTsoResponse = Optional.ofNullable(zosmfTsoResponse);
         if (zosmfTsoResponse.getMsgData().isPresent()) {
             this.success = false;
-            ZosmfMessages zosmfMsg = zosmfTsoResponse.getMsgData().get().get(0);
-            this.failureResponse = Optional.of(zosmfMsg.getMessageText().orElse(TsoConstants.ZOSMF_UNKNOWN_ERROR));
+            ZosmfMessages zOSMFMsg = zosmfTsoResponse.getMsgData().get().get(0);
+            this.failureResponse = Optional.of(zOSMFMsg.getMessageText().orElse(TsoConstants.ZOSMF_UNKNOWN_ERROR));
         } else {
             this.success = true;
             this.failureResponse = Optional.empty();
@@ -40,10 +40,10 @@ public class StartStopResponses {
             this.servletKey = Optional.of(zosmfTsoResponse.getServletKey().get());
         }
 
-        StringBuilder msgs = new StringBuilder();
+        StringBuilder buildMessage = new StringBuilder();
         List<TsoMessages> tsoMsgLst = zosmfTsoResponse.getTsoData().orElse(new ArrayList<>());
-        tsoMsgLst.forEach(msg -> msgs.append(msg));
-        this.messages = Optional.of(msgs.toString());
+        tsoMsgLst.forEach(msg -> buildMessage.append(msg));
+        this.messages = Optional.of(buildMessage.toString());
     }
 
     public Optional<ZosmfTsoResponse> getZosmfTsoResponse() {

--- a/src/main/java/zostso/StartTso.java
+++ b/src/main/java/zostso/StartTso.java
@@ -13,18 +13,13 @@ import core.ZOSConnection;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.json.simple.JSONObject;
 import rest.IZoweRequest;
 import rest.JsonRequest;
 import rest.Response;
 import utility.Util;
 import utility.UtilTso;
 import zostso.input.StartTsoParams;
-import zostso.zosmf.ZosmfMessages;
 import zostso.zosmf.ZosmfTsoResponse;
-
-import java.util.Arrays;
-import java.util.Optional;
 
 public class StartTso {
 
@@ -58,16 +53,7 @@ public class StartTso {
         IZoweRequest request = new JsonRequest(connection, new HttpPost(url));
         Response response = request.httpPost();
 
-        ZosmfTsoResponse result;
-        if (response.getStatusCode() != 200) {
-            String errorMsg = (String) response.getResult();
-            ZosmfMessages zosmfMsg = new ZosmfMessages(Optional.of(errorMsg), Optional.empty(), Optional.empty());
-            result = new ZosmfTsoResponse.Builder().msgData(Arrays.asList(zosmfMsg)).build();
-        } else {
-            result = UtilTso.parseJsonTsoResponse((JSONObject) response.getResult());
-        }
-
-        return result;
+        return UtilTso.getZosmfTsoResponse(response);
     }
 
     private static StartTsoParams setDefaultAddressSpaceParams(StartTsoParams parms, String accountNumber) {

--- a/src/main/java/zostso/StopTso.java
+++ b/src/main/java/zostso/StopTso.java
@@ -32,7 +32,7 @@ public class StopTso {
 
         String url = "https://" + connection.getHost() + ":" + connection.getPort() +
                 TsoConstants.RESOURCE + "/" + TsoConstants.RES_START_TSO + "/" + commandParms.getServletKey().get();
-        LOG.info("StopTso::stopCommon url {}" + url);
+        LOG.info("StopTso::stopCommon url {}", url);
 
         IZoweRequest request = new JsonRequest(connection, new HttpDelete(url));
         JSONObject result = request.httpDelete();

--- a/src/main/java/zostso/zosmf/TsoMessages.java
+++ b/src/main/java/zostso/zosmf/TsoMessages.java
@@ -13,9 +13,9 @@ import java.util.Optional;
 
 public class TsoMessages {
 
-    public Optional<TsoMessage> tsoMessage;
-    public Optional<TsoPromptMessage> tsoPrompt;
-    public Optional<TsoResponseMessage> tsoResponse;
+    public Optional<TsoMessage> tsoMessage = Optional.empty();
+    public Optional<TsoPromptMessage> tsoPrompt = Optional.empty();
+    public Optional<TsoResponseMessage> tsoResponse = Optional.empty();
 
     public Optional<TsoMessage> getTsoMessage() {
         return tsoMessage;

--- a/src/test/java/rest/JsonRequestTest.java
+++ b/src/test/java/rest/JsonRequestTest.java
@@ -9,7 +9,6 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.BasicResponseHandler;
 import org.json.simple.JSONObject;
 
-import org.json.simple.parser.ParseException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
@@ -79,41 +78,6 @@ public class JsonRequestTest {
         Mockito.verify(httpClient, Mockito.times(1))
                .execute(any(HttpGet.class), any(ResponseHandler.class));
         Assertions.assertEquals(json, jsonObject.toString());
-    }
-
-    @Test
-    public void tstHttpPutThrowsException() throws IOException {
-        Mockito.when(httpClient.execute(any(HttpUriRequest.class), any(BasicResponseHandler.class)))
-               .thenThrow(new IOException());
-
-        assertThrows(IOException.class, putRequest::httpPut);
-        Mockito.verify(httpClient, Mockito.times(1))
-               .execute(any(HttpPut.class), any(ResponseHandler.class));
-    }
-
-    @Test
-    public void tstHttpPutReturnsNullForInvalidJson() throws IOException {
-        String invalidJson = UUID.randomUUID().toString();
-
-        Mockito.when(httpClient.execute(any(HttpUriRequest.class), any(ResponseHandler.class)))
-               .thenReturn(invalidJson);
-
-        Assertions.assertNull(putRequest.httpPut());
-        Mockito.verify(httpClient, Mockito.times(1))
-               .execute(any(HttpPut.class), any(ResponseHandler.class));
-    }
-
-    @Test
-    public void tstHttpPutReturnsJson() throws IOException {
-        String json = "{\"data\":{}}";
-
-        Mockito.when(httpClient.execute(any(HttpUriRequest.class), any(ResponseHandler.class)))
-               .thenReturn(json);
-
-        JSONObject jsonObject = putRequest.httpPut();
-        Assertions.assertEquals(json, jsonObject.toString());
-        Mockito.verify(httpClient, Mockito.times(1))
-               .execute(any(HttpPut.class), any(BasicResponseHandler.class));
     }
 
 }

--- a/src/test/java/rest/JsonRequestTest.java
+++ b/src/test/java/rest/JsonRequestTest.java
@@ -19,6 +19,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.powermock.reflect.Whitebox;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -41,7 +42,7 @@ public class JsonRequestTest {
         Whitebox.setInternalState(getRequest, "client", httpClient);
 
         HttpPut httpPut = Mockito.mock(HttpPut.class);
-        putRequest = new JsonRequest(connection, httpPut, "");
+        putRequest = new JsonRequest(connection, httpPut, Optional.empty());
         Whitebox.setInternalState(putRequest, "client", httpClient);
     }
 

--- a/src/test/java/rest/TextRequestTest.java
+++ b/src/test/java/rest/TextRequestTest.java
@@ -14,6 +14,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.powermock.reflect.Whitebox;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -35,7 +36,7 @@ public class TextRequestTest {
         Whitebox.setInternalState(getRequest, "client", httpClient);
 
         HttpPut httpPut = Mockito.mock(HttpPut.class);
-        putRequest = new JsonRequest(connection, httpPut, "");
+        putRequest = new JsonRequest(connection, httpPut, Optional.empty());
         Whitebox.setInternalState(putRequest, "client", httpClient);
     }
 

--- a/src/test/java/rest/TextRequestTest.java
+++ b/src/test/java/rest/TextRequestTest.java
@@ -50,14 +50,4 @@ public class TextRequestTest {
                .execute(any(HttpGet.class), any(ResponseHandler.class));
     }
 
-    @Test
-    public void tstHttpPutThrowsException() throws IOException {
-        Mockito.when(httpClient.execute(any(HttpUriRequest.class), any(ResponseHandler.class)))
-               .thenThrow(new IOException());
-
-        assertThrows(IOException.class, putRequest::httpPut);
-        Mockito.verify(httpClient, Mockito.times(1))
-               .execute(any(HttpPut.class), any(ResponseHandler.class));
-    }
-
 }


### PR DESCRIPTION
I made changes to successfully retrieve the TSO output of a TSO command. This is done within the second rest call in this workflow. Stage 1 PRs handled the first rest call which started a TSO address space waiting for us to send commands too. This first rest command returned a servlet id and response. The servlet id is used in the second rest uri being sent with a JSON body describing the command to perform. The JSON body had to be specified with no spaces to get it to work. This is very zosmf oddity it seems. I struggled getting that to work until someone recommended it that way. I made changes to properly propagate the responses of the TSO command to the end user. Lastly, I made changes to the PUT and POST code which uses a new Response POJO/class to store a HttpResponse results and status code. This allows us to check http return codes like 200, 404, 500 etc.. Before it was not interested in that and just return the string results. I had to remove some of the test code for PUT and POST as it is more complicated to mock these methods and will be a future TODO.  