### PR TITLE
Fixes #151

### DIFF
--- a/src/main/java/zosfiles/ZosDsn.java
+++ b/src/main/java/zosfiles/ZosDsn.java
@@ -54,31 +54,29 @@ public class ZosDsn {
      * @param content     new content of the dataset or a dataset member
      * @author Leonid Baranov
      */
-    public void writeDsn(String dataSetName, String content) {
+    public void writeDsn(String dataSetName, String content) throws Exception {
         Util.checkNullParameter(dataSetName == null, "dataSetName is null");
         Util.checkStateParameter(dataSetName.isEmpty(), "dataSetName not specified");
         Util.checkConnection(connection);
 
         String url = "https://" + connection.getHost() + ":" + connection.getZosmfPort()
-                + ZosFilesConstants.RESOURCE + ZosFilesConstants.RES_DS_FILES + "/" + dataSetName;
+                + ZosFilesConstants.RESOURCE + ZosFilesConstants.RES_DS_FILES + "/"
+                + Util.encodeURIComponent(dataSetName);
+
+        LOG.debug(url);
+
+        ZoweRequest request = ZoweRequestFactory.buildRequest(connection, url, content,
+                ZoweRequestType.VerbType.PUT_TEXT);
+        Response response = request.executeHttpRequest();
+        if (response.isEmpty())
+            return;
 
         try {
-            LOG.debug(url);
-
-            ZoweRequest request = ZoweRequestFactory.buildRequest(connection, url, content,
-                    ZoweRequestType.VerbType.PUT_TEXT);
-            Response response = request.executeHttpRequest();
-            if (response.isEmpty())
-                return;
-
-            try {
-                UtilRest.checkHttpErrors(response);
-            } catch (Exception e) {
-                UtilDataset.checkHttpErrors(e.getMessage(), dataSetName);
-            }
+            UtilRest.checkHttpErrors(response);
         } catch (Exception e) {
-            e.printStackTrace();
+            UtilDataset.checkHttpErrors(e.getMessage(), dataSetName);
         }
+
     }
 
     /**
@@ -87,30 +85,27 @@ public class ZosDsn {
      * @param dataSetName name of a dataset or a dataset member (f.e. 'DATASET.LIB(MEMBER)')
      * @author Leonid Baranov
      */
-    public void deleteDsn(String dataSetName) {
+    public void deleteDsn(String dataSetName) throws Exception {
         Util.checkNullParameter(dataSetName == null, "dataSetName is null");
         Util.checkStateParameter(dataSetName.isEmpty(), "dataSetName not specified");
         Util.checkConnection(connection);
 
         String url = "https://" + connection.getHost() + ":" + connection.getZosmfPort()
-                + ZosFilesConstants.RESOURCE + ZosFilesConstants.RES_DS_FILES + "/" + dataSetName;
+                + ZosFilesConstants.RESOURCE + ZosFilesConstants.RES_DS_FILES + "/"
+                + Util.encodeURIComponent(dataSetName);
+
+        LOG.debug(url);
+
+        ZoweRequest request = ZoweRequestFactory.buildRequest(connection, url, null,
+                ZoweRequestType.VerbType.DELETE_JSON);
+        Response response = request.executeHttpRequest();
+        if (response.isEmpty())
+            return;
 
         try {
-            LOG.debug(url);
-
-            ZoweRequest request = ZoweRequestFactory.buildRequest(connection, url, null,
-                    ZoweRequestType.VerbType.DELETE_JSON);
-            Response response = request.executeHttpRequest();
-            if (response.isEmpty())
-                return;
-
-            try {
-                UtilRest.checkHttpErrors(response);
-            } catch (Exception e) {
-                UtilDataset.checkHttpErrors(e.getMessage(), dataSetName);
-            }
+            UtilRest.checkHttpErrors(response);
         } catch (Exception e) {
-            e.printStackTrace();
+            UtilDataset.checkHttpErrors(e.getMessage(), dataSetName);
         }
     }
 
@@ -121,35 +116,33 @@ public class ZosDsn {
      * @param params      create dataset parameters, see CreateParams object
      * @author Leonid Baranov
      */
-    public void createDsn(String dataSetName, CreateParams params) {
+    public void createDsn(String dataSetName, CreateParams params) throws Exception {
         Util.checkNullParameter(params == null, "params is null");
         Util.checkNullParameter(dataSetName == null, "dataSetName is null");
         Util.checkStateParameter(dataSetName.isEmpty(), "dataSetName not specified");
         Util.checkConnection(connection);
 
         String url = "https://" + connection.getHost() + ":" + connection.getZosmfPort()
-                + ZosFilesConstants.RESOURCE + ZosFilesConstants.RES_DS_FILES + "/" + dataSetName;
+                + ZosFilesConstants.RESOURCE + ZosFilesConstants.RES_DS_FILES + "/"
+                + Util.encodeURIComponent(dataSetName);
+
+        LOG.debug(url);
+
+        String body = buildBody(params);
+
+        ZoweRequest request = ZoweRequestFactory.buildRequest(connection, url, body,
+                ZoweRequestType.VerbType.POST_JSON);
+
+        Response response = request.executeHttpRequest();
+        if (response.isEmpty())
+            return;
 
         try {
-            LOG.debug(url);
-
-            String body = buildBody(params);
-
-            ZoweRequest request = ZoweRequestFactory.buildRequest(connection, url, body,
-                    ZoweRequestType.VerbType.POST_JSON);
-
-            Response response = request.executeHttpRequest();
-            if (response.isEmpty())
-                return;
-
-            try {
-                UtilRest.checkHttpErrors(response);
-            } catch (Exception e) {
-                UtilDataset.checkHttpErrors(e.getMessage(), dataSetName);
-            }
+            UtilRest.checkHttpErrors(response);
         } catch (Exception e) {
-            e.printStackTrace();
+            UtilDataset.checkHttpErrors(e.getMessage(), dataSetName);
         }
+
     }
 
     /**

--- a/src/main/java/zosfiles/ZosDsnList.java
+++ b/src/main/java/zosfiles/ZosDsnList.java
@@ -65,7 +65,7 @@ public class ZosDsnList {
         List<String> members = new ArrayList<>();
         String url = "https://" + connection.getHost() + ":" + connection.getZosmfPort()
                 + ZosFilesConstants.RESOURCE + ZosFilesConstants.RES_DS_FILES + "/"
-                + dataSetName + ZosFilesConstants.RES_DS_MEMBERS;
+                + Util.encodeURIComponent(dataSetName) + ZosFilesConstants.RES_DS_MEMBERS;
 
         if (params.getPattern().isPresent()) {
             url += QueryConstants.QUERY_ID + ZosFilesConstants.QUERY_PATTERN + params.getPattern().get();
@@ -114,7 +114,7 @@ public class ZosDsnList {
         String url = "https://" + connection.getHost() + ":" + connection.getZosmfPort()
                 + ZosFilesConstants.RESOURCE + ZosFilesConstants.RES_DS_FILES + QueryConstants.QUERY_ID;
 
-        url += ZosFilesConstants.QUERY_DS_LEVEL + dataSetName;
+        url += ZosFilesConstants.QUERY_DS_LEVEL + Util.encodeURIComponent(dataSetName);
 
         if (params.getVolume().isPresent()) {
             url += QueryConstants.COMBO_ID + ZosFilesConstants.QUERY_VOLUME + params.getVolume().get();

--- a/src/main/java/zosfiles/examples/WriteDataset.java
+++ b/src/main/java/zosfiles/examples/WriteDataset.java
@@ -40,7 +40,7 @@ public class WriteDataset {
         WriteDataset.writeToDsnMember(connection, datasetMember, "NEW CONTENT\nTHE SECOND LINE UPDATED");
     }
 
-    private static void writeToDsnMember(ZOSConnection connection, String datasetMember, String content) {
+    private static void writeToDsnMember(ZOSConnection connection, String datasetMember, String content) throws Exception {
         new ZosDsn(connection).writeDsn(datasetMember, content);
     }
 


### PR DESCRIPTION
Update ZosDsn to call Util.encodeURIComponent on inputs and remove the Exception squashing.
Update ZosDsnList to call Util.encodeURIComponent on inputs.
Update WriteDataset sample for new Exception.

Add a few more checks to test it in https://github.gwd.broadcom.net/MFD/zowe-client-java-sdk-tests/commit/90fc56c6e05b063abb910ea46bce2b485ebbb983

Signed-off-by: Corinne DeStefano <corinne.destefano@broadcom.com>