### PR TITLE
Optimize the handling of copying all partition dataset members

### DIFF
--- a/src/main/java/examples/zosfiles/CopyDataset.java
+++ b/src/main/java/examples/zosfiles/CopyDataset.java
@@ -42,39 +42,85 @@ public class CopyDataset extends ZosConnection {
         ZOSConnection connection = new ZOSConnection(hostName, zosmfPort, userName, password);
         copyDataset(connection, fromDataSetName, toDataSetName);
         copyDatasetByCopyParams(connection, fromDataSetName, toDataSetName);
+        fromDataSetName = "XXX";  // specify a partition dataset only no member
+        toDataSetName = "XXX"; // specify a partition dataset only no member
+        copyFullPartitionDatasetByCopyParams(connection, fromDataSetName, toDataSetName);
     }
 
     /**
      * Example on how to call ZosDsnCopy copy method.
-     * copy accepts a from and to strings for copying
+     * Copy method accepts a from and too strings for copying.
+     * <p>
+     * This copy method allows the following copy operations:
+     * <p>
+     * sequential dataset to sequential dataset
+     * sequential dataset to partition dataset member
+     * partition dataset member to partition dataset member
+     * partition dataset member to partition dataset non-existing member
+     * <p>
+     * This example sends false value for copyAllMembers parameter in copy method to indicate we
+     * are not copying all members in a partition dataset to another.
      *
      * @param connection      ZOSConnection
-     * @param fromDataSetName source dataset (e.g. SOURCE.DATASET(MEMBER))
-     * @param toDataSetName   destination dataset (e.g. TARGET.DATASET(MEMBER))
+     * @param fromDataSetName source dataset (e.g. 'SOURCE.DATASET' or 'SOURCE.DATASET(MEMBER)')
+     * @param toDataSetName   destination dataset (e.g. 'TARGET.DATASET' or 'TARGET.DATASET(MEMBER)')
      * @throws Exception error processing copy request
      * @author Frank Giordano
      */
-    public static void copyDataset(ZOSConnection connection, String fromDataSetName, String toDataSetName) throws Exception {
+    public static void copyDataset(ZOSConnection connection, String fromDataSetName, String toDataSetName)
+            throws Exception {
         ZosDsnCopy zosDsnCopy = new ZosDsnCopy(connection);
-        Response response = zosDsnCopy.copy(fromDataSetName, toDataSetName, true);
+        Response response = zosDsnCopy.copy(fromDataSetName, toDataSetName, true, false);
         LOG.info("http response code " + response.getStatusCode());
     }
 
     /**
      * Example on how to call ZosDsnCopy copy method.
-     * copy accepts a CopyParams object
+     * Copy method accepts a CopyParams object.
+     * <p>
+     * This copy method allows the following copy operations:
+     * <p>
+     * sequential dataset to sequential dataset
+     * sequential dataset to partition dataset member
+     * partition dataset member to partition dataset member
+     * partition dataset member to partition dataset non-existing member
      *
      * @param connection      ZOSConnection
-     * @param fromDataSetName source dataset (e.g. SOURCE.DATASET(MEMBER))
-     * @param toDataSetName   destination dataset (e.g. TARGET.DATASET(MEMBER))
+     * @param fromDataSetName source dataset (e.g. 'SOURCE.DATASET' or 'SOURCE.DATASET(MEMBER)')
+     * @param toDataSetName   destination dataset (e.g. 'TARGET.DATASET' or 'TARGET.DATASET(MEMBER)')
      * @throws Exception error processing copy request
      * @author Frank Giordano
      */
-    public static void copyDatasetByCopyParams(ZOSConnection connection, String fromDataSetName,
-                                               String toDataSetName) throws Exception {
+    public static void copyDatasetByCopyParams(ZOSConnection connection, String fromDataSetName, String toDataSetName)
+            throws Exception {
+        ZosDsnCopy zosDsnCopy = new ZosDsnCopy(connection);
+        // 'replace' builder variable here will be true by default if not specified in builder.
+        // 'copyAllMembers' builder variable here will be false by default
+        CopyParams copyParams = new CopyParams.Builder().fromDataSet(fromDataSetName).toDataSet(toDataSetName).build();
+        Response response = zosDsnCopy.copy(copyParams);
+        LOG.info("http response code " + response.getStatusCode());
+    }
+
+    /**
+     * Example on how to call ZosDsnCopy copy method.
+     * Copy method accepts a CopyParams object.
+     * <p>
+     * This copy method is different than the other two examples above as it
+     * sets the copyAllMember variable true to indicate that the copy operation will be performed
+     * on a partition dataset to another partition dataset copying all its members to the target.
+     *
+     * @param connection      ZOSConnection
+     * @param fromDataSetName source dataset (e.g. 'SOURCE.PARTITION.DATASET')
+     * @param toDataSetName   destination dataset (e.g. 'TARGET.PARTITION.DATASET')
+     * @throws Exception error processing copy request
+     * @author Frank Giordano
+     */
+    public static void copyFullPartitionDatasetByCopyParams(ZOSConnection connection, String fromDataSetName,
+                                                            String toDataSetName) throws Exception {
         ZosDsnCopy zosDsnCopy = new ZosDsnCopy(connection);
         // 'replace' here will be true by default if not specified in builder.
-        CopyParams copyParams = new CopyParams.Builder().fromDataSet(fromDataSetName).toDataSet(toDataSetName).build();
+        CopyParams copyParams = new CopyParams.Builder()
+                .fromDataSet(fromDataSetName).toDataSet(toDataSetName).copyAllMembers(true).build();
         Response response = zosDsnCopy.copy(copyParams);
         LOG.info("http response code " + response.getStatusCode());
     }

--- a/src/main/java/zosfiles/ZosDsnCopy.java
+++ b/src/main/java/zosfiles/ZosDsnCopy.java
@@ -107,7 +107,8 @@ public class ZosDsnCopy {
      * @throws Exception error processing copy request
      * @author Leonid Baranov
      */
-    public Response copy(String fromDataSetName, String toDataSetName, boolean replace, boolean copyAllMembers) throws Exception {
+    public Response copy(String fromDataSetName, String toDataSetName, boolean replace, boolean copyAllMembers)
+            throws Exception {
         return copy(new CopyParams.Builder()
                 .fromDataSet(fromDataSetName)
                 .toDataSet(toDataSetName)
@@ -143,7 +144,7 @@ public class ZosDsnCopy {
         fromDataSetReq.put("dsn", fromDataSetName);
         if (member.length() > 0) // include a member if it was specified in fromDataSetName
             fromDataSetReq.put("member", member);
-        else if (isFullPartitionCopy) // if true indicates a copy of all members in partition dataset to other
+        else if (isFullPartitionCopy) // if true indicates a copy of all members in partition dataset to another
             fromDataSetReq.put("member", "*");
 
         JSONObject fromDataSetObj = new JSONObject(fromDataSetReq);

--- a/src/main/java/zosfiles/ZosDsnCopy.java
+++ b/src/main/java/zosfiles/ZosDsnCopy.java
@@ -90,17 +90,30 @@ public class ZosDsnCopy {
     }
 
     /**
-     * Copy dataset or dataset member
+     * This copy method allows the following copy operations:
+     * <p>
+     * sequential dataset to sequential dataset
+     * sequential dataset to partition dataset member
+     * partition dataset member to partition dataset member
+     * partition dataset member to partition dataset non-existing member
      *
-     * @param fromDataSetName is a name of source dataset (e.g. SOURCE.DATASET(MEMBER))
-     * @param toDataSetName   is a name of target dataset (e.g. TARGET.DATASET(MEMBER))
-     * @param replace         if true, members in the target dataset are replaced. if false,
+     * If copyAllMembers parameter value sent as true it will perform a copy of all
+     * members in source partition dataset to another partition dataset.
+     *
+     * @param fromDataSetName is a name of source dataset (e.g. 'SOURCE.DATASET' or 'SOURCE.DATASET(MEMBER)')
+     * @param toDataSetName   is a name of target dataset (e.g. 'SOURCE.DATASET' or 'SOURCE.DATASET(MEMBER)')
+     * @param replace         if true members in the target dataset are replaced
      * @return http response object
      * @throws Exception error processing copy request
      * @author Leonid Baranov
      */
-    public Response copy(String fromDataSetName, String toDataSetName, boolean replace) throws Exception {
-        return copy(new CopyParams.Builder().fromDataSet(fromDataSetName).toDataSet(toDataSetName).replace(replace).build());
+    public Response copy(String fromDataSetName, String toDataSetName, boolean replace, boolean copyAllMembers) throws Exception {
+        return copy(new CopyParams.Builder()
+                .fromDataSet(fromDataSetName)
+                .toDataSet(toDataSetName)
+                .replace(replace)
+                .copyAllMembers(copyAllMembers)
+                .build());
     }
 
     /**
@@ -113,11 +126,13 @@ public class ZosDsnCopy {
      */
     private String buildBody(CopyParams params) throws Exception {
         String fromDataSetName = params.getFromDataSet().orElseThrow(() -> new Exception("dataset not specified"));
+        boolean isFullPartitionCopy = params.isCopyAllMembers();
 
         var jsonMap = new HashMap<String, Object>();
         jsonMap.put("request", "copy");
 
-        String member = "*";
+        String member = "";
+        // does fromDataSetName contain a member if so extract it and include member field and value in the json body
         int startMemberIndex = fromDataSetName.indexOf("(");
         if (startMemberIndex > 0) {
             member = fromDataSetName.substring(startMemberIndex + 1, fromDataSetName.length() - 1);
@@ -126,7 +141,11 @@ public class ZosDsnCopy {
 
         var fromDataSetReq = new HashMap<String, Object>();
         fromDataSetReq.put("dsn", fromDataSetName);
-        fromDataSetReq.put("member", member);
+        if (member.length() > 0) // include a member if it was specified in fromDataSetName
+            fromDataSetReq.put("member", member);
+        else if (isFullPartitionCopy) // if true indicates a copy of all members in partition dataset to other
+            fromDataSetReq.put("member", "*");
+
         JSONObject fromDataSetObj = new JSONObject(fromDataSetReq);
 
         jsonMap.put("from-dataset", fromDataSetObj);

--- a/src/main/java/zosfiles/input/CopyParams.java
+++ b/src/main/java/zosfiles/input/CopyParams.java
@@ -44,12 +44,18 @@ public class CopyParams {
      */
     private final boolean replace;
 
+    /**
+     * Specified as true to indicate a copying of all members in partial dataset to another partial dataset request
+     */
+    private final boolean copyAllMembers;
+
     private CopyParams(CopyParams.Builder builder) {
         this.fromVolser = Optional.ofNullable(builder.fromVolser);
         this.fromDataSet = Optional.ofNullable(builder.fromDataSet);
         this.toVolser = Optional.ofNullable(builder.toVolser);
         this.toDataSet = Optional.ofNullable(builder.toDataSet);
         this.replace = builder.replace;
+        this.copyAllMembers = builder.copyAllMembers;
     }
 
     /**
@@ -102,6 +108,16 @@ public class CopyParams {
         return replace;
     }
 
+    /**
+     * Retrieve copyAllMembers value
+     *
+     * @return copyAllMembers value
+     * @author Frank Giordano
+     */
+    public boolean isCopyAllMembers() {
+        return copyAllMembers;
+    }
+
     @Override
     public String toString() {
         return "CopyParams{" +
@@ -120,6 +136,7 @@ public class CopyParams {
         private String toVolser;
         private String toDataSet;
         private boolean replace = true;
+        private boolean copyAllMembers = false;
 
         public CopyParams.Builder fromVolser(String volser) {
             this.fromVolser = volser;
@@ -143,6 +160,11 @@ public class CopyParams {
 
         public CopyParams.Builder replace(boolean replace) {
             this.replace = replace;
+            return this;
+        }
+
+        public CopyParams.Builder copyAllMembers(boolean value) {
+            this.copyAllMembers = value;
             return this;
         }
 


### PR DESCRIPTION
Introduced new 'copyAllMembers' param variable to control the usage of member = "*" setting which was set by default for all copy operations that caused errors in some copy operations. Fixes #202 