### PR TITLE
Fixes #143

### DIFF
--- a/src/main/java/utility/UtilDataset.java
+++ b/src/main/java/utility/UtilDataset.java
@@ -12,6 +12,10 @@ package utility;
 import org.json.simple.JSONObject;
 import zosfiles.response.Dataset;
 
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * Utility Class for Dataset related static helper methods.
  *
@@ -63,6 +67,72 @@ public class UtilDataset {
             throw new Exception(errorMsg + " You may not have permission to view " + dataSetName + ".");
         }
         throw new Exception(errorMsg);
+    }
+
+    /**
+     * Verifies that a dataset follows the naming conventions that IBM has defined:
+     * Segment naming rules
+     * - A data set name must be composed of at least two joined character segments (qualifiers), separated by a
+     * period (.); for example, HLQ.ABC.XYZ.
+     * - A data set name cannot be longer than 44 characters.
+     * - A data set name cannot contain two successive periods; for example, HLQ..ABC.
+     * - A data set name cannot end with a period.
+     * - Each segment in a data set name represents a level of qualification. For example, the first segment
+     * represents the high-level qualifier (HLQ), and the last segment represents the lowest-level qualifier (LLQ).
+     * - A segment cannot be longer than eight characters.
+     * - The first segment character must be either a letter or one of the following three special characters: #,
+     * @, $.
+     * - The remaining seven characters in a segment can be letters, numbers, special characters (only #, @, or
+     * $), or a hyphen (-).
+     * - A data set name cannot contain accented characters (à, é, è, and so on).
+     *
+     * @param dataSetName The dataset name to validate as per the above rules
+     * @param additionalTests     Set to true to check that a dataset has more than one segment (for example, when used by
+     *                    listMembers()).  Set to false to ignore this check (for example, when used by listDsn()).
+     * @throws Exception
+     * @author Corinne DeStefano
+     */
+    public static void checkDatasetName(String dataSetName, boolean additionalTests) throws Exception {
+        dataSetName = dataSetName.toUpperCase(Locale.ROOT);
+        String invalidDatasetMsg = "Invalid data set name '" + dataSetName + "'.";
+
+        // Check that the dataset contains more than one segment
+        // This could be valid for additionalTests
+        String[] segments = dataSetName.split("\\.");
+        if (additionalTests) {
+            if (segments.length < 2) {
+                throw new Exception(invalidDatasetMsg);
+            }
+        }
+
+        // The length cannot be longer than 44
+        if (dataSetName.length() > 44) {
+            throw new Exception(invalidDatasetMsg);
+        }
+
+        // The name cannot contain two successive periods
+        if (dataSetName.contains("..")) {
+            throw new Exception(invalidDatasetMsg);
+        }
+
+        // Cannot end in a period
+        if (dataSetName.endsWith(".")) {
+            throw new Exception(invalidDatasetMsg);
+        }
+
+        // Each segment cannot be more than 8 characters
+        // Each segment's first letter is a letter or #, @, $.
+        // The remaining seven characters in a segment can be letters, numbers, and #, @, $, -
+        for (String segment : segments) {
+            if (segment.length() > 8) {
+                throw new Exception(invalidDatasetMsg);
+            }
+            Pattern p = Pattern.compile("[A-Z#@\\$]{1}[A-Z0-9#@\\$\\-]{1,7}");
+            Matcher m = p.matcher(segment);
+            if (!m.matches()) {
+                throw new Exception(invalidDatasetMsg);
+            }
+        }
     }
 
 }

