### PR TITLE
streamline tso code

### DIFF
--- a/src/main/java/zostso/IssueResponse.java
+++ b/src/main/java/zostso/IssueResponse.java
@@ -24,7 +24,7 @@ public class IssueResponse {
     /**
      * True if the command was issued and the responses were collected.
      */
-    private Optional<Boolean> success;
+    private boolean success = false;
 
     /**
      * zOSMF start TSO API response.
@@ -34,7 +34,7 @@ public class IssueResponse {
     /**
      * Indicates if started TSO contains "READY " message
      */
-    private Optional<Boolean> startReady;
+    private boolean startReady = false;
 
     /**
      * zOSMF stop TSO API response.
@@ -53,33 +53,12 @@ public class IssueResponse {
     private Optional<String> commandResponses;
 
     /**
-     * IssueResponse constructor
-     *
-     * @param success          true or false if response seen
-     * @param startResponse    tso response
-     * @param startReady       true or false if ready tso starting prompt is seen
-     * @param stopResponses    tso response
-     * @param zosmfResponse    z/OSMF response
-     * @param commandResponses tso command responses
-     * @author Frank Giordano
-     */
-    public IssueResponse(boolean success, StartStopResponses startResponse, boolean startReady,
-                         StartStopResponse stopResponses, ZosmfTsoResponse zosmfResponse, String commandResponses) {
-        this.success = Optional.of(success);
-        this.startResponse = Optional.ofNullable(startResponse);
-        this.startReady = Optional.of(startReady);
-        this.stopResponse = Optional.ofNullable(stopResponses);
-        this.zosmfResponse = Optional.ofNullable(zosmfResponse);
-        this.commandResponses = Optional.ofNullable(commandResponses);
-    }
-
-    /**
      * Retrieve success specified
      *
      * @return boolean value
      * @author Frank Giordano
      */
-    public Optional<Boolean> getSuccess() {
+    public boolean getSuccess() {
         return success;
     }
 
@@ -89,7 +68,7 @@ public class IssueResponse {
      * @param success true or false is response seen
      * @author Frank Giordano
      */
-    public void setSuccess(Optional<Boolean> success) {
+    public void setSuccess(boolean success) {
         this.success = success;
     }
 
@@ -109,8 +88,8 @@ public class IssueResponse {
      * @param startResponse tso response
      * @author Frank Giordano
      */
-    public void setStartResponse(Optional<StartStopResponses> startResponse) {
-        this.startResponse = startResponse;
+    public void setStartResponse(StartStopResponses startResponse) {
+        this.startResponse = Optional.ofNullable(startResponse);
     }
 
     /**
@@ -119,7 +98,7 @@ public class IssueResponse {
      * @return startReady value
      * @author Frank Giordano
      */
-    public Optional<Boolean> getStartReady() {
+    public boolean getStartReady() {
         return startReady;
     }
 
@@ -129,7 +108,7 @@ public class IssueResponse {
      * @param startReady true or false is start ready prompt seen or not
      * @author Frank Giordano
      */
-    public void setStartReady(Optional<Boolean> startReady) {
+    public void setStartReady(boolean startReady) {
         this.startReady = startReady;
     }
 
@@ -149,8 +128,8 @@ public class IssueResponse {
      * @param stopResponse tso response
      * @author Frank Giordano
      */
-    public void setStopResponse(Optional<StartStopResponse> stopResponse) {
-        this.stopResponse = stopResponse;
+    public void setStopResponse(StartStopResponse stopResponse) {
+        this.stopResponse = Optional.ofNullable(stopResponse);
     }
 
     /**
@@ -169,8 +148,8 @@ public class IssueResponse {
      * @param zosmfResponse z/OSMF response
      * @author Frank Giordano
      */
-    public void setZosmfResponse(Optional<ZosmfTsoResponse> zosmfResponse) {
-        this.zosmfResponse = zosmfResponse;
+    public void setZosmfResponse(ZosmfTsoResponse zosmfResponse) {
+        this.zosmfResponse = Optional.ofNullable(zosmfResponse);
     }
 
     /**

--- a/src/main/java/zostso/IssueResponse.java
+++ b/src/main/java/zostso/IssueResponse.java
@@ -11,6 +11,7 @@ package zostso;
 
 import zostso.zosmf.ZosmfTsoResponse;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -45,7 +46,7 @@ public class IssueResponse {
      * The list of zOSMF send API responses. May issue multiple requests or
      * to ensure that all messages are collected. Each individual response is placed here.
      */
-    private Optional<ZosmfTsoResponse> zosmfResponse;
+    private Optional<List<ZosmfTsoResponse>> zosmfResponses;
 
     /**
      * The command response text.
@@ -133,23 +134,23 @@ public class IssueResponse {
     }
 
     /**
-     * Retrieve zosmfResponse specified
+     * Retrieve zosmfResponses specified
      *
-     * @return zosmfResponse z/OSMF response
+     * @return zosmfResponses z/OSMF responses
      * @author Frank Giordano
      */
-    public Optional<ZosmfTsoResponse> getZosmfResponse() {
-        return zosmfResponse;
+    public Optional<List<ZosmfTsoResponse>> getZosmfResponse() {
+        return zosmfResponses;
     }
 
     /**
-     * Assign zosmfResponse value
+     * Assign zosmfResponses value
      *
-     * @param zosmfResponse z/OSMF response
+     * @param zosmfResponses z/OSMF tso responses
      * @author Frank Giordano
      */
-    public void setZosmfResponse(ZosmfTsoResponse zosmfResponse) {
-        this.zosmfResponse = Optional.ofNullable(zosmfResponse);
+    public void setZosmfResponses(List<ZosmfTsoResponse> zosmfResponses) {
+        this.zosmfResponses = Optional.ofNullable(zosmfResponses);
     }
 
     /**
@@ -179,7 +180,7 @@ public class IssueResponse {
                 ", startResponse=" + startResponse +
                 ", startReady=" + startReady +
                 ", stopResponse=" + stopResponse +
-                ", zosmfResponse=" + zosmfResponse +
+                ", zosmfResponses=" + zosmfResponses +
                 ", commandResponses=" + commandResponses +
                 '}';
     }

--- a/src/main/java/zostso/SendResponse.java
+++ b/src/main/java/zostso/SendResponse.java
@@ -11,7 +11,6 @@ package zostso;
 
 import zostso.zosmf.ZosmfTsoResponse;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -32,7 +31,7 @@ public class SendResponse {
      * The list of zOSMF send API responses. May issue multiple requests or
      * to ensure that all messages are collected. Each individual response is placed here.
      */
-    private final List<ZosmfTsoResponse> zosmfResponse;
+    private final Optional<List<ZosmfTsoResponse>> zosmfTsoResponses;
 
     /**
      * The command response text.
@@ -42,16 +41,14 @@ public class SendResponse {
     /**
      * SendResponse constructor
      *
-     * @param success         boolean value
-     * @param zosmfResponse   list of ZosmfTsoResponse objects
-     * @param commandResponse tso command response
+     * @param success           boolean value
+     * @param zosmfTsoResponses list of ZosmfTsoResponse objects
+     * @param commandResponse   tso command response
      * @author Frank Giordano
      */
-    public SendResponse(boolean success, List<ZosmfTsoResponse> zosmfResponse, String commandResponse) {
+    public SendResponse(boolean success, List<ZosmfTsoResponse> zosmfTsoResponses, String commandResponse) {
         this.success = success;
-        if (zosmfResponse == null)
-            this.zosmfResponse = new ArrayList<>();
-        else this.zosmfResponse = zosmfResponse;
+        this.zosmfTsoResponses = Optional.ofNullable(zosmfTsoResponses);
         this.commandResponse = Optional.ofNullable(commandResponse);
     }
 
@@ -66,13 +63,13 @@ public class SendResponse {
     }
 
     /**
-     * Retrieve zosmfResponse specified
+     * Retrieve zosmfResponses specified
      *
-     * @return zosmfResponse value
+     * @return zosmfTsoResponses value, see ZosmfTsoResponse object
      * @author Frank Giordano
      */
-    public List<ZosmfTsoResponse> getZosmfResponse() {
-        return zosmfResponse;
+    public Optional<List<ZosmfTsoResponse>> getZosmfResponses() {
+        return zosmfTsoResponses;
     }
 
     /**
@@ -89,7 +86,7 @@ public class SendResponse {
     public String toString() {
         return "SendResponse{" +
                 "success=" + success +
-                ", zosmfResponse=" + zosmfResponse +
+                ", zosmfTsoResponses=" + zosmfTsoResponses +
                 ", commandResponse=" + commandResponse +
                 '}';
     }

--- a/src/main/java/zostso/SendResponse.java
+++ b/src/main/java/zostso/SendResponse.java
@@ -11,6 +11,7 @@ package zostso;
 
 import zostso.zosmf.ZosmfTsoResponse;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -25,13 +26,13 @@ public class SendResponse {
     /**
      * True if the command was issued and the responses were collected.
      */
-    private final Optional<Boolean> success;
+    private final boolean success;
 
     /**
      * The list of zOSMF send API responses. May issue multiple requests or
      * to ensure that all messages are collected. Each individual response is placed here.
      */
-    private final Optional<List<ZosmfTsoResponse>> zosmfResponse;
+    private final List<ZosmfTsoResponse> zosmfResponse;
 
     /**
      * The command response text.
@@ -47,8 +48,10 @@ public class SendResponse {
      * @author Frank Giordano
      */
     public SendResponse(boolean success, List<ZosmfTsoResponse> zosmfResponse, String commandResponse) {
-        this.success = Optional.of(success);
-        this.zosmfResponse = Optional.ofNullable(zosmfResponse);
+        this.success = success;
+        if (zosmfResponse == null)
+            this.zosmfResponse = new ArrayList<>();
+        else this.zosmfResponse = zosmfResponse;
         this.commandResponse = Optional.ofNullable(commandResponse);
     }
 
@@ -58,7 +61,7 @@ public class SendResponse {
      * @return success value
      * @author Frank Giordano
      */
-    public Optional<Boolean> getSuccess() {
+    public boolean getSuccess() {
         return success;
     }
 
@@ -68,7 +71,7 @@ public class SendResponse {
      * @return zosmfResponse value
      * @author Frank Giordano
      */
-    public Optional<List<ZosmfTsoResponse>> getZosmfResponse() {
+    public List<ZosmfTsoResponse> getZosmfResponse() {
         return zosmfResponse;
     }
 

--- a/src/main/java/zostso/SendTso.java
+++ b/src/main/java/zostso/SendTso.java
@@ -20,7 +20,6 @@ import utility.Util;
 import utility.UtilRest;
 import utility.UtilTso;
 import zostso.input.SendTsoParams;
-import zostso.zosmf.TsoMessage;
 import zostso.zosmf.TsoMessages;
 import zostso.zosmf.TsoResponseMessage;
 import zostso.zosmf.ZosmfTsoResponse;
@@ -69,7 +68,7 @@ public class SendTso {
         ZosmfTsoResponse putResponse = sendDataToTSOCommon(new SendTsoParams(servletKey, data));
 
         CollectedResponses responses = getAllResponses(putResponse);
-        return SendTso.createResponse(responses);
+        return createResponse(responses);
     }
 
     /**
@@ -142,8 +141,8 @@ public class SendTso {
             if (tso.getTsoData().isPresent()) {
                 for (TsoMessages tsoDatum : tso.getTsoData().get()) {
                     if (tsoDatum.getTsoMessage().isPresent()) {
-                        TsoMessage tsoMsg = tsoDatum.getTsoMessage().orElseThrow(Exception::new);
-                        String data = tsoMsg.getData().orElseThrow(Exception::new);
+                        var tsoMsg = tsoDatum.getTsoMessage().orElseThrow(() -> new Exception("missing tso message"));
+                        var data = tsoMsg.getData().orElseThrow(() -> new Exception("missing tso message data"));
                         messages.append(data);
                         messages.append("\n");
                     } else if (tsoDatum.getTsoPrompt().isPresent()) {
@@ -200,8 +199,9 @@ public class SendTso {
      * @return SendResponse, see SendResponse
      * @author Frank Giordano
      */
-    private static SendResponse createResponse(CollectedResponses responses) {
-        return new SendResponse(true, responses.getTsos().get(), responses.getMessages().get());
+    private static SendResponse createResponse(CollectedResponses responses) throws Exception {
+        return new SendResponse(true, responses.getTsos().orElseThrow(() -> new Exception("no responses exist")),
+                responses.getMessages().orElseThrow(() -> new Exception("no responses messages exist")));
     }
 
 }

--- a/src/main/java/zostso/StartTso.java
+++ b/src/main/java/zostso/StartTso.java
@@ -71,10 +71,10 @@ public class StartTso {
     }
 
     /**
-     * Start TSO address space with provided  parameters
+     * Start TSO address space with provided parameters
      *
      * @param commandParams object with required parameters, see StartTsoParams
-     * @return z/OSMF response object, see IZosmfTsoResponse
+     * @return z/OSMF response object, see ZosmfTsoResponse
      * @throws Exception error executing command
      * @author Frank Giordano
      */
@@ -104,7 +104,7 @@ public class StartTso {
      * Set default TSO address space parameters
      *
      * @param params        object with required parameters, see StartTsoParams
-     * @param accountNumber user's account number permission
+     * @param accountNumber user's account number for permission
      * @return response object, see StartTsoParams
      * @author Frank Giordano
      */

--- a/src/main/java/zostso/examples/IssueTsoCommand.java
+++ b/src/main/java/zostso/examples/IssueTsoCommand.java
@@ -37,12 +37,12 @@ public class IssueTsoCommand {
      * @author Frank Giordano
      */
     public static void main(String[] args) throws Exception {
-        String hostName = "usilCA31.lvn.broadcom.net";
-        String zosmfPort = "1443";
-        String userName = "FG892105";
-        String password = "dell101D";
-        String command = "status";
-        String accountNumber = "105200000";
+        String hostName = "XXX";
+        String zosmfPort = "XXX";
+        String userName = "XXX";
+        String password = "XXX";
+        String command = "XXX";
+        String accountNumber = "XXX";
 
         connection = new ZOSConnection(hostName, zosmfPort, userName, password);
         IssueResponse response = IssueTsoCommand.tsoConsoleCmdByIssue(accountNumber, command);


### PR DESCRIPTION
1. Overhauled issueTsoCommand() method. It is much more readable.
2. Fixed issue where all zosmf tso responses where not collected in IssueResponse object.  
3. Added more defined exception checks which helped hide get() calls and protect on get() calls with orElseThrow() chain method.
4. Improved example IssueTsoCommand. java class which clearer example code. 
