### PR TITLE
ZosDsn Class Optimizations

### DIFF
--- a/src/main/java/rest/JsonDeleteRequest.java
+++ b/src/main/java/rest/JsonDeleteRequest.java
@@ -70,7 +70,7 @@ public class JsonDeleteRequest extends ZoweRequest {
                 httpResponse.getStatusLine().getStatusCode(), httpResponse.toString());
 
         if (UtilRest.isHttpError(statusCode)) {
-            return new Response(Optional.ofNullable(httpResponse.getStatusLine().getReasonPhrase()), statusCode);
+            return new Response(httpResponse.getStatusLine().getReasonPhrase(), statusCode);
         }
 
         return new Response(UtilRest.getJsonResponseEntity(httpResponse), statusCode);

--- a/src/main/java/rest/JsonPutRequest.java
+++ b/src/main/java/rest/JsonPutRequest.java
@@ -76,7 +76,7 @@ public class JsonPutRequest extends ZoweRequest {
                 httpResponse.getStatusLine().getStatusCode(), httpResponse.toString());
 
         if (UtilRest.isHttpError(statusCode)) {
-            return new Response(Optional.ofNullable(httpResponse.getStatusLine().getReasonPhrase()), statusCode);
+            return new Response(httpResponse.getStatusLine().getReasonPhrase(), statusCode);
         }
 
         return new Response(UtilRest.getJsonResponseEntity(httpResponse), statusCode);

--- a/src/main/java/rest/TextGetRequest.java
+++ b/src/main/java/rest/TextGetRequest.java
@@ -71,7 +71,7 @@ public class TextGetRequest extends ZoweRequest {
                 httpResponse.getStatusLine().getStatusCode(), httpResponse.toString());
 
         if (UtilRest.isHttpError(statusCode)) {
-            return new Response(Optional.ofNullable(httpResponse.getStatusLine().getReasonPhrase()), statusCode);
+            return new Response(httpResponse.getStatusLine().getReasonPhrase(), statusCode);
         }
 
         return new Response(UtilRest.getTextResponseEntity(httpResponse), statusCode);

--- a/src/main/java/rest/TextPutRequest.java
+++ b/src/main/java/rest/TextPutRequest.java
@@ -77,7 +77,7 @@ public class TextPutRequest extends ZoweRequest {
                 httpResponse.getStatusLine().getStatusCode(), httpResponse.toString());
 
         if (UtilRest.isHttpError(statusCode)) {
-            return new Response(Optional.ofNullable(httpResponse.getStatusLine().getReasonPhrase()), statusCode);
+            return new Response(httpResponse.getStatusLine().getReasonPhrase(), statusCode);
         }
 
         return new Response(UtilRest.getTextResponseEntity(httpResponse), statusCode);

--- a/src/main/java/utility/UtilDataset.java
+++ b/src/main/java/utility/UtilDataset.java
@@ -53,19 +53,37 @@ public class UtilDataset {
     }
 
     /**
-     * Formulate and return a Dataset object based on incoming Json object.
+     * Formulate and return a more redefined error exception message base on crud operation.
      *
      * @param errorMsg    error message
      * @param dataSetName dataset representation
+     * @param crudType crud type value of operation taken place
      * @throws Exception execution with error msg
      */