--- a/src/main/java/utility/UtilDataset.java
+++ b/src/main/java/utility/UtilDataset.java
@@ -80,16 +80,16 @@ public class UtilDataset {
      * - Each segment in a data set name represents a level of qualification. For example, the first segment
      * represents the high-level qualifier (HLQ), and the last segment represents the lowest-level qualifier (LLQ).
      * - A segment cannot be longer than eight characters.
-     * - The first segment character must be either a letter or one of the following three special characters: #,
-     * @, $.
-     * - The remaining seven characters in a segment can be letters, numbers, special characters (only #, @, or
-     * $), or a hyphen (-).
+     * - The first segment character must be either a letter or one of the following three special
+     * characters: #, *, @, $.
+     * - The remaining seven characters in a segment can be letters, numbers,
+     * special characters (only #, @, or * $), or a hyphen (-).
      * - A data set name cannot contain accented characters (à, é, è, and so on).
      *
-     * @param dataSetName The dataset name to validate as per the above rules
-     * @param additionalTests     Set to true to check that a dataset has more than one segment (for example, when used by
-     *                    listMembers()).  Set to false to ignore this check (for example, when used by listDsn()).
-     * @throws Exception
+     * @param dataSetName     Dataset name to validate as per the above rules
+     * @param additionalTests Set to true to check that a dataset has more than one segment (for example, when used by
+     *                        listMembers()). Set to false to ignore this check (for example, when used by listDsn()).
+     * @throws Exception if given dataset format is invalid
      * @author Corinne DeStefano
      */
     public static void checkDatasetName(String dataSetName, boolean additionalTests) throws Exception {

--- a/src/main/java/zosfiles/ZosDsnList.java
+++ b/src/main/java/zosfiles/ZosDsnList.java
@@ -59,6 +59,7 @@ public class ZosDsnList {
         Util.checkNullParameter(dataSetName == null, "dataSetName is null");
         Util.checkStateParameter(dataSetName.isEmpty(), "dataSetName not specified");
         Util.checkConnection(connection);
+        UtilDataset.checkDatasetName(dataSetName, true);
 
         Map<String, String> headers = new HashMap<>();
         List<String> members = new ArrayList<>();
@@ -106,6 +107,7 @@ public class ZosDsnList {
         Util.checkNullParameter(dataSetName == null, "dataSetName is null");
         Util.checkStateParameter(dataSetName.isEmpty(), "dataSetName not specified");
         Util.checkConnection(connection);
+        UtilDataset.checkDatasetName(dataSetName, false);
 
         Map<String, String> headers = new HashMap<>();
         List<Dataset> datasets = new ArrayList<>();

--- a/src/test/java/utility/UtilDatasetTest.java
+++ b/src/test/java/utility/UtilDatasetTest.java
@@ -1,0 +1,74 @@
+package utility;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class UtilDatasetTest {
+
+    @Test
+    public void checkValidDatasetName() {
+        List<String> validDatasetNames = Arrays.asList(
+                "DSNAME.NOTEXIST",
+                "#DSNAME.NOTEXIST",
+                "@DSNAME.NOTEXIST",
+                "$DSNAME.NOTEXIST",
+                "DS#NAME.NOTEXIST",
+                "DS@NAME.NOTEXIST",
+                "DS$NAME.NOTEXIST",
+                "DSNAME.#NOEXIST",
+                "DSNAME.@NOEXIST",
+                "DSNAME.$NOEXIST",
+                "DSNAME.NO$EXIST",
+                "DSNAME.NO@EXIST",
+                "DSNAME.NO#EXIST",
+                "DSNAME.NO-EXIST",
+                "DSNAME.LLQ1.#NOEXIST",
+                "DSNAME.LLQ1.@NOEXIST",
+                "DSNAME.LLQ1.$NOEXIST",
+                "DSNAME.LLQ1.NO$EXIST",
+                "DSNAME.LLQ1.NO@EXIST",
+                "DSNAME.LLQ1.NO#EXIST",
+                "DSNAME.LLQ1.NO-EXIST"
+        );
+
+        for (String validDatasetName : validDatasetNames) {
+            assertDoesNotThrow(() -> {
+                UtilDataset.checkDatasetName(validDatasetName, true);
+            });
+        }
+
+        assertDoesNotThrow(() -> {
+            UtilDataset.checkDatasetName("DSNAME", false);
+        });
+
+    }
+
+    @Test
+    public void checkInvalidDatasetName() {
+        List<String> invalidDatasetNames = Arrays.asList(
+                "DSNAME.ITSTOOLONG.DS",
+                "DSNAME",
+                "DSNAME..LLQ.DS",
+                "DSNAME.LLQ.",
+                "DSNAME.DS%^&.DS",
+                "DSNAME.VERYLONG.MORE.THAN.FORTY.FOUR.CHARS.LONG.INVALID",
+                "DSNAME.0123.DS"
+        );
+
+        for (String invalidDatasetName : invalidDatasetNames) {
+            Exception exception = assertThrows(Exception.class, () -> {
+                UtilDataset.checkDatasetName(invalidDatasetName, true);
+            });
+
+            assertTrue(invalidDatasetName,
+                    exception.getMessage().contains("Invalid data set name '" + invalidDatasetName + "'"));
+        }
+
+    }
+}

--- a/src/test/java/utility/UtilDatasetTest.java
+++ b/src/test/java/utility/UtilDatasetTest.java
@@ -38,14 +38,10 @@ public class UtilDatasetTest {
         );
 
         for (String validDatasetName : validDatasetNames) {
-            assertDoesNotThrow(() -> {
-                UtilDataset.checkDatasetName(validDatasetName, true);
-            });
+            assertDoesNotThrow(() -> UtilDataset.checkDatasetName(validDatasetName, true));
         }
 
-        assertDoesNotThrow(() -> {
-            UtilDataset.checkDatasetName("DSNAME", false);
-        });
+        assertDoesNotThrow(() -> UtilDataset.checkDatasetName("DSNAME", false));
 
     }
 
@@ -62,13 +58,12 @@ public class UtilDatasetTest {
         );
 
         for (String invalidDatasetName : invalidDatasetNames) {
-            Exception exception = assertThrows(Exception.class, () -> {
-                UtilDataset.checkDatasetName(invalidDatasetName, true);
-            });
+            Exception exception = assertThrows(Exception.class,
+                    () -> UtilDataset.checkDatasetName(invalidDatasetName, true));
 
             assertTrue(invalidDatasetName,
                     exception.getMessage().contains("Invalid data set name '" + invalidDatasetName + "'"));
         }
-
     }
+
 }


### PR DESCRIPTION
Add UtilDataset.checkDatasetName() that rejects a input dataset that could never be a valid dataset name, thus preventing it from building a rest call.  Add to ZosDsnList.

Add UtilDatasetTest to verify its functionality.

See [my github repo](https://github.gwd.broadcom.net/cd612833/test-zowe-java-sdk/blob/master/src/test/java/ZosDsnListTest.java) for system tests.

Let me know what you think of this approach.  I can add the dataset validation to the other objects that utilize datasets if you think this looks good.  

Signed-off-by: Corinne DeStefano <corinne.destefano@broadcom.com>