-    public static void checkHttpErrors(String errorMsg, String dataSetName) throws Exception {
+    public static void checkHttpErrors(String errorMsg, String dataSetName, String crudType) throws Exception {
         if (errorMsg.contains("404")) {
-            throw new Exception(errorMsg + " You may have specified an invalid or non-existent data set.");
+            throw new Exception(errorMsg + " You may have specified an invalid or non-existent data set or member.");
         }
-        if (errorMsg.contains("500")) {
-            throw new Exception(errorMsg + " You may not have permission to view " + dataSetName + ", or if creating" +
-                    " this dataset, it may already exist!");
+
+        var type = crudType.toLowerCase();
+        var permissionDataSetMsg = " You may not have permission to " + type + " the following " + dataSetName;
+        var permissionDataSetMemberMsg = permissionDataSetMsg + " or the dataset or member do not exists.";
+
+        if ("create".equals(type)) {
+            if (errorMsg.contains("500")) {
+                String exceptionMsg = permissionDataSetMsg + " or the dataset already exists.";
+                throw new Exception(errorMsg + exceptionMsg);
+            }
+        }
+        if ("read".equals(type)) {
+            if (errorMsg.contains("500")) {
+                throw new Exception(errorMsg + permissionDataSetMsg + ".");
+            }
+        }
+        if ("delete".equals(type) || "write".equals(type) || "copy".equals(type) || "download".equals(type)) {
+            if (errorMsg.contains("500")) {
+                throw new Exception(errorMsg + permissionDataSetMemberMsg + ".");
+            }
         }
         throw new Exception(errorMsg);
     }

--- a/src/main/java/utility/UtilTso.java
+++ b/src/main/java/utility/UtilTso.java
@@ -16,7 +16,10 @@ import zostso.StartStopResponse;
 import zostso.TsoConstants;
 import zostso.zosmf.*;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * Utility Class for Tso command related static helper methods.

--- a/src/main/java/zosfiles/ZosDsn.java
+++ b/src/main/java/zosfiles/ZosDsn.java
@@ -47,88 +47,156 @@ public class ZosDsn {
     }
 
     /**
-     * Replaces a content of a dataset or a dataset member with a new content
-     * The new dataset member will be created if a dataset member is not exists
+     * Replaces the content of an existing sequential data set with new content.
      *
-     * @param dataSetName dataset or a dataset member (f.e. DATASET.LIB(MEMBER))
-     * @param content     new content of the dataset or a dataset member
+     * @param dataSetName sequential dataset (e.g. 'DATASET.LIB')
+     * @param content     new content
      * @author Leonid Baranov
      */
-    public void writeDsn(String dataSetName, String content) throws Exception {
+    public Response writeDsn(String dataSetName, String content) throws Exception {
         Util.checkConnection(connection);
         Util.checkNullParameter(content == null, "content is null");
         Util.checkNullParameter(dataSetName == null, "dataSetName is null");
         Util.checkIllegalParameter(dataSetName.isEmpty(), "dataSetName not specified");
         UtilDataset.checkDatasetName(dataSetName, true);
 
-        String url = "https://" + connection.getHost() + ":" + connection.getZosmfPort()
-                + ZosFilesConstants.RESOURCE + ZosFilesConstants.RES_DS_FILES + "/"
-                + Util.encodeURIComponent(dataSetName);
+        String url = "https://" + connection.getHost() + ":" + connection.getZosmfPort() + ZosFilesConstants.RESOURCE +
+                ZosFilesConstants.RES_DS_FILES + "/" + Util.encodeURIComponent(dataSetName);
 
         LOG.debug(url);
 
         ZoweRequest request = ZoweRequestFactory.buildRequest(connection, url, content,
                 ZoweRequestType.VerbType.PUT_TEXT);
         Response response = request.executeHttpRequest();
-        if (response.isEmpty())
-            return;
 
         try {
             UtilRest.checkHttpErrors(response);
         } catch (Exception e) {
-            UtilDataset.checkHttpErrors(e.getMessage(), dataSetName);
+            UtilDataset.checkHttpErrors(e.getMessage(), dataSetName, "write");
         }
 
+        return response;
     }
 
     /**
-     * Delete dataset or a dataset member
+     * Replaces the content of a member of a partitioned data set (PDS or PDSE) with new content.
+     * A new dataset member will be created if the specified dataset member does not exists.
      *
-     * @param dataSetName name of a dataset or a dataset member (f.e. 'DATASET.LIB(MEMBER)')
+     * @param dataSetName dataset name of where the member is located (e.g. 'DATASET.LIB')
+     * @param member      name of member to add new content
+     * @param content     new content
+     * @author Frank Giordano
+     */
+    public Response writeDsnMember(String dataSetName, String member, String content) throws Exception {
+        Util.checkConnection(connection);
+        Util.checkNullParameter(content == null, "content is null");
+        Util.checkNullParameter(dataSetName == null, "dataSetName is null");
+        Util.checkIllegalParameter(dataSetName.isEmpty(), "dataSetName not specified");
+        Util.checkNullParameter(member == null, "member is null");
+        Util.checkIllegalParameter(member.isEmpty(), "member not specified");
+        UtilDataset.checkDatasetName(dataSetName, true);
+
+        var dataSetMember = Util.encodeURIComponent(dataSetName) + "(" + Util.encodeURIComponent(member) + ")";
+
+        String url = "https://" + connection.getHost() + ":" + connection.getZosmfPort() + ZosFilesConstants.RESOURCE +
+                ZosFilesConstants.RES_DS_FILES + "/" + dataSetMember;
+
+        LOG.debug(url);
+
+        ZoweRequest request = ZoweRequestFactory.buildRequest(connection, url, content,
+                ZoweRequestType.VerbType.PUT_TEXT);
+        Response response = request.executeHttpRequest();
+
+        try {
+            UtilRest.checkHttpErrors(response);
+        } catch (Exception e) {
+            UtilDataset.checkHttpErrors(e.getMessage(), dataSetName, "write");
+        }
+
+        return response;
+    }
+
+    /**
+     * Delete a dataset
+     *
+     * @param dataSetName name of a dataset (e.g. 'DATASET.LIB')
      * @author Leonid Baranov
      */
-    public void deleteDsn(String dataSetName) throws Exception {
+    public Response deleteDsn(String dataSetName) throws Exception {
         Util.checkConnection(connection);
         Util.checkNullParameter(dataSetName == null, "dataSetName is null");
         Util.checkIllegalParameter(dataSetName.isEmpty(), "dataSetName not specified");
         UtilDataset.checkDatasetName(dataSetName, true);
 
-        String url = "https://" + connection.getHost() + ":" + connection.getZosmfPort()
-                + ZosFilesConstants.RESOURCE + ZosFilesConstants.RES_DS_FILES + "/"
-                + Util.encodeURIComponent(dataSetName);
+        String url = "https://" + connection.getHost() + ":" + connection.getZosmfPort() + ZosFilesConstants.RESOURCE +
+                ZosFilesConstants.RES_DS_FILES + "/" + Util.encodeURIComponent(dataSetName);
 
         LOG.debug(url);
 
         ZoweRequest request = ZoweRequestFactory.buildRequest(connection, url, null,
                 ZoweRequestType.VerbType.DELETE_JSON);
         Response response = request.executeHttpRequest();
-        if (response.isEmpty())
-            return;
 
         try {
             UtilRest.checkHttpErrors(response);
         } catch (Exception e) {
-            UtilDataset.checkHttpErrors(e.getMessage(), dataSetName);
+            UtilDataset.checkHttpErrors(e.getMessage(), dataSetName, "delete");
         }
+
+        return response;
+    }
+
+    /**
+     * Delete a dataset member
+     *
+     * @param dataSetName name of a dataset (e.g. 'DATASET.LIB')
+     * @param member      name of member to delete
+     * @author Frank Giordano
+     */
+    public Response deleteDsnMember(String dataSetName, String member) throws Exception {
+        Util.checkConnection(connection);
+        Util.checkNullParameter(dataSetName == null, "dataSetName is null");
+        Util.checkIllegalParameter(dataSetName.isEmpty(), "dataSetName not specified");
+        Util.checkNullParameter(member == null, "member is null");
+        Util.checkIllegalParameter(member.isEmpty(), "member not specified");
+        UtilDataset.checkDatasetName(dataSetName, true);
+
+        var dataSetMember = Util.encodeURIComponent(dataSetName) + "(" + Util.encodeURIComponent(member) + ")";
+
+        String url = "https://" + connection.getHost() + ":" + connection.getZosmfPort() + ZosFilesConstants.RESOURCE +
+                ZosFilesConstants.RES_DS_FILES + "/" + dataSetMember;
+
+        LOG.debug(url);
+
+        ZoweRequest request = ZoweRequestFactory.buildRequest(connection, url, null,
+                ZoweRequestType.VerbType.DELETE_JSON);
+        Response response = request.executeHttpRequest();
+
+        try {
+            UtilRest.checkHttpErrors(response);
+        } catch (Exception e) {
+            UtilDataset.checkHttpErrors(e.getMessage(), dataSetMember, "delete");
+        }
+
+        return response;
     }
 
     /**
      * Creates a new dataset with specified parameters
      *
-     * @param dataSetName name of a dataset to create (f.e. 'DATASET.LIB')
+     * @param dataSetName name of a dataset to create (e.g. 'DATASET.LIB')
      * @param params      create dataset parameters, see CreateParams object
      * @author Leonid Baranov
      */
-    public void createDsn(String dataSetName, CreateParams params) throws Exception {
+    public Response createDsn(String dataSetName, CreateParams params) throws Exception {
         Util.checkConnection(connection);
         Util.checkNullParameter(params == null, "params is null");
         Util.checkNullParameter(dataSetName == null, "dataSetName is null");
         Util.checkIllegalParameter(dataSetName.isEmpty(), "dataSetName not specified");
         UtilDataset.checkDatasetName(dataSetName, true);
 
-        String url = "https://" + connection.getHost() + ":" + connection.getZosmfPort()
-                + ZosFilesConstants.RESOURCE + ZosFilesConstants.RES_DS_FILES + "/"
-                + Util.encodeURIComponent(dataSetName);
+        String url = "https://" + connection.getHost() + ":" + connection.getZosmfPort() + ZosFilesConstants.RESOURCE +
+                ZosFilesConstants.RES_DS_FILES + "/" + Util.encodeURIComponent(dataSetName);
 
         LOG.debug(url);
 
@@ -138,15 +206,14 @@ public class ZosDsn {
                 ZoweRequestType.VerbType.POST_JSON);
 
         Response response = request.executeHttpRequest();
-        if (response.isEmpty())
-            return;
 
         try {
             UtilRest.checkHttpErrors(response);
         } catch (Exception e) {
-            UtilDataset.checkHttpErrors(e.getMessage(), dataSetName);
+            UtilDataset.checkHttpErrors(e.getMessage(), dataSetName, "create");
         }
 
+        return response;
     }
 
     /**

--- a/src/main/java/zosfiles/ZosDsnCopy.java
+++ b/src/main/java/zosfiles/ZosDsnCopy.java
@@ -84,7 +84,7 @@ public class ZosDsnCopy {
             try {
                 UtilRest.checkHttpErrors(response);
             } catch (Exception e) {
-                UtilDataset.checkHttpErrors(e.getMessage(), toDataSet);
+                UtilDataset.checkHttpErrors(e.getMessage(), toDataSet, "copy");
             }
 
         } catch (Exception e) {

--- a/src/main/java/zosfiles/ZosDsnDownload.java
+++ b/src/main/java/zosfiles/ZosDsnDownload.java
@@ -88,7 +88,7 @@ public class ZosDsnDownload {
         try {
             UtilRest.checkHttpErrors(response);
         } catch (Exception e) {
-            UtilDataset.checkHttpErrors(e.getMessage(), dataSetName);
+            UtilDataset.checkHttpErrors(e.getMessage(), dataSetName, "download");
         }
 
         return (InputStream) response.getResponsePhrase().orElse(null);

--- a/src/main/java/zosfiles/ZosDsnList.java
+++ b/src/main/java/zosfiles/ZosDsnList.java
@@ -50,11 +50,11 @@ public class ZosDsnList {
      *
      * @param dataSetName name of a dataset (e.g. 'DATASET.LIB')
      * @param params      list parameters, see ListParams object
-     * @return A String list of member names
+     * @return list of member names
      * @author Nikunj Goyal
      */
     @SuppressWarnings("unchecked")
-    public List<String> listMembers(String dataSetName, ListParams params) throws Exception {
+    public List<String> listDsnMembers(String dataSetName, ListParams params) throws Exception {
         Util.checkConnection(connection);
         Util.checkNullParameter(params == null, "params is null");
         Util.checkNullParameter(dataSetName == null, "dataSetName is null");
@@ -63,9 +63,9 @@ public class ZosDsnList {
 
         Map<String, String> headers = new HashMap<>();
         List<String> members = new ArrayList<>();
-        String url = "https://" + connection.getHost() + ":" + connection.getZosmfPort()
-                + ZosFilesConstants.RESOURCE + ZosFilesConstants.RES_DS_FILES + "/"
-                + Util.encodeURIComponent(dataSetName) + ZosFilesConstants.RES_DS_MEMBERS;
+        String url = "https://" + connection.getHost() + ":" + connection.getZosmfPort() +
+                ZosFilesConstants.RESOURCE + ZosFilesConstants.RES_DS_FILES + "/" +
+                Util.encodeURIComponent(dataSetName) + ZosFilesConstants.RES_DS_MEMBERS;
 
         if (params.getPattern().isPresent()) {
             url += QueryConstants.QUERY_ID + ZosFilesConstants.QUERY_PATTERN + params.getPattern().get();
@@ -78,7 +78,7 @@ public class ZosDsnList {
         try {
             UtilRest.checkHttpErrors(response);
         } catch (Exception e) {
-            UtilDataset.checkHttpErrors(e.getMessage(), dataSetName);
+            UtilDataset.checkHttpErrors(e.getMessage(), dataSetName, "read");
         }
 
         JSONObject results = (JSONObject) response.getResponsePhrase().orElse(new JSONObject());
@@ -111,8 +111,8 @@ public class ZosDsnList {
 
         Map<String, String> headers = new HashMap<>();
         List<Dataset> datasets = new ArrayList<>();
-        String url = "https://" + connection.getHost() + ":" + connection.getZosmfPort()
-                + ZosFilesConstants.RESOURCE + ZosFilesConstants.RES_DS_FILES + QueryConstants.QUERY_ID;
+        String url = "https://" + connection.getHost() + ":" + connection.getZosmfPort() + ZosFilesConstants.RESOURCE +
+                ZosFilesConstants.RES_DS_FILES + QueryConstants.QUERY_ID;
 
         url += ZosFilesConstants.QUERY_DS_LEVEL + Util.encodeURIComponent(dataSetName);
 
@@ -130,7 +130,7 @@ public class ZosDsnList {
         try {
             UtilRest.checkHttpErrors(response);
         } catch (Exception e) {
-            UtilDataset.checkHttpErrors(e.getMessage(), dataSetName);
+            UtilDataset.checkHttpErrors(e.getMessage(), dataSetName, "read");
         }
 
         JSONObject results = (JSONObject) response.getResponsePhrase().orElse(new JSONObject());

--- a/src/main/java/zosfiles/examples/CreateDataset.java
+++ b/src/main/java/zosfiles/examples/CreateDataset.java
@@ -10,6 +10,9 @@
 package zosfiles.examples;
 
 import core.ZOSConnection;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import rest.Response;
 import zosfiles.ZosDsn;
 import zosfiles.input.CreateParams;
 
@@ -20,6 +23,10 @@ import zosfiles.input.CreateParams;
  * @version 1.0
  */
 public class CreateDataset {
+
+    private static final Logger LOG = LogManager.getLogger(CreateDataset.class);
+
+    private static ZOSConnection connection;
 
     /**
      * Main method defines z/OSMF host and user connection and other parameters needed to showcase
@@ -36,9 +43,22 @@ public class CreateDataset {
         String password = "XXX";
         String dataSetName = "XXX";
 
-        ZOSConnection connection = new ZOSConnection(hostName, zosmfPort, userName, password);
+        connection = new ZOSConnection(hostName, zosmfPort, userName, password);
 
-        new ZosDsn(connection).createDsn(dataSetName, CreateParams.partitioned());
+        createDataSet(dataSetName);
+    }
+
+    /**
+     * Create a new partition data set
+     *
+     * @param dataSetName name of a dataset to create (e.g. 'DATASET.LIB')
+     * @throws Exception error processing request
+     * @author Frank Giordano
+     */
+    public static void createDataSet(String dataSetName) throws Exception {
+        ZosDsn zosDsn = new ZosDsn(connection);
+        Response response = zosDsn.createDsn(dataSetName, CreateParams.partitioned());
+        LOG.info("http response code " + response.getStatusCode());
     }
 
 }

--- a/src/main/java/zosfiles/examples/DeleteDataset.java
+++ b/src/main/java/zosfiles/examples/DeleteDataset.java
@@ -10,6 +10,9 @@
 package zosfiles.examples;
 
 import core.ZOSConnection;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import rest.Response;
 import zosfiles.ZosDsn;
 
 /**
@@ -19,6 +22,10 @@ import zosfiles.ZosDsn;
  * @version 1.0
  */
 public class DeleteDataset {
+
+    private static final Logger LOG = LogManager.getLogger(DeleteDataset.class);
+
+    private static ZOSConnection connection;
 
     /**
      * Main method defines z/OSMF host and user connection and other parameters needed to showcase
@@ -33,11 +40,36 @@ public class DeleteDataset {
         String zosmfPort = "XXX";
         String userName = "XXX";
         String password = "XXX";
-        String datasetMember = "XXX";
+        String dataSetName = "XXX";
+        String member = "XXX";
 
-        ZOSConnection connection = new ZOSConnection(hostName, zosmfPort, userName, password);
+        connection = new ZOSConnection(hostName, zosmfPort, userName, password);
 
-        new ZosDsn(connection).deleteDsn(datasetMember);
+        deleteDataSet(dataSetName);
+        deleteMember(dataSetName, member);
+    }
+
+    /**
+     * @param dataSetName name of a dataset to delete (e.g. 'DATASET.LIB')
+     * @throws Exception error processing request
+     * @author Frank Giordano
+     */
+    public static void deleteDataSet(String dataSetName) throws Exception {
+        ZosDsn zosDsn = new ZosDsn(connection);
+        Response response = zosDsn.deleteDsn(dataSetName);
+        LOG.info("http response code " + response.getStatusCode());
+    }
+
+    /**
+     * @param dataSetName name of a dataset where member should be located (e.g. 'DATASET.LIB')
+     * @param member      name of member to delete
+     * @throws Exception error processing request
+     * @author Frank Giordano
+     */
+    public static void deleteMember(String dataSetName, String member) throws Exception {
+        ZosDsn zosDsn = new ZosDsn(connection);
+        Response response = zosDsn.deleteDsnMember(dataSetName, member);
+        LOG.info("http response code " + response.getStatusCode());
     }
 
 }

--- a/src/main/java/zosfiles/examples/DownloadDataset.java
+++ b/src/main/java/zosfiles/examples/DownloadDataset.java
@@ -17,7 +17,6 @@ import utility.UtilIO;
 import zosfiles.ZosDsnDownload;
 import zosfiles.input.DownloadParams;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
 

--- a/src/main/java/zosfiles/examples/ListDatasets.java
+++ b/src/main/java/zosfiles/examples/ListDatasets.java
@@ -35,7 +35,7 @@ public class ListDatasets {
      * @param args for main not used
      * @author Leonid Baranov
      */
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
         String hostName = "XXX";
         String zosmfPort = "XXX";
         String userName = "XXX";
@@ -45,22 +45,18 @@ public class ListDatasets {
 
         ZOSConnection connection = new ZOSConnection(hostName, zosmfPort, userName, password);
 
-        try {
-            ListDatasets.listDsn(connection, dataSetMask);
-            ListDatasets.listMembers(connection, dataSetName);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        ListDatasets.listDsn(connection, dataSetMask);
+        ListDatasets.listMembers(connection, dataSetName);
     }
 
-    private static void listMembers(ZOSConnection connection, String dataSetName) throws Exception {
+    public static void listMembers(ZOSConnection connection, String dataSetName) throws Exception {
         ListParams params = new ListParams.Builder().build();
         ZosDsnList zosDsnList = new ZosDsnList(connection);
-        List<String> datasets = zosDsnList.listMembers(dataSetName, params);
+        List<String> datasets = zosDsnList.listDsnMembers(dataSetName, params);
         datasets.forEach(LOG::info);
     }
 
-    private static void listDsn(ZOSConnection connection, String dataSetName) throws Exception {
+    public static void listDsn(ZOSConnection connection, String dataSetName) throws Exception {
         ListParams params = new ListParams.Builder().build();
         ZosDsnList zosDsnList = new ZosDsnList(connection);
         List<Dataset> datasets = zosDsnList.listDsn(dataSetName, params);

--- a/src/main/java/zosfiles/examples/WriteDataset.java
+++ b/src/main/java/zosfiles/examples/WriteDataset.java
@@ -10,6 +10,9 @@
 package zosfiles.examples;
 
 import core.ZOSConnection;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import rest.Response;
 import zosfiles.ZosDsn;
 
 /**
@@ -19,6 +22,10 @@ import zosfiles.ZosDsn;
  * @version 1.0
  */
 public class WriteDataset {
+
+    private static final Logger LOG = LogManager.getLogger(WriteDataset.class);
+
+    private static ZOSConnection connection;
 
     /**
      * Main method defines z/OSMF host and user connection and other parameters needed to showcase
@@ -33,15 +40,27 @@ public class WriteDataset {
         String zosmfPort = "XXX";
         String userName = "XXX";
         String password = "XXX";
-        String datasetMember = "XXX";
+        String dataSetName = "XXX";
+        String member = "XXX";
 
-        ZOSConnection connection = new ZOSConnection(hostName, zosmfPort, userName, password);
+        connection = new ZOSConnection(hostName, zosmfPort, userName, password);
 
-        WriteDataset.writeToDsnMember(connection, datasetMember, "NEW CONTENT\nTHE SECOND LINE UPDATED");
+        var content = "NEW CONTENT\nTHE SECOND LINE UPDATED";
+        WriteDataset.writeToDsnMember(dataSetName, member, content);
     }
 
-    private static void writeToDsnMember(ZOSConnection connection, String datasetMember, String content) throws Exception {
-        new ZosDsn(connection).writeDsn(datasetMember, content);
+    /**
+     * Write to the given member name specified replacing its content. If it does exists, it will be created.
+     *
+     * @param dataSetName name of a dataset where member should be located (e.g. 'DATASET.LIB')
+     * @param member      name of member to write
+     * @throws Exception error processing request
+     * @author Frank Giordano
+     */
+    public static void writeToDsnMember(String dataSetName, String member, String content) throws Exception {
+        ZosDsn zosDsn = new ZosDsn(connection);
+        Response response = zosDsn.writeDsnMember(dataSetName, member, content);
+        LOG.info("http response code " + response.getStatusCode());
     }
 
 }


### PR DESCRIPTION
PR changes made:

1. Needed to make more changes to complete a previous PR request #125  "Use Optional internally within Response object only" to shore up using optional internally only for Response object.
2. Amended UtilDataset.checkHttpErrors() method to take in a type parameter so that error messages can be more tuned to the crud type operation taking place from ZosDsn classes. 
3. Minor import optimizations.
4. Amended ZosDsn class:
        -  Updated javadoc descriptions
        -  Amended createDsn(), deleteDsnMember(), deleteDsn(), writeDsnMember(), and downloadDsn() methods to return response object contains http response information so the end user can inspect to determine success of operation.
         -  Spilt writeDsn() method into two writeDsn and writeDsnMember methods
         -  Spilt deleteDsn() method into two deleteDsn and deleteDsnMember methods
            Note: The reason for separating them is to better focus on one operation per method. Before the one method was handling a data set or member operation. Now we will have one method for each. This also helps to parse dataset validation for each method as the member name is passed in a separate parameter and our data set validation method does not handle member name specified in the dataset string as was being passing in some cases in the one method. 
5. Minor tweaks to ZosDsnList method names for better readability. 
6. Added and amended the following example classes CreateDataset.java, DeleteDataset.java and WriteDataset.java with more example code and better javadoc descriptions.