### PR TITLE
Make parse singleton

### DIFF
--- a/src/main/java/zowe/client/sdk/core/SshConnection.java
+++ b/src/main/java/zowe/client/sdk/core/SshConnection.java
@@ -46,7 +46,7 @@ public class SshConnection {
      * @param password machine host username's password with access to backend z/OS instance
      * @author Frank Giordano
      */
-    public SshConnection(String host, int port, String user, String password) {
+    public SshConnection(final String host, final int port, final String user, final String password) {
         this.host = host;
         this.port = port;
         this.user = user;

--- a/src/main/java/zowe/client/sdk/core/ZosConnection.java
+++ b/src/main/java/zowe/client/sdk/core/ZosConnection.java
@@ -46,7 +46,7 @@ public class ZosConnection {
      * @param password  machine host username's password with access to backend z/OS instance
      * @author Frank Giordano
      */
-    public ZosConnection(String host, String zosmfPort, String user, String password) {
+    public ZosConnection(final String host, final String zosmfPort, final String user, final String password) {
         this.host = host;
         this.zosmfPort = zosmfPort;
         this.user = user;

--- a/src/main/java/zowe/client/sdk/parse/DatasetParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/DatasetParseResponse.java
@@ -10,6 +10,7 @@
 package zowe.client.sdk.parse;
 
 import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.ValidateUtils;
 import zowe.client.sdk.zosfiles.dsn.response.Dataset;
 
 /**
@@ -18,16 +19,37 @@ import zowe.client.sdk.zosfiles.dsn.response.Dataset;
  * @author Frank Giordano
  * @version 2.0
  */
-public class DatasetParseResponse extends JsonParseResponse {
+public final class DatasetParseResponse implements JsonParseResponse {
 
     /**
-     * DatasetParseResponse constructor
+     * Represents one singleton instance
+     */
+    private static JsonParseResponse INSTANCE;
+
+    /**
+     * JSON data value to be parsed
+     */
+    private JSONObject data;
+
+    /**
+     * Private constructor defined to avoid public instantiation of class
      *
-     * @param data json data value to be parsed
      * @author Frank Giordano
      */
-    public DatasetParseResponse(JSONObject data) {
-        super(data);
+    private DatasetParseResponse() {
+    }
+
+    /**
+     * Get singleton instance
+     *
+     * @return ConsoleResponseService object
+     * @author Frank Giordano
+     */
+    public synchronized static JsonParseResponse getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new DatasetParseResponse();
+        }
+        return INSTANCE;
     }
 
     /**
@@ -38,7 +60,8 @@ public class DatasetParseResponse extends JsonParseResponse {
      */
     @Override
     public Dataset parseResponse() {
-        return new Dataset.Builder()
+        ValidateUtils.checkNullParameter(data == null, ParseConstants.REQUIRED_ACTION_MSG);
+        final Dataset dataset = new Dataset.Builder()
                 .dsname(data.get("dsname") != null ? (String) data.get("dsname") : null)
                 .blksz(data.get("blksz") != null ? (String) data.get("blksz") : null)
                 .catnm(data.get("catnm") != null ? (String) data.get("catnm") : null)
@@ -59,6 +82,22 @@ public class DatasetParseResponse extends JsonParseResponse {
                 .used(data.get("used") != null ? (String) data.get("used") : null)
                 .vol(data.get("vol") != null ? (String) data.get("vol") : null)
                 .build();
+        data = null;
+        return dataset;
+    }
+
+    /**
+     * Set the data to be parsed
+     *
+     * @param data json data to parse
+     * @return JsonParseResponse this object
+     * @author Frank Giordano
+     */
+    @Override
+    public JsonParseResponse setJsonObject(final JSONObject data) {
+        ValidateUtils.checkNullParameter(data == null, ParseConstants.DATA_NULL_MSG);
+        this.data = data;
+        return this;
     }
 
 }

--- a/src/main/java/zowe/client/sdk/parse/JobFileParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/JobFileParseResponse.java
@@ -19,7 +19,7 @@ import zowe.client.sdk.zosjobs.input.JobFile;
  * @author Frank Giordano
  * @version 2.0
  */
-public class JobFileParseResponse implements JsonParseResponse {
+public final class JobFileParseResponse implements JsonParseResponse {
 
     /**
      * Represents one singleton instance

--- a/src/main/java/zowe/client/sdk/parse/JobFileParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/JobFileParseResponse.java
@@ -10,6 +10,7 @@
 package zowe.client.sdk.parse;
 
 import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.ValidateUtils;
 import zowe.client.sdk.zosjobs.input.JobFile;
 
 /**
@@ -18,16 +19,37 @@ import zowe.client.sdk.zosjobs.input.JobFile;
  * @author Frank Giordano
  * @version 2.0
  */
-public class JobFileParseResponse extends JsonParseResponse {
+public class JobFileParseResponse implements JsonParseResponse {
 
     /**
-     * JobFileParseResponse constructor
+     * Represents one singleton instance
+     */
+    private static JsonParseResponse INSTANCE;
+
+    /**
+     * JSON data value to be parsed
+     */
+    private JSONObject data;
+
+    /**
+     * Private constructor defined to avoid public instantiation of class
      *
-     * @param data json data value to be parsed
      * @author Frank Giordano
      */
-    public JobFileParseResponse(JSONObject data) {
-        super(data);
+    private JobFileParseResponse() {
+    }
+
+    /**
+     * Get singleton instance
+     *
+     * @return JobFileParseResponse object
+     * @author Frank Giordano
+     */
+    public synchronized static JsonParseResponse getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new JobFileParseResponse();
+        }
+        return INSTANCE;
     }
 
     /**
@@ -38,7 +60,8 @@ public class JobFileParseResponse extends JsonParseResponse {
      */
     @Override
     public Object parseResponse() {
-        return new JobFile.Builder()
+        ValidateUtils.checkNullParameter(data == null, ParseConstants.REQUIRED_ACTION_MSG);
+        final JobFile jobFile = new JobFile.Builder()
                 .jobId(data.get("jobid") != null ? (String) data.get("jobid") : null)
                 .jobName(data.get("jobname") != null ? (String) data.get("jobname") : null)
                 .recfm(data.get("recfm") != null ? (String) data.get("recfm") : null)
@@ -54,6 +77,22 @@ public class JobFileParseResponse extends JsonParseResponse {
                 .stepName(data.get("stepname") != null ? (String) data.get("stepname") : null)
                 .procStep(data.get("procstep") != null ? (String) data.get("procstep") : null)
                 .build();
+        data = null;
+        return jobFile;
+    }
+
+    /**
+     * Set the data to be parsed
+     *
+     * @param data json data to parse
+     * @return JsonParseResponse this object
+     * @author Frank Giordano
+     */
+    @Override
+    public JsonParseResponse setJsonObject(final JSONObject data) {
+        ValidateUtils.checkNullParameter(data == null, ParseConstants.DATA_NULL_MSG);
+        this.data = data;
+        return this;
     }
 
 }

--- a/src/main/java/zowe/client/sdk/parse/JobParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/JobParseResponse.java
@@ -21,7 +21,7 @@ import zowe.client.sdk.zosjobs.response.JobStepData;
  * @author Frank Giordano
  * @version 2.0
  */
-public class JobParseResponse implements JsonParseResponse {
+public final class JobParseResponse implements JsonParseResponse {
 
     /**
      * Represents one singleton instance

--- a/src/main/java/zowe/client/sdk/parse/JobParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/JobParseResponse.java
@@ -11,6 +11,7 @@ package zowe.client.sdk.parse;
 
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.ValidateUtils;
 import zowe.client.sdk.zosjobs.response.Job;
 import zowe.client.sdk.zosjobs.response.JobStepData;
 
@@ -20,16 +21,37 @@ import zowe.client.sdk.zosjobs.response.JobStepData;
  * @author Frank Giordano
  * @version 2.0
  */
-public class JobParseResponse extends JsonParseResponse {
+public class JobParseResponse implements JsonParseResponse {
 
     /**
-     * JobParseResponse constructor
+     * Represents one singleton instance
+     */
+    private static JsonParseResponse INSTANCE;
+
+    /**
+     * JSON data value to be parsed
+     */
+    private JSONObject data;
+
+    /**
+     * Private constructor defined to avoid public instantiation of class
      *
-     * @param data json data value to be parsed
      * @author Frank Giordano
      */
-    public JobParseResponse(JSONObject data) {
-        super(data);
+    private JobParseResponse() {
+    }
+
+    /**
+     * Get singleton instance
+     *
+     * @return JobParseResponse object
+     * @author Frank Giordano
+     */
+    public synchronized static JsonParseResponse getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new JobParseResponse();
+        }
+        return INSTANCE;
     }
 
     /**
@@ -40,6 +62,7 @@ public class JobParseResponse extends JsonParseResponse {
      */
     @Override
     public Object parseResponse() {
+        ValidateUtils.checkNullParameter(data == null, ParseConstants.REQUIRED_ACTION_MSG);
         final Job.Builder job = new Job.Builder()
                 .jobId(data.get("jobid") != null ? (String) data.get("jobid") : null)
                 .jobName(data.get("jobname") != null ? (String) data.get("jobname") : null)
@@ -66,6 +89,7 @@ public class JobParseResponse extends JsonParseResponse {
             return job.stepData(jobStepDataArray).build();
         }
 
+        data = null;
         return job.build();
     }
 
@@ -85,6 +109,20 @@ public class JobParseResponse extends JsonParseResponse {
                 .stepName(data.get("step-name") != null ? (String) data.get("step-name") : null)
                 .procStepName(data.get("proc-step-name") != null ? (String) data.get("proc-step-name") : null)
                 .build();
+    }
+
+    /**
+     * Set the data to be parsed
+     *
+     * @param data json data to parse
+     * @return JsonParseResponse this object
+     * @author Frank Giordano
+     */
+    @Override
+    public JsonParseResponse setJsonObject(final JSONObject data) {
+        ValidateUtils.checkNullParameter(data == null, ParseConstants.DATA_NULL_MSG);
+        this.data = data;
+        return this;
     }
 
 }

--- a/src/main/java/zowe/client/sdk/parse/JobParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/JobParseResponse.java
@@ -99,13 +99,13 @@ public final class JobParseResponse implements JsonParseResponse {
      * @return JobStepData object
      * @author Frank Giordano
      */
-    private JobStepData parseStepDataResponse(JSONObject data) {
+    private JobStepData parseStepDataResponse(final JSONObject data) {
         return new JobStepData.Builder()
                 .smfid(data.get("smfid") != null ? (String) data.get("smfid") : null)
                 .completion(data.get("completion") != null ? (String) data.get("completion") : null)
                 .stepNumber(data.get("step-number") != null ? (Long) data.get("step-number") : null)
                 .programName(data.get("program-name") != null ? (String) data.get("program-name") : null)
-                .active(data.get("active") != null ? (Boolean) data.get("active") : null)
+                .active(data.get("active") != null && (boolean) data.get("active"))
                 .stepName(data.get("step-name") != null ? (String) data.get("step-name") : null)
                 .procStepName(data.get("proc-step-name") != null ? (String) data.get("proc-step-name") : null)
                 .build();

--- a/src/main/java/zowe/client/sdk/parse/JsonParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/JsonParseResponse.java
@@ -17,28 +17,22 @@ import org.json.simple.JSONObject;
  * @author Frank Giordano
  * @version 2.0
  */
-public abstract class JsonParseResponse {
-
-    /**
-     * JSON data value to be parsed
-     */
-    protected final JSONObject data;
-
-    /**
-     * JsonParseResponse constructor
-     *
-     * @param data json data value to be parsed
-     */
-    public JsonParseResponse(JSONObject data) {
-        this.data = data;
-    }
+public interface JsonParseResponse {
 
     /**
      * Parse the data json value given in constructor
      *
      * @return Object value of parsed json data
      */
-    public abstract Object parseResponse();
+    public Object parseResponse();
+
+    /**
+     * Set the data to be parsed
+     *
+     * @param data json data to parse
+     * @author Frank Giordano
+     */
+    public JsonParseResponse setJsonObject(JSONObject data);
 
 }
 

--- a/src/main/java/zowe/client/sdk/parse/JsonParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/JsonParseResponse.java
@@ -32,7 +32,7 @@ public interface JsonParseResponse {
      * @param data json data to parse
      * @author Frank Giordano
      */
-    public JsonParseResponse setJsonObject(JSONObject data);
+    public JsonParseResponse setJsonObject(final JSONObject data);
 
 }
 

--- a/src/main/java/zowe/client/sdk/parse/JsonParseResponseFactory.java
+++ b/src/main/java/zowe/client/sdk/parse/JsonParseResponseFactory.java
@@ -9,12 +9,9 @@
  */
 package zowe.client.sdk.parse;
 
-import org.json.simple.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zowe.client.sdk.parse.type.ParseType;
-import zowe.client.sdk.rest.ZoweRequestFactory;
-import zowe.client.sdk.utility.ValidateUtils;
 
 /**
  * Parse factory that generates the desire json parse operation
@@ -36,58 +33,56 @@ public final class JsonParseResponseFactory {
     /**
      * Assign json parse response abstract object for type given
      *
-     * @param data json object
      * @param type ParseType type
      * @return JsonParseResponse abstract object
      * @throws Exception invalid ParseType value
      * @author Frank Giordano
      */
-    public static JsonParseResponse buildParser(JSONObject data, ParseType type) throws Exception {
+    public static JsonParseResponse buildParser(ParseType type) throws Exception {
         LOG.debug(type.name());
-        ValidateUtils.checkNullParameter(data == null, "json data is null");
         JsonParseResponse parseResponse;
         switch (type) {
             case DATASET:
-                parseResponse = new DatasetParseResponse(data);
+                parseResponse = DatasetParseResponse.getInstance();
                 break;
             case JOB:
-                parseResponse = new JobParseResponse(data);
+                parseResponse = JobParseResponse.getInstance();
                 break;
             case JOB_FILE:
-                parseResponse = new JobFileParseResponse(data);
+                parseResponse = JobFileParseResponse.getInstance();
                 break;
             case MEMBER:
-                parseResponse = new MemberParseResponse(data);
+                parseResponse = MemberParseResponse.getInstance();
                 break;
             case MVS_CONSOLE:
-                parseResponse = new MvsConsoleParseResponse(data);
+                parseResponse = MvsConsoleParseResponse.getInstance();
                 break;
             case PROPS:
-                parseResponse = new PropsParseResponse(data);
+                parseResponse = PropsParseResponse.getInstance();
                 break;
             case TSO_CONSOLE:
-                parseResponse = new TsoParseResponse(data);
+                parseResponse = TsoParseResponse.getInstance();
                 break;
             case TSO_STOP:
-                parseResponse = new TsoStopParseResponse(data);
+                parseResponse = TsoStopParseResponse.getInstance();
                 break;
             case UNIX_FILE:
-                parseResponse = new UnixFileParseResponse(data);
+                parseResponse = UnixFileParseResponse.getInstance();
                 break;
             case UNIX_ZFS:
-                parseResponse = new UnixZfsParseResponse(data);
+                parseResponse = UnixZfsParseResponse.getInstance();
                 break;
             case ZOS_LOG_ITEM:
-                parseResponse = new ZosLogItemParseResponse(data);
+                parseResponse = ZosLogItemParseResponse.getInstance();
                 break;
             case ZOS_LOG_REPLY:
-                parseResponse = new ZosLogReplyParseResponse(data);
+                parseResponse = ZosLogReplyParseResponse.getInstance();
                 break;
             case ZOSMF_SYSTEMS:
-                parseResponse = new SystemsParseResponse(data);
+                parseResponse = SystemsParseResponse.getInstance();
                 break;
             case ZOSMF_INFO:
-                parseResponse = new SystemInfoParseResponse(data);
+                parseResponse = SystemInfoParseResponse.getInstance();
                 break;
             default:
                 throw new IllegalStateException("no valid ParseType type specified");

--- a/src/main/java/zowe/client/sdk/parse/JsonParseResponseFactory.java
+++ b/src/main/java/zowe/client/sdk/parse/JsonParseResponseFactory.java
@@ -38,7 +38,7 @@ public final class JsonParseResponseFactory {
      * @throws Exception invalid ParseType value
      * @author Frank Giordano
      */
-    public static JsonParseResponse buildParser(ParseType type) throws Exception {
+    public static JsonParseResponse buildParser(final ParseType type) throws Exception {
         LOG.debug(type.name());
         JsonParseResponse parseResponse;
         switch (type) {

--- a/src/main/java/zowe/client/sdk/parse/MemberParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/MemberParseResponse.java
@@ -19,7 +19,7 @@ import zowe.client.sdk.zosfiles.dsn.response.Member;
  * @author Frank Giordano
  * @version 2.0
  */
-public class MemberParseResponse implements JsonParseResponse {
+public final class MemberParseResponse implements JsonParseResponse {
 
     /**
      * Represents one singleton instance

--- a/src/main/java/zowe/client/sdk/parse/MemberParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/MemberParseResponse.java
@@ -10,6 +10,7 @@
 package zowe.client.sdk.parse;
 
 import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.ValidateUtils;
 import zowe.client.sdk.zosfiles.dsn.response.Member;
 
 /**
@@ -18,16 +19,37 @@ import zowe.client.sdk.zosfiles.dsn.response.Member;
  * @author Frank Giordano
  * @version 2.0
  */
-public class MemberParseResponse extends JsonParseResponse {
+public class MemberParseResponse implements JsonParseResponse {
 
     /**
-     * MemberParseResponse constructor
+     * Represents one singleton instance
+     */
+    private static JsonParseResponse INSTANCE;
+
+    /**
+     * JSON data value to be parsed
+     */
+    private JSONObject data;
+
+    /**
+     * Private constructor defined to avoid public instantiation of class
      *
-     * @param data json data value to be parsed
      * @author Frank Giordano
      */
-    public MemberParseResponse(JSONObject data) {
-        super(data);
+    private MemberParseResponse() {
+    }
+
+    /**
+     * Get singleton instance
+     *
+     * @return MemberParseResponse object
+     * @author Frank Giordano
+     */
+    public synchronized static JsonParseResponse getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new MemberParseResponse();
+        }
+        return INSTANCE;
     }
 
     /**
@@ -38,7 +60,8 @@ public class MemberParseResponse extends JsonParseResponse {
      */
     @Override
     public Object parseResponse() {
-        return new Member.Builder()
+        ValidateUtils.checkNullParameter(data == null, ParseConstants.REQUIRED_ACTION_MSG);
+        final Member member = new Member.Builder()
                 .member(data.get("member") != null ? (String) data.get("member") : null)
                 .vers(data.get("vers") != null ? (Long) data.get("vers") : 0)
                 .mod(data.get("mod") != null ? (Long) data.get("mod") : 0)
@@ -52,6 +75,22 @@ public class MemberParseResponse extends JsonParseResponse {
                 .user(data.get("user") != null ? (String) data.get("user") : null)
                 .sclm(data.get("sclm") != null ? (String) data.get("sclm") : null)
                 .build();
+        data = null;
+        return member;
+    }
+
+    /**
+     * Set the data to be parsed
+     *
+     * @param data json data to parse
+     * @return JsonParseResponse this object
+     * @author Frank Giordano
+     */
+    @Override
+    public JsonParseResponse setJsonObject(final JSONObject data) {
+        ValidateUtils.checkNullParameter(data == null, ParseConstants.DATA_NULL_MSG);
+        this.data = data;
+        return this;
     }
 
 }

--- a/src/main/java/zowe/client/sdk/parse/MvsConsoleParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/MvsConsoleParseResponse.java
@@ -19,7 +19,7 @@ import zowe.client.sdk.zosconsole.response.ZosmfIssueResponse;
  * @author Frank Giordano
  * @version 2.0
  */
-public class MvsConsoleParseResponse implements JsonParseResponse {
+public final class MvsConsoleParseResponse implements JsonParseResponse {
 
     /**
      * Represents one singleton instance

--- a/src/main/java/zowe/client/sdk/parse/MvsConsoleParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/MvsConsoleParseResponse.java
@@ -10,6 +10,7 @@
 package zowe.client.sdk.parse;
 
 import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.ValidateUtils;
 import zowe.client.sdk.zosconsole.response.ZosmfIssueResponse;
 
 /**
@@ -18,16 +19,37 @@ import zowe.client.sdk.zosconsole.response.ZosmfIssueResponse;
  * @author Frank Giordano
  * @version 2.0
  */
-public class MvsConsoleParseResponse extends JsonParseResponse {
+public class MvsConsoleParseResponse implements JsonParseResponse {
 
     /**
-     * MvsConsoleParseResponse constructor
+     * Represents one singleton instance
+     */
+    private static JsonParseResponse INSTANCE;
+
+    /**
+     * JSON data value to be parsed
+     */
+    private JSONObject data;
+
+    /**
+     * Private constructor defined to avoid public instantiation of class
      *
-     * @param data json data value to be parsed
      * @author Frank Giordano
      */
-    public MvsConsoleParseResponse(JSONObject data) {
-        super(data);
+    private MvsConsoleParseResponse() {
+    }
+
+    /**
+     * Get singleton instance
+     *
+     * @return MvsConsoleParseResponse object
+     * @author Frank Giordano
+     */
+    public synchronized static JsonParseResponse getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new MvsConsoleParseResponse();
+        }
+        return INSTANCE;
     }
 
     /**
@@ -38,7 +60,8 @@ public class MvsConsoleParseResponse extends JsonParseResponse {
      */
     @Override
     public Object parseResponse() {
-        ZosmfIssueResponse zosmfIssueResponse = new ZosmfIssueResponse();
+        ValidateUtils.checkNullParameter(data == null, ParseConstants.REQUIRED_ACTION_MSG);
+        final ZosmfIssueResponse zosmfIssueResponse = new ZosmfIssueResponse();
         zosmfIssueResponse.setCmdResponseKey(
                 data.get("cmd-response-key") != null ? (String) data.get("cmd-response-key") : null);
         zosmfIssueResponse.setCmdResponseUrl(
@@ -49,7 +72,22 @@ public class MvsConsoleParseResponse extends JsonParseResponse {
                 data.get("cmd-response") != null ? (String) data.get("cmd-response") : null);
         zosmfIssueResponse.setSolKeyDetected(
                 data.get("sol-key-detected") != null ? (String) data.get("sol-key-detected") : null);
+        data = null;
         return zosmfIssueResponse;
+    }
+
+    /**
+     * Set the data to be parsed
+     *
+     * @param data json data to parse
+     * @return JsonParseResponse this object
+     * @author Frank Giordano
+     */
+    @Override
+    public JsonParseResponse setJsonObject(final JSONObject data) {
+        ValidateUtils.checkNullParameter(data == null, ParseConstants.DATA_NULL_MSG);
+        this.data = data;
+        return this;
     }
 
 }

--- a/src/main/java/zowe/client/sdk/parse/ParseConstants.java
+++ b/src/main/java/zowe/client/sdk/parse/ParseConstants.java
@@ -1,0 +1,50 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.parse;
+
+/**
+ * Constants definitions for parse package
+ *
+ * @author Frank Giordano
+ * @version 2.0
+ */
+public final class ParseConstants {
+
+    /**
+     * Private constructor defined to avoid instantiation of class
+     */
+    private ParseConstants() {
+        throw new IllegalStateException("Constants class");
+    }
+
+    /**
+     * Data is null message
+     */
+    public static final String DATA_NULL_MSG = "data is null";
+
+    /**
+     * Required action for parse processing message
+     */
+    public static final String REQUIRED_ACTION_MSG =
+            "each parseResponse call requires data to be reset via setJsonObject first";
+
+    /**
+     * Required action for parse processing message
+     */
+    public static final String REQUIRED_ACTION_MODE_STR_MSG =
+            "each parseResponse call requires data to be reset via modeStr first";
+
+    /**
+     * Required action for parse processing message
+     */
+    public static final String REQUIRED_ACTION_ZOS_LOG_ITEMS_MSG =
+            "each parseResponse call requires data to be reset via setZosLogItems first";
+
+}

--- a/src/main/java/zowe/client/sdk/parse/PropsParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/PropsParseResponse.java
@@ -10,6 +10,7 @@
 package zowe.client.sdk.parse;
 
 import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.ValidateUtils;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -20,16 +21,37 @@ import java.util.Map;
  * @author Frank Giordano
  * @version 2.0
  */
-public class PropsParseResponse extends JsonParseResponse {
+public class PropsParseResponse implements JsonParseResponse {
 
     /**
-     * PropsParseResponse constructor
+     * Represents one singleton instance
+     */
+    private static JsonParseResponse INSTANCE;
+
+    /**
+     * JSON data value to be parsed
+     */
+    private JSONObject data;
+
+    /**
+     * Private constructor defined to avoid public instantiation of class
      *
-     * @param data json data value to be parsed
      * @author Frank Giordano
      */
-    public PropsParseResponse(JSONObject data) {
-        super(data);
+    private PropsParseResponse() {
+    }
+
+    /**
+     * Get singleton instance
+     *
+     * @return PropsParseResponse object
+     * @author Frank Giordano
+     */
+    public synchronized static JsonParseResponse getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new PropsParseResponse();
+        }
+        return INSTANCE;
     }
 
     /**
@@ -41,6 +63,7 @@ public class PropsParseResponse extends JsonParseResponse {
     @SuppressWarnings("unchecked")
     @Override
     public Object parseResponse() {
+        ValidateUtils.checkNullParameter(data == null, ParseConstants.REQUIRED_ACTION_MSG);
         // i.e. properties='{"rejectUnauthorized":false,"host":"mvsxe47.lvn.company.net"}'
         final Map<String, String> props = new HashMap<>();
         data.keySet().forEach(key -> {
@@ -54,7 +77,22 @@ public class PropsParseResponse extends JsonParseResponse {
             }
             props.put((String) key, value);
         });
+        data = null;
         return props;
+    }
+
+    /**
+     * Set the data to be parsed
+     *
+     * @param data json data to parse
+     * @return JsonParseResponse this object
+     * @author Frank Giordano
+     */
+    @Override
+    public JsonParseResponse setJsonObject(final JSONObject data) {
+        ValidateUtils.checkNullParameter(data == null, ParseConstants.DATA_NULL_MSG);
+        this.data = data;
+        return this;
     }
 
 }

--- a/src/main/java/zowe/client/sdk/parse/PropsParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/PropsParseResponse.java
@@ -21,7 +21,7 @@ import java.util.Map;
  * @author Frank Giordano
  * @version 2.0
  */
-public class PropsParseResponse implements JsonParseResponse {
+public final class PropsParseResponse implements JsonParseResponse {
 
     /**
      * Represents one singleton instance

--- a/src/main/java/zowe/client/sdk/parse/SystemInfoParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/SystemInfoParseResponse.java
@@ -21,7 +21,7 @@ import zowe.client.sdk.zosmfinfo.response.ZosmfPluginInfo;
  * @author Frank Giordano
  * @version 2.0
  */
-public class SystemInfoParseResponse implements JsonParseResponse {
+public final class SystemInfoParseResponse implements JsonParseResponse {
 
     /**
      * Represents one singleton instance

--- a/src/main/java/zowe/client/sdk/parse/SystemInfoParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/SystemInfoParseResponse.java
@@ -92,7 +92,7 @@ public final class SystemInfoParseResponse implements JsonParseResponse {
      * @return ZosmfPluginInfo object
      * @author Frank Giordano
      */
-    private static ZosmfPluginInfo parseZosmfPluginInfo(JSONObject data) {
+    private static ZosmfPluginInfo parseZosmfPluginInfo(final JSONObject data) {
         return new ZosmfPluginInfo.Builder()
                 .pluginVersion(data.get("pluginVersion") != null ? (String) data.get("pluginVersion") : null)
                 .pluginDefaultName(data.get("pluginDefaultName") != null ? (String) data.get("pluginDefaultName") : null)

--- a/src/main/java/zowe/client/sdk/parse/SystemInfoParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/SystemInfoParseResponse.java
@@ -11,6 +11,7 @@ package zowe.client.sdk.parse;
 
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.ValidateUtils;
 import zowe.client.sdk.zosmfinfo.response.ZosmfInfoResponse;
 import zowe.client.sdk.zosmfinfo.response.ZosmfPluginInfo;
 
@@ -20,16 +21,37 @@ import zowe.client.sdk.zosmfinfo.response.ZosmfPluginInfo;
  * @author Frank Giordano
  * @version 2.0
  */
-public class SystemInfoParseResponse extends JsonParseResponse {
+public class SystemInfoParseResponse implements JsonParseResponse {
 
     /**
-     * SystemInfoParseResponse constructor
+     * Represents one singleton instance
+     */
+    private static JsonParseResponse INSTANCE;
+
+    /**
+     * JSON data value to be parsed
+     */
+    private JSONObject data;
+
+    /**
+     * Private constructor defined to avoid public instantiation of class
      *
-     * @param data json data value to be parsed
      * @author Frank Giordano
      */
-    public SystemInfoParseResponse(JSONObject data) {
-        super(data);
+    private SystemInfoParseResponse() {
+    }
+
+    /**
+     * Get singleton instance
+     *
+     * @return SystemInfoParseResponse object
+     * @author Frank Giordano
+     */
+    public synchronized static JsonParseResponse getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new SystemInfoParseResponse();
+        }
+        return INSTANCE;
     }
 
     /**
@@ -40,7 +62,8 @@ public class SystemInfoParseResponse extends JsonParseResponse {
      */
     @Override
     public Object parseResponse() {
-        ZosmfInfoResponse.Builder zosmfInfoResponse = new ZosmfInfoResponse.Builder()
+        ValidateUtils.checkNullParameter(data == null, ParseConstants.REQUIRED_ACTION_MSG);
+        final ZosmfInfoResponse.Builder zosmfInfoResponse = new ZosmfInfoResponse.Builder()
                 .zosVersion(data.get("zos_version") != null ? (String) data.get("zos_version") : null)
                 .zosmfPort(data.get("zosmf_port") != null ? (String) data.get("zosmf_port") : null)
                 .zosmfVersion(data.get("zosmf_version") != null ? (String) data.get("zosmf_version") : null)
@@ -58,7 +81,7 @@ public class SystemInfoParseResponse extends JsonParseResponse {
             }
             return zosmfInfoResponse.zosmfPluginsInfo(zosmfPluginsInfo).build();
         }
-
+        data = null;
         return zosmfInfoResponse.build();
     }
 
@@ -75,6 +98,20 @@ public class SystemInfoParseResponse extends JsonParseResponse {
                 .pluginDefaultName(data.get("pluginDefaultName") != null ? (String) data.get("pluginDefaultName") : null)
                 .pluginStatus(data.get("pluginStatus") != null ? (String) data.get("pluginStatus") : null)
                 .build();
+    }
+
+    /**
+     * Set the data to be parsed
+     *
+     * @param data json data to parse
+     * @return JsonParseResponse this object
+     * @author Frank Giordano
+     */
+    @Override
+    public JsonParseResponse setJsonObject(final JSONObject data) {
+        ValidateUtils.checkNullParameter(data == null, ParseConstants.DATA_NULL_MSG);
+        this.data = data;
+        return this;
     }
 
 }

--- a/src/main/java/zowe/client/sdk/parse/SystemsParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/SystemsParseResponse.java
@@ -11,6 +11,7 @@ package zowe.client.sdk.parse;
 
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.ValidateUtils;
 import zowe.client.sdk.zosmfinfo.response.DefinedSystem;
 import zowe.client.sdk.zosmfinfo.response.ZosmfSystemsResponse;
 
@@ -20,16 +21,37 @@ import zowe.client.sdk.zosmfinfo.response.ZosmfSystemsResponse;
  * @author Frank Giordano
  * @version 2.0
  */
-public class SystemsParseResponse extends JsonParseResponse {
+public class SystemsParseResponse implements JsonParseResponse {
 
     /**
-     * DefinedSysParseResponse constructor
+     * Represents one singleton instance
+     */
+    private static JsonParseResponse INSTANCE;
+
+    /**
+     * JSON data value to be parsed
+     */
+    private JSONObject data;
+
+    /**
+     * Private constructor defined to avoid public instantiation of class
      *
-     * @param data json data value to be parsed
      * @author Frank Giordano
      */
-    public SystemsParseResponse(JSONObject data) {
-        super(data);
+    private SystemsParseResponse() {
+    }
+
+    /**
+     * Get singleton instance
+     *
+     * @return SystemsParseResponse object
+     * @author Frank Giordano
+     */
+    public synchronized static JsonParseResponse getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new SystemsParseResponse();
+        }
+        return INSTANCE;
     }
 
     /**
@@ -40,19 +62,20 @@ public class SystemsParseResponse extends JsonParseResponse {
      */
     @Override
     public Object parseResponse() {
-        ZosmfSystemsResponse.Builder systemsResponse = new ZosmfSystemsResponse.Builder()
+        ValidateUtils.checkNullParameter(data == null, ParseConstants.REQUIRED_ACTION_MSG);
+        final ZosmfSystemsResponse.Builder systemsResponse = new ZosmfSystemsResponse.Builder()
                 .numRows((Long) data.get("numRows"));
 
-        JSONArray items = (JSONArray) data.get("items");
+        final JSONArray items = (JSONArray) data.get("items");
         if (items != null) {
             int size = items.size();
-            DefinedSystem[] definedSystems = new DefinedSystem[size];
+            final DefinedSystem[] definedSystems = new DefinedSystem[size];
             for (int i = 0; i < size; i++) {
                 definedSystems[i] = parseDefinedSystem((JSONObject) items.get(i));
             }
             return systemsResponse.definedSystems(definedSystems).build();
         }
-
+        data = null;
         return systemsResponse.build();
     }
 
@@ -78,6 +101,20 @@ public class SystemsParseResponse extends JsonParseResponse {
                 .url(data.get("url") != null ? (String) data.get("url") : null)
                 .cpcName(data.get("cpcName") != null ? (String) data.get("cpcName") : null)
                 .build();
+    }
+
+    /**
+     * Set the data to be parsed
+     *
+     * @param data json data to parse
+     * @return JsonParseResponse this object
+     * @author Frank Giordano
+     */
+    @Override
+    public JsonParseResponse setJsonObject(final JSONObject data) {
+        ValidateUtils.checkNullParameter(data == null, ParseConstants.DATA_NULL_MSG);
+        this.data = data;
+        return this;
     }
 
 }

--- a/src/main/java/zowe/client/sdk/parse/SystemsParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/SystemsParseResponse.java
@@ -86,7 +86,7 @@ public final class SystemsParseResponse implements JsonParseResponse {
      * @return DefinedSystem object
      * @author Frank Giordano
      */
-    private static DefinedSystem parseDefinedSystem(JSONObject data) {
+    private static DefinedSystem parseDefinedSystem(final JSONObject data) {
         return new DefinedSystem.Builder()
                 .systemNickName(data.get("systemNickName") != null ? (String) data.get("systemNickName") : null)
                 .groupNames(data.get("groupNames") != null ? (String) data.get("groupNames") : null)

--- a/src/main/java/zowe/client/sdk/parse/SystemsParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/SystemsParseResponse.java
@@ -21,7 +21,7 @@ import zowe.client.sdk.zosmfinfo.response.ZosmfSystemsResponse;
  * @author Frank Giordano
  * @version 2.0
  */
-public class SystemsParseResponse implements JsonParseResponse {
+public final class SystemsParseResponse implements JsonParseResponse {
 
     /**
      * Represents one singleton instance

--- a/src/main/java/zowe/client/sdk/parse/TsoParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/TsoParseResponse.java
@@ -29,7 +29,7 @@ import java.util.Optional;
  * @author Frank Giordano
  * @version 2.0
  */
-public class TsoParseResponse implements JsonParseResponse {
+public final class TsoParseResponse implements JsonParseResponse {
 
     /**
      * Represents one singleton instance

--- a/src/main/java/zowe/client/sdk/parse/TsoParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/TsoParseResponse.java
@@ -81,8 +81,8 @@ public final class TsoParseResponse implements JsonParseResponse {
                 .queueId(data.get("queueID") != null ? (String) data.get("queueID") : null)
                 .ver(data.get("ver") != null ? (String) data.get("ver") : null)
                 .servletKey(data.get("servletKey") != null ? (String) data.get("servletKey") : null)
-                .reused(data.get("reused") != null ? (boolean) data.get("reused") : null)
-                .timeout(data.get("timeout") != null ? (boolean) data.get("timeout") : null)
+                .reused(data.get("reused") != null && (boolean) data.get("reused"))
+                .timeout(data.get("timeout") != null && (boolean) data.get("timeout"))
                 .build();
 
         final List<TsoMessages> tsoMessagesLst = new ArrayList<>();
@@ -102,7 +102,8 @@ public final class TsoParseResponse implements JsonParseResponse {
     }
 
     @SuppressWarnings("unchecked")
-    private static void parseJsonTsoMessage(List<TsoMessages> tsoMessagesLst, JSONObject obj, TsoMessages tsoMessages) {
+    private static void parseJsonTsoMessage(final List<TsoMessages> tsoMessagesLst, final JSONObject obj,
+                                            final TsoMessages tsoMessages) {
         final Map<String, String> tsoMessageMap = ((Map<String, String>) obj.get(TsoConstants.TSO_MESSAGE));
         if (tsoMessageMap != null) {
             final TsoMessage tsoMessage = new TsoMessage();
@@ -120,7 +121,8 @@ public final class TsoParseResponse implements JsonParseResponse {
     }
 
     @SuppressWarnings("unchecked")
-    private static void parseJsonTsoPrompt(List<TsoMessages> tsoMessagesLst, JSONObject obj, TsoMessages tsoMessages) {
+    private static void parseJsonTsoPrompt(final List<TsoMessages> tsoMessagesLst, final JSONObject obj,
+                                           final TsoMessages tsoMessages) {
         final Map<String, String> tsoPromptMap = ((Map<String, String>) obj.get(TsoConstants.TSO_PROMPT));
         if (tsoPromptMap != null) {
             TsoPromptMessage tsoPromptMessage = new TsoPromptMessage();

--- a/src/main/java/zowe/client/sdk/parse/TsoParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/TsoParseResponse.java
@@ -11,6 +11,7 @@ package zowe.client.sdk.parse;
 
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.ValidateUtils;
 import zowe.client.sdk.zostso.TsoConstants;
 import zowe.client.sdk.zostso.message.TsoMessage;
 import zowe.client.sdk.zostso.message.TsoMessages;
@@ -28,16 +29,37 @@ import java.util.Optional;
  * @author Frank Giordano
  * @version 2.0
  */
-public class TsoParseResponse extends JsonParseResponse {
+public class TsoParseResponse implements JsonParseResponse {
 
     /**
-     * TsoParseResponse constructor
+     * Represents one singleton instance
+     */
+    private static JsonParseResponse INSTANCE;
+
+    /**
+     * JSON data value to be parsed
+     */
+    private JSONObject data;
+
+    /**
+     * Private constructor defined to avoid public instantiation of class
      *
-     * @param data json data value to be parsed
      * @author Frank Giordano
      */
-    public TsoParseResponse(JSONObject data) {
-        super(data);
+    private TsoParseResponse() {
+    }
+
+    /**
+     * Get singleton instance
+     *
+     * @return TsoParseResponse object
+     * @author Frank Giordano
+     */
+    public synchronized static JsonParseResponse getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new TsoParseResponse();
+        }
+        return INSTANCE;
     }
 
     /*
@@ -54,7 +76,8 @@ public class TsoParseResponse extends JsonParseResponse {
     @SuppressWarnings("unchecked")
     @Override
     public ZosmfTsoResponse parseResponse() {
-        ZosmfTsoResponse response = new ZosmfTsoResponse.Builder()
+        ValidateUtils.checkNullParameter(data == null, ParseConstants.REQUIRED_ACTION_MSG);
+        final ZosmfTsoResponse response = new ZosmfTsoResponse.Builder()
                 .queueId(data.get("queueID") != null ? (String) data.get("queueID") : null)
                 .ver(data.get("ver") != null ? (String) data.get("ver") : null)
                 .servletKey(data.get("servletKey") != null ? (String) data.get("servletKey") : null)
@@ -62,7 +85,7 @@ public class TsoParseResponse extends JsonParseResponse {
                 .timeout(data.get("timeout") != null ? (boolean) data.get("timeout") : null)
                 .build();
 
-        List<TsoMessages> tsoMessagesLst = new ArrayList<>();
+        final List<TsoMessages> tsoMessagesLst = new ArrayList<>();
         final Optional<JSONArray> tsoData = Optional.ofNullable((JSONArray) data.get("tsoData"));
 
         tsoData.ifPresent(data -> {
@@ -74,7 +97,7 @@ public class TsoParseResponse extends JsonParseResponse {
             });
             response.setTsoData(tsoMessagesLst);
         });
-
+        data = null;
         return response;
     }
 
@@ -112,6 +135,20 @@ public class TsoParseResponse extends JsonParseResponse {
             tsoMessages.setTsoPrompt(tsoPromptMessage);
             tsoMessagesLst.add(tsoMessages);
         }
+    }
+
+    /**
+     * Set the data to be parsed
+     *
+     * @param data json data to parse
+     * @return JsonParseResponse this object
+     * @author Frank Giordano
+     */
+    @Override
+    public JsonParseResponse setJsonObject(final JSONObject data) {
+        ValidateUtils.checkNullParameter(data == null, ParseConstants.DATA_NULL_MSG);
+        this.data = data;
+        return this;
     }
 
 }

--- a/src/main/java/zowe/client/sdk/parse/TsoStopParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/TsoStopParseResponse.java
@@ -64,8 +64,8 @@ public final class TsoStopParseResponse implements JsonParseResponse {
         final ZosmfTsoResponse zosmfTsoResponse = new ZosmfTsoResponse.Builder()
                 .ver(data.get("ver") != null ? (String) data.get("ver") : null)
                 .servletKey(data.get("servletKey") != null ? (String) data.get("servletKey") : null)
-                .reused(data.get("reused") != null ? (Boolean) data.get("reused") : null)
-                .timeout(data.get("timeout") != null ? (Boolean) data.get("timeout") : null)
+                .reused(data.get("reused") != null && (boolean) data.get("reused"))
+                .timeout(data.get("timeout") != null && (boolean) data.get("timeout"))
                 .build();
         data = null;
         return zosmfTsoResponse;

--- a/src/main/java/zowe/client/sdk/parse/TsoStopParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/TsoStopParseResponse.java
@@ -10,6 +10,7 @@
 package zowe.client.sdk.parse;
 
 import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.ValidateUtils;
 import zowe.client.sdk.zostso.message.ZosmfTsoResponse;
 
 /**
@@ -18,16 +19,37 @@ import zowe.client.sdk.zostso.message.ZosmfTsoResponse;
  * @author Frank Giordano
  * @version 2.0
  */
-public class TsoStopParseResponse extends JsonParseResponse {
+public class TsoStopParseResponse implements JsonParseResponse {
 
     /**
-     * TsoStopParseResponse constructor
+     * Represents one singleton instance
+     */
+    private static JsonParseResponse INSTANCE;
+
+    /**
+     * JSON data value to be parsed
+     */
+    private JSONObject data;
+
+    /**
+     * Private constructor defined to avoid public instantiation of class
      *
-     * @param data json data value to be parsed
      * @author Frank Giordano
      */
-    public TsoStopParseResponse(JSONObject data) {
-        super(data);
+    private TsoStopParseResponse() {
+    }
+
+    /**
+     * Get singleton instance
+     *
+     * @return TsoStopParseResponse object
+     * @author Frank Giordano
+     */
+    public synchronized static JsonParseResponse getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new TsoStopParseResponse();
+        }
+        return INSTANCE;
     }
 
     /**
@@ -38,12 +60,29 @@ public class TsoStopParseResponse extends JsonParseResponse {
      */
     @Override
     public Object parseResponse() {
-        return new ZosmfTsoResponse.Builder()
+        ValidateUtils.checkNullParameter(data == null, ParseConstants.REQUIRED_ACTION_MSG);
+        final ZosmfTsoResponse zosmfTsoResponse = new ZosmfTsoResponse.Builder()
                 .ver(data.get("ver") != null ? (String) data.get("ver") : null)
                 .servletKey(data.get("servletKey") != null ? (String) data.get("servletKey") : null)
                 .reused(data.get("reused") != null ? (Boolean) data.get("reused") : null)
                 .timeout(data.get("timeout") != null ? (Boolean) data.get("timeout") : null)
                 .build();
+        data = null;
+        return zosmfTsoResponse;
+    }
+
+    /**
+     * Set the data to be parsed
+     *
+     * @param data json data to parse
+     * @return JsonParseResponse this object
+     * @author Frank Giordano
+     */
+    @Override
+    public JsonParseResponse setJsonObject(final JSONObject data) {
+        ValidateUtils.checkNullParameter(data == null, ParseConstants.DATA_NULL_MSG);
+        this.data = data;
+        return this;
     }
 
 }

--- a/src/main/java/zowe/client/sdk/parse/TsoStopParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/TsoStopParseResponse.java
@@ -19,7 +19,7 @@ import zowe.client.sdk.zostso.message.ZosmfTsoResponse;
  * @author Frank Giordano
  * @version 2.0
  */
-public class TsoStopParseResponse implements JsonParseResponse {
+public final class TsoStopParseResponse implements JsonParseResponse {
 
     /**
      * Represents one singleton instance

--- a/src/main/java/zowe/client/sdk/parse/UnixFileParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/UnixFileParseResponse.java
@@ -10,6 +10,7 @@
 package zowe.client.sdk.parse;
 
 import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.ValidateUtils;
 import zowe.client.sdk.zosfiles.uss.response.UnixFile;
 
 /**
@@ -18,16 +19,37 @@ import zowe.client.sdk.zosfiles.uss.response.UnixFile;
  * @author Frank Giordano
  * @version 2.0
  */
-public class UnixFileParseResponse extends JsonParseResponse {
+public class UnixFileParseResponse implements JsonParseResponse {
 
     /**
-     * UnixFileParseResponse constructor
+     * Represents one singleton instance
+     */
+    private static JsonParseResponse INSTANCE;
+
+    /**
+     * JSON data value to be parsed
+     */
+    private JSONObject data;
+
+    /**
+     * Private constructor defined to avoid public instantiation of class
      *
-     * @param data json data value to be parsed
      * @author Frank Giordano
      */
-    public UnixFileParseResponse(JSONObject data) {
-        super(data);
+    private UnixFileParseResponse() {
+    }
+
+    /**
+     * Get singleton instance
+     *
+     * @return UnixFileParseResponse object
+     * @author Frank Giordano
+     */
+    public synchronized static JsonParseResponse getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new UnixFileParseResponse();
+        }
+        return INSTANCE;
     }
 
     /**
@@ -38,7 +60,8 @@ public class UnixFileParseResponse extends JsonParseResponse {
      */
     @Override
     public Object parseResponse() {
-        return new UnixFile.Builder()
+        ValidateUtils.checkNullParameter(data == null, ParseConstants.REQUIRED_ACTION_MSG);
+        UnixFile unixFile = new UnixFile.Builder()
                 .name(data.get("name") != null ? (String) data.get("name") : null)
                 .mode(data.get("mode") != null ? (String) data.get("mode") : null)
                 .size(data.get("size") != null ? (Long) data.get("size") : null)
@@ -48,6 +71,22 @@ public class UnixFileParseResponse extends JsonParseResponse {
                 .group(data.get("group") != null ? (String) data.get("group") : null)
                 .mtime(data.get("mtime") != null ? (String) data.get("mtime") : null)
                 .build();
+        data = null;
+        return unixFile;
+    }
+
+    /**
+     * Set the data to be parsed
+     *
+     * @param data json data to parse
+     * @return JsonParseResponse this object
+     * @author Frank Giordano
+     */
+    @Override
+    public JsonParseResponse setJsonObject(final JSONObject data) {
+        ValidateUtils.checkNullParameter(data == null, ParseConstants.DATA_NULL_MSG);
+        this.data = data;
+        return this;
     }
 
 }

--- a/src/main/java/zowe/client/sdk/parse/UnixFileParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/UnixFileParseResponse.java
@@ -19,7 +19,7 @@ import zowe.client.sdk.zosfiles.uss.response.UnixFile;
  * @author Frank Giordano
  * @version 2.0
  */
-public class UnixFileParseResponse implements JsonParseResponse {
+public final class UnixFileParseResponse implements JsonParseResponse {
 
     /**
      * Represents one singleton instance

--- a/src/main/java/zowe/client/sdk/parse/UnixZfsParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/UnixZfsParseResponse.java
@@ -10,6 +10,7 @@
 package zowe.client.sdk.parse;
 
 import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.ValidateUtils;
 import zowe.client.sdk.zosfiles.uss.response.UnixZfs;
 
 /**
@@ -18,18 +19,39 @@ import zowe.client.sdk.zosfiles.uss.response.UnixZfs;
  * @author Frank Giordano
  * @version 2.0
  */
-public class UnixZfsParseResponse extends JsonParseResponse {
-
-    private String modeStr;
+public class UnixZfsParseResponse implements JsonParseResponse {
 
     /**
-     * UnixZfsParseResponse constructor
+     * Represents one singleton instance
+     */
+    private static JsonParseResponse INSTANCE;
+
+    private String modeStr = "";
+
+    /**
+     * JSON data value to be parsed
+     */
+    private JSONObject data;
+
+    /**
+     * Private constructor defined to avoid public instantiation of class
      *
-     * @param data json data value to be parsed
      * @author Frank Giordano
      */
-    public UnixZfsParseResponse(JSONObject data) {
-        super(data);
+    private UnixZfsParseResponse() {
+    }
+
+    /**
+     * Get singleton instance
+     *
+     * @return UnixZfsParseResponse object
+     * @author Frank Giordano
+     */
+    public synchronized static JsonParseResponse getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new UnixZfsParseResponse();
+        }
+        return INSTANCE;
     }
 
     /**
@@ -40,7 +62,8 @@ public class UnixZfsParseResponse extends JsonParseResponse {
      */
     @Override
     public UnixZfs parseResponse() {
-        return new UnixZfs.Builder()
+        ValidateUtils.checkNullParameter(data == null, ParseConstants.REQUIRED_ACTION_MSG);
+        final UnixZfs unixZfs = new UnixZfs.Builder()
                 .name(data.get("name") != null ? (String) data.get("name") : null)
                 .mountpoint(data.get("mountpoint") != null ? (String) data.get("mountpoint") : null)
                 .fstname(data.get("fstname") != null ? (String) data.get("fstname") : null)
@@ -59,6 +82,9 @@ public class UnixZfsParseResponse extends JsonParseResponse {
                 .totalRows(data.get("totalRows") != null ? (Long) data.get("totalRows") : null)
                 .moreRows(data.get("moreRows") != null ? (Boolean) data.get("moreRows") : false)
                 .build();
+        data = null;
+        modeStr = "";
+        return unixZfs;
     }
 
     /**
@@ -70,7 +96,22 @@ public class UnixZfsParseResponse extends JsonParseResponse {
      * @author Frank Giordano
      */
     public void setModeStr(String modeStr) {
+        ValidateUtils.checkNullParameter(modeStr.isBlank(), ParseConstants.REQUIRED_ACTION_MODE_STR_MSG);
         this.modeStr = modeStr;
+    }
+
+    /**
+     * Set the data to be parsed
+     *
+     * @param data json data to parse
+     * @return JsonParseResponse this object
+     * @author Frank Giordano
+     */
+    @Override
+    public JsonParseResponse setJsonObject(final JSONObject data) {
+        ValidateUtils.checkNullParameter(data == null, ParseConstants.DATA_NULL_MSG);
+        this.data = data;
+        return this;
     }
 
 }

--- a/src/main/java/zowe/client/sdk/parse/UnixZfsParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/UnixZfsParseResponse.java
@@ -19,7 +19,7 @@ import zowe.client.sdk.zosfiles.uss.response.UnixZfs;
  * @author Frank Giordano
  * @version 2.0
  */
-public class UnixZfsParseResponse implements JsonParseResponse {
+public final class UnixZfsParseResponse implements JsonParseResponse {
 
     /**
      * Represents one singleton instance

--- a/src/main/java/zowe/client/sdk/parse/UnixZfsParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/UnixZfsParseResponse.java
@@ -63,6 +63,7 @@ public class UnixZfsParseResponse implements JsonParseResponse {
     @Override
     public UnixZfs parseResponse() {
         ValidateUtils.checkNullParameter(data == null, ParseConstants.REQUIRED_ACTION_MSG);
+        ValidateUtils.checkNullParameter(modeStr.isBlank(), ParseConstants.REQUIRED_ACTION_MODE_STR_MSG);
         final UnixZfs unixZfs = new UnixZfs.Builder()
                 .name(data.get("name") != null ? (String) data.get("name") : null)
                 .mountpoint(data.get("mountpoint") != null ? (String) data.get("mountpoint") : null)
@@ -96,7 +97,7 @@ public class UnixZfsParseResponse implements JsonParseResponse {
      * @author Frank Giordano
      */
     public void setModeStr(String modeStr) {
-        ValidateUtils.checkNullParameter(modeStr.isBlank(), ParseConstants.REQUIRED_ACTION_MODE_STR_MSG);
+        ValidateUtils.checkNullParameter(modeStr == null, "modeStr is null");
         this.modeStr = modeStr;
     }
 

--- a/src/main/java/zowe/client/sdk/parse/UnixZfsParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/UnixZfsParseResponse.java
@@ -81,7 +81,7 @@ public final class UnixZfsParseResponse implements JsonParseResponse {
                 .diribc(data.get("diribc") != null ? (Long) data.get("diribc") : null)
                 .returnedRows(data.get("returnedRows") != null ? (Long) data.get("returnedRows") : null)
                 .totalRows(data.get("totalRows") != null ? (Long) data.get("totalRows") : null)
-                .moreRows(data.get("moreRows") != null ? (Boolean) data.get("moreRows") : false)
+                .moreRows(data.get("moreRows") != null && (boolean) data.get("moreRows"))
                 .build();
         data = null;
         modeStr = "";
@@ -96,7 +96,7 @@ public final class UnixZfsParseResponse implements JsonParseResponse {
      * @param modeStr mode permission(s) string value
      * @author Frank Giordano
      */
-    public void setModeStr(String modeStr) {
+    public void setModeStr(final String modeStr) {
         ValidateUtils.checkNullParameter(modeStr == null, "modeStr is null");
         this.modeStr = modeStr;
     }

--- a/src/main/java/zowe/client/sdk/parse/ZosLogItemParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/ZosLogItemParseResponse.java
@@ -89,7 +89,7 @@ public final class ZosLogItemParseResponse implements JsonParseResponse {
      * @return string value of the message processed
      * @author Frank Giordano
      */
-    private static String processMessage(JSONObject data, boolean isProcessResponse) {
+    private static String processMessage(final JSONObject data, final boolean isProcessResponse) {
         try {
             String message = (String) data.get("message");
             if (isProcessResponse) {
@@ -112,7 +112,7 @@ public final class ZosLogItemParseResponse implements JsonParseResponse {
      * @param processResponse boolean value
      * @author Frank Giordano
      */
-    public void setProcessResponse(boolean processResponse) {
+    public void setProcessResponse(final boolean processResponse) {
         isProcessResponse = processResponse;
     }
 

--- a/src/main/java/zowe/client/sdk/parse/ZosLogItemParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/ZosLogItemParseResponse.java
@@ -10,6 +10,7 @@
 package zowe.client.sdk.parse;
 
 import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.ValidateUtils;
 import zowe.client.sdk.zoslogs.response.ZosLogItem;
 
 /**
@@ -18,17 +19,39 @@ import zowe.client.sdk.zoslogs.response.ZosLogItem;
  * @author Frank Giordano
  * @version 2.0
  */
-public class ZosLogItemParseResponse extends JsonParseResponse {
+public class ZosLogItemParseResponse implements JsonParseResponse {
+
+    /**
+     * Represents one singleton instance
+     */
+    private static JsonParseResponse INSTANCE;
 
     private boolean isProcessResponse;
 
     /**
-     * JsonParseResponse constructor
+     * Private constructor defined to avoid public instantiation of class
      *
-     * @param data json data value to be parsed
+     * @author Frank Giordano
      */
-    public ZosLogItemParseResponse(JSONObject data) {
-        super(data);
+    private ZosLogItemParseResponse() {
+    }
+
+    /**
+     * JSON data value to be parsed
+     */
+    private JSONObject data;
+
+    /**
+     * Get singleton instance
+     *
+     * @return ZosLogItemParseResponse object
+     * @author Frank Giordano
+     */
+    public synchronized static JsonParseResponse getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new ZosLogItemParseResponse();
+        }
+        return INSTANCE;
     }
 
     /**
@@ -39,8 +62,9 @@ public class ZosLogItemParseResponse extends JsonParseResponse {
      */
     @Override
     public ZosLogItem parseResponse() {
+        ValidateUtils.checkNullParameter(data == null, ParseConstants.REQUIRED_ACTION_MSG);
         final String message = processMessage(data, isProcessResponse);
-        return new ZosLogItem.Builder()
+        final ZosLogItem zosLogItem = new ZosLogItem.Builder()
                 .cart(data.get("cart") != null ? (String) data.get("cart") : null)
                 .color(data.get("color") != null ? (String) data.get("color") : null)
                 .jobName(data.get("jobName") != null ? (String) data.get("jobName") : null)
@@ -53,6 +77,8 @@ public class ZosLogItemParseResponse extends JsonParseResponse {
                 .time(data.get("time") != null ? (String) data.get("time") : null)
                 .timeStamp(data.get("timestamp") != null ? (Long) data.get("timestamp") : 0)
                 .build();
+        data = null;
+        return zosLogItem;
     }
 
     /**
@@ -88,6 +114,20 @@ public class ZosLogItemParseResponse extends JsonParseResponse {
      */
     public void setProcessResponse(boolean processResponse) {
         isProcessResponse = processResponse;
+    }
+
+    /**
+     * Set the data to be parsed
+     *
+     * @param data json data to parse
+     * @return JsonParseResponse this object
+     * @author Frank Giordano
+     */
+    @Override
+    public JsonParseResponse setJsonObject(final JSONObject data) {
+        ValidateUtils.checkNullParameter(data == null, ParseConstants.DATA_NULL_MSG);
+        this.data = data;
+        return this;
     }
 
 }

--- a/src/main/java/zowe/client/sdk/parse/ZosLogItemParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/ZosLogItemParseResponse.java
@@ -19,7 +19,7 @@ import zowe.client.sdk.zoslogs.response.ZosLogItem;
  * @author Frank Giordano
  * @version 2.0
  */
-public class ZosLogItemParseResponse implements JsonParseResponse {
+public final class ZosLogItemParseResponse implements JsonParseResponse {
 
     /**
      * Represents one singleton instance

--- a/src/main/java/zowe/client/sdk/parse/ZosLogReplyParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/ZosLogReplyParseResponse.java
@@ -10,6 +10,7 @@
 package zowe.client.sdk.parse;
 
 import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.ValidateUtils;
 import zowe.client.sdk.zoslogs.response.ZosLogItem;
 import zowe.client.sdk.zoslogs.response.ZosLogReply;
 
@@ -22,17 +23,39 @@ import java.util.List;
  * @author Frank Giordano
  * @version 2.0
  */
-public class ZosLogReplyParseResponse extends JsonParseResponse {
+public class ZosLogReplyParseResponse implements JsonParseResponse {
+
+    /**
+     * Represents one singleton instance
+     */
+    private static JsonParseResponse INSTANCE;
 
     private List<ZosLogItem> zosLogItems = new ArrayList<>();
 
     /**
-     * JsonParseResponse constructor
-     *
-     * @param data json data value to be parsed
+     * JSON data value to be parsed
      */
-    public ZosLogReplyParseResponse(JSONObject data) {
-        super(data);
+    private JSONObject data;
+
+    /**
+     * Private constructor defined to avoid public instantiation of class
+     *
+     * @author Frank Giordano
+     */
+    private ZosLogReplyParseResponse() {
+    }
+
+    /**
+     * Get singleton instance
+     *
+     * @return ZosLogReplyParseResponse object
+     * @author Frank Giordano
+     */
+    public synchronized static JsonParseResponse getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new ZosLogReplyParseResponse();
+        }
+        return INSTANCE;
     }
 
     /**
@@ -43,12 +66,17 @@ public class ZosLogReplyParseResponse extends JsonParseResponse {
      */
     @Override
     public ZosLogReply parseResponse() {
-        return new ZosLogReply(
+        ValidateUtils.checkNullParameter(data == null, ParseConstants.REQUIRED_ACTION_MSG);
+        ValidateUtils.checkNullParameter(zosLogItems.isEmpty(), ParseConstants.REQUIRED_ACTION_ZOS_LOG_ITEMS_MSG);
+        final ZosLogReply zosLogReply = new ZosLogReply(
                 data.get("timezone") != null ? (Long) data.get("timezone") : 0,
                 data.get("nextTimestamp") != null ? (Long) data.get("nextTimestamp") : 0,
                 data.get("source") != null ? (String) data.get("source") : null,
                 data.get("totalitems") != null ? (Long) data.get("totalitems") : null,
                 zosLogItems);
+        data = null;
+        zosLogItems = new ArrayList<>();
+        return zosLogReply;
     }
 
     /**
@@ -58,7 +86,22 @@ public class ZosLogReplyParseResponse extends JsonParseResponse {
      * @author Frank Giordano
      */
     public void setZosLogItems(List<ZosLogItem> zosLogItems) {
+        ValidateUtils.checkNullParameter(zosLogItems == null, "zosLogItems is null");
         this.zosLogItems = zosLogItems;
+    }
+
+    /**
+     * Set the data to be parsed
+     *
+     * @param data json data to parse
+     * @return JsonParseResponse this object
+     * @author Frank Giordano
+     */
+    @Override
+    public JsonParseResponse setJsonObject(final JSONObject data) {
+        ValidateUtils.checkNullParameter(data == null, ParseConstants.DATA_NULL_MSG);
+        this.data = data;
+        return this;
     }
 
 }

--- a/src/main/java/zowe/client/sdk/parse/ZosLogReplyParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/ZosLogReplyParseResponse.java
@@ -14,7 +14,6 @@ import zowe.client.sdk.utility.ValidateUtils;
 import zowe.client.sdk.zoslogs.response.ZosLogItem;
 import zowe.client.sdk.zoslogs.response.ZosLogReply;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -30,7 +29,7 @@ public class ZosLogReplyParseResponse implements JsonParseResponse {
      */
     private static JsonParseResponse INSTANCE;
 
-    private List<ZosLogItem> zosLogItems = new ArrayList<>();
+    private List<ZosLogItem> zosLogItems;
 
     /**
      * JSON data value to be parsed
@@ -67,15 +66,15 @@ public class ZosLogReplyParseResponse implements JsonParseResponse {
     @Override
     public ZosLogReply parseResponse() {
         ValidateUtils.checkNullParameter(data == null, ParseConstants.REQUIRED_ACTION_MSG);
-        ValidateUtils.checkNullParameter(zosLogItems.isEmpty(), ParseConstants.REQUIRED_ACTION_ZOS_LOG_ITEMS_MSG);
+        ValidateUtils.checkNullParameter(zosLogItems == null, ParseConstants.REQUIRED_ACTION_ZOS_LOG_ITEMS_MSG);
         final ZosLogReply zosLogReply = new ZosLogReply(
                 data.get("timezone") != null ? (Long) data.get("timezone") : 0,
                 data.get("nextTimestamp") != null ? (Long) data.get("nextTimestamp") : 0,
                 data.get("source") != null ? (String) data.get("source") : null,
-                data.get("totalitems") != null ? (Long) data.get("totalitems") : null,
+                data.get("totalitems") != null ? (Long) data.get("totalitems") : 0,
                 zosLogItems);
         data = null;
-        zosLogItems = new ArrayList<>();
+        zosLogItems = null;
         return zosLogReply;
     }
 

--- a/src/main/java/zowe/client/sdk/parse/ZosLogReplyParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/ZosLogReplyParseResponse.java
@@ -22,7 +22,7 @@ import java.util.List;
  * @author Frank Giordano
  * @version 2.0
  */
-public class ZosLogReplyParseResponse implements JsonParseResponse {
+public final class ZosLogReplyParseResponse implements JsonParseResponse {
 
     /**
      * Represents one singleton instance

--- a/src/main/java/zowe/client/sdk/parse/ZosLogReplyParseResponse.java
+++ b/src/main/java/zowe/client/sdk/parse/ZosLogReplyParseResponse.java
@@ -84,7 +84,7 @@ public final class ZosLogReplyParseResponse implements JsonParseResponse {
      * @param zosLogItems list of ZosLogItem objects
      * @author Frank Giordano
      */
-    public void setZosLogItems(List<ZosLogItem> zosLogItems) {
+    public void setZosLogItems(final List<ZosLogItem> zosLogItems) {
         ValidateUtils.checkNullParameter(zosLogItems == null, "zosLogItems is null");
         this.zosLogItems = zosLogItems;
     }

--- a/src/main/java/zowe/client/sdk/rest/JsonDeleteRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/JsonDeleteRequest.java
@@ -31,7 +31,7 @@ public class JsonDeleteRequest extends ZoweRequest {
      * @param connection connection information, see ZosConnection object
      * @author Frank Giordano
      */
-    public JsonDeleteRequest(ZosConnection connection) {
+    public JsonDeleteRequest(final ZosConnection connection) {
         super(connection);
     }
 

--- a/src/main/java/zowe/client/sdk/rest/JsonGetRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/JsonGetRequest.java
@@ -31,7 +31,7 @@ public class JsonGetRequest extends ZoweRequest {
      * @param connection connection information, see ZosConnection object
      * @author Frank Giordano
      */
-    public JsonGetRequest(ZosConnection connection) {
+    public JsonGetRequest(final ZosConnection connection) {
         super(connection);
     }
 

--- a/src/main/java/zowe/client/sdk/rest/JsonPostRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/JsonPostRequest.java
@@ -40,7 +40,7 @@ public class JsonPostRequest extends ZoweRequest {
      * @param connection connection information, see ZosConnection object
      * @author Frank Giordano
      */
-    public JsonPostRequest(ZosConnection connection) {
+    public JsonPostRequest(final ZosConnection connection) {
         super(connection);
     }
 
@@ -67,7 +67,7 @@ public class JsonPostRequest extends ZoweRequest {
      * @author Frank Giordano
      */
     @Override
-    public void setBody(Object body) {
+    public void setBody(final Object body) {
         this.body = (String) body;
         LOG.debug(this.body);
     }

--- a/src/main/java/zowe/client/sdk/rest/JsonPutRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/JsonPutRequest.java
@@ -40,7 +40,7 @@ public class JsonPutRequest extends ZoweRequest {
      * @param connection connection information, see ZosConnection object
      * @author Frank Giordano
      */
-    public JsonPutRequest(ZosConnection connection) {
+    public JsonPutRequest(final ZosConnection connection) {
         super(connection);
     }
 
@@ -67,7 +67,7 @@ public class JsonPutRequest extends ZoweRequest {
      * @author Frank Giordano
      */
     @Override
-    public void setBody(Object body) {
+    public void setBody(final Object body) {
         this.body = (String) body;
         LOG.debug(this.body);
     }

--- a/src/main/java/zowe/client/sdk/rest/Response.java
+++ b/src/main/java/zowe/client/sdk/rest/Response.java
@@ -10,6 +10,7 @@
 package zowe.client.sdk.rest;
 
 import java.util.Optional;
+import java.util.OptionalInt;
 
 /**
  * Holds http response information
@@ -27,7 +28,7 @@ public class Response {
     /**
      * Holds http response status code
      */
-    private final Optional<Integer> statusCode;
+    private final OptionalInt statusCode;
 
     /**
      * Holds http response status text
@@ -44,7 +45,11 @@ public class Response {
      */
     public Response(Object responsePhrase, Integer statusCode, String statusText) {
         this.responsePhrase = Optional.ofNullable(responsePhrase);
-        this.statusCode = Optional.ofNullable(statusCode);
+        if (statusCode == null) {
+            this.statusCode = OptionalInt.empty();
+        } else {
+            this.statusCode = OptionalInt.of(statusCode);
+        }
         this.statusText = Optional.ofNullable(statusText);
     }
 
@@ -64,7 +69,7 @@ public class Response {
      * @return statusCode value
      * @author Frank Giordano
      */
-    public Optional<Integer> getStatusCode() {
+    public OptionalInt getStatusCode() {
         return statusCode;
     }
 

--- a/src/main/java/zowe/client/sdk/rest/Response.java
+++ b/src/main/java/zowe/client/sdk/rest/Response.java
@@ -43,7 +43,7 @@ public class Response {
      * @param statusText     http response status text
      * @author Frank Giordano
      */
-    public Response(Object responsePhrase, Integer statusCode, String statusText) {
+    public Response(final Object responsePhrase, final Integer statusCode, final String statusText) {
         this.responsePhrase = Optional.ofNullable(responsePhrase);
         if (statusCode == null) {
             this.statusCode = OptionalInt.empty();

--- a/src/main/java/zowe/client/sdk/rest/StreamPutRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/StreamPutRequest.java
@@ -36,7 +36,7 @@ public class StreamPutRequest extends ZoweRequest {
      * @param connection connection information, see ZosConnection object
      * @author Frank Giordano
      */
-    public StreamPutRequest(ZosConnection connection) {
+    public StreamPutRequest(final ZosConnection connection) {
         super(connection);
     }
 
@@ -63,7 +63,7 @@ public class StreamPutRequest extends ZoweRequest {
      * @author Frank Giordano
      */
     @Override
-    public void setBody(Object body) {
+    public void setBody(final Object body) {
         this.body = (byte[]) body;
     }
 

--- a/src/main/java/zowe/client/sdk/rest/TextGetRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/TextGetRequest.java
@@ -30,7 +30,7 @@ public class TextGetRequest extends ZoweRequest {
      * @param connection connection information, see ZosConnection object
      * @author Frank Giordano
      */
-    public TextGetRequest(ZosConnection connection) {
+    public TextGetRequest(final ZosConnection connection) {
         super(connection);
     }
 

--- a/src/main/java/zowe/client/sdk/rest/TextPutRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/TextPutRequest.java
@@ -39,7 +39,7 @@ public class TextPutRequest extends ZoweRequest {
      * @param connection connection information, see ZosConnection object
      * @author Frank Giordano
      */
-    public TextPutRequest(ZosConnection connection) {
+    public TextPutRequest(final ZosConnection connection) {
         super(connection);
     }
 
@@ -66,7 +66,7 @@ public class TextPutRequest extends ZoweRequest {
      * @author Frank Giordano
      */
     @Override
-    public void setBody(Object body) {
+    public void setBody(final Object body) {
         this.body = (String) body;
         LOG.debug(this.body);
     }

--- a/src/main/java/zowe/client/sdk/rest/ZoweRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/ZoweRequest.java
@@ -43,7 +43,7 @@ public abstract class ZoweRequest {
      * @param connection connection information, see ZosConnection object
      * @author Frank Giordano
      */
-    public ZoweRequest(ZosConnection connection) {
+    public ZoweRequest(final ZosConnection connection) {
         this.connection = connection;
         this.setup();
     }
@@ -55,7 +55,7 @@ public abstract class ZoweRequest {
      * @return Response object
      * @author Frank Giordano
      */
-    protected static Response getJsonResponse(HttpResponse<JsonNode> reply) {
+    protected static Response getJsonResponse(final HttpResponse<JsonNode> reply) {
         if (reply.getBody().isArray()) {
             return new Response(reply.getBody().getArray(), reply.getStatus(), reply.getStatusText());
         }
@@ -88,7 +88,7 @@ public abstract class ZoweRequest {
      * @throws UnirestException error setting body
      * @author Frank Giordano
      */
-    public abstract void setBody(Object body) throws UnirestException;
+    public abstract void setBody(final Object body) throws UnirestException;
 
     /**
      * Set any headers needed for the http request
@@ -96,7 +96,7 @@ public abstract class ZoweRequest {
      * @param headers headers to add to the request
      * @author Frank Giordano
      */
-    public void setHeaders(Map<String, String> headers) {
+    public void setHeaders(final Map<String, String> headers) {
         this.headers.clear();
         this.setStandardHeaders();
         this.headers.putAll(headers);
@@ -116,7 +116,7 @@ public abstract class ZoweRequest {
      * @throws IllegalArgumentException error setting valid url string
      * @author Frank Giordano
      */
-    public void setUrl(String url) throws IllegalArgumentException {
+    public void setUrl(final String url) throws IllegalArgumentException {
         ValidateUtils.checkNullParameter(url == null, "url is null");
         ValidateUtils.checkIllegalParameter(url.isBlank(), "url not specified");
         if (RestUtils.isUrlNotValid(url)) {

--- a/src/main/java/zowe/client/sdk/rest/ZoweRequestFactory.java
+++ b/src/main/java/zowe/client/sdk/rest/ZoweRequestFactory.java
@@ -40,7 +40,8 @@ public final class ZoweRequestFactory {
      * @throws Exception error with type not found
      * @author Frank Giordano
      */
-    public static ZoweRequest buildRequest(ZosConnection connection, ZoweRequestType type) throws Exception {
+    public static ZoweRequest buildRequest(final ZosConnection connection, final ZoweRequestType type)
+            throws Exception {
         LOG.debug(type.name());
         ZoweRequest request;
         switch (type) {

--- a/src/main/java/zowe/client/sdk/teamconfig/TeamConfig.java
+++ b/src/main/java/zowe/client/sdk/teamconfig/TeamConfig.java
@@ -104,7 +104,7 @@ public class TeamConfig {
      * @throws Exception error processing
      * @author Frank Giordano
      */
-    public ProfileDao getDefaultProfileByName(String name) throws Exception {
+    public ProfileDao getDefaultProfileByName(final String name) throws Exception {
         ValidateUtils.checkNullParameter(name == null, "name is null");
         ValidateUtils.checkIllegalParameter(name.isBlank(), "name not specified");
         final Optional<String> defaultName = Optional.ofNullable(teamConfig.getDefaults().get(name));
@@ -129,10 +129,9 @@ public class TeamConfig {
      * @param profileName   profile name
      * @param partitionName partition name
      * @return ProfileDao object
-     * @throws Exception error processing
      * @author Frank Giordano
      */
-    public ProfileDao getDefaultProfileFromPartitionByName(String profileName, String partitionName) throws Exception {
+    public ProfileDao getDefaultProfileFromPartitionByName(final String profileName, final String partitionName) {
         ValidateUtils.checkNullParameter(profileName == null, "profileName is null");
         ValidateUtils.checkIllegalParameter(profileName.isBlank(), "profileName not specified");
         ValidateUtils.checkNullParameter(partitionName == null, "partitionName is null");
@@ -168,7 +167,7 @@ public class TeamConfig {
      * @param base   profile object
      * @author Frank Giordano
      */
-    private void merge(Optional<Profile> target, Optional<Profile> base) {
+    private void merge(final Optional<Profile> target, final Optional<Profile> base) {
         final Optional<Map<String, String>> targetProps = Optional.ofNullable(target.get().getProperties());
         final Optional<Map<String, String>> baseProps = Optional.ofNullable(base.get().getProperties());
         if (mergeProperties.getHost().isEmpty() && targetProps.isPresent()) {
@@ -194,7 +193,7 @@ public class TeamConfig {
             return host;
         }
 
-        public void setHost(String host) {
+        public void setHost(final String host) {
             this.host = Optional.ofNullable(host);
         }
 
@@ -202,7 +201,7 @@ public class TeamConfig {
             return port;
         }
 
-        public void setPort(String port) {
+        public void setPort(final String port) {
             this.port = Optional.ofNullable(port);
         }
 

--- a/src/main/java/zowe/client/sdk/teamconfig/keytar/KeyTarConfig.java
+++ b/src/main/java/zowe/client/sdk/teamconfig/keytar/KeyTarConfig.java
@@ -38,7 +38,7 @@ public class KeyTarConfig {
      * @param password password specified from parsed KeyTar keyValue
      * @author Frank Giordano
      */
-    public KeyTarConfig(String location, String userName, String password) {
+    public KeyTarConfig(final String location, final String userName, final String password) {
         this.location = location;
         this.userName = userName;
         this.password = password;

--- a/src/main/java/zowe/client/sdk/teamconfig/keytar/KeyTarImpl.java
+++ b/src/main/java/zowe/client/sdk/teamconfig/keytar/KeyTarImpl.java
@@ -126,12 +126,12 @@ public class KeyTarImpl implements IKeyTar {
     }
 
     @Override
-    public void setAccountName(String accountName) {
+    public void setAccountName(final String accountName) {
         this.accountName = accountName;
     }
 
     @Override
-    public void setServiceName(String serviceName) {
+    public void setServiceName(final String serviceName) {
         this.serviceName = serviceName;
     }
 

--- a/src/main/java/zowe/client/sdk/teamconfig/model/ConfigContainer.java
+++ b/src/main/java/zowe/client/sdk/teamconfig/model/ConfigContainer.java
@@ -52,8 +52,8 @@ public class ConfigContainer {
      * @param autoStore  autoStore value from Zowe Global Team Configuration
      * @author Frank Giordano
      */
-    public ConfigContainer(List<Partition> partitions, String schema, List<Profile> profiles,
-                           Map<String, String> defaults, Boolean autoStore) {
+    public ConfigContainer(final List<Partition> partitions, final String schema, final List<Profile> profiles,
+                           final Map<String, String> defaults, final Boolean autoStore) {
         this.partitions = partitions;
         this.schema = schema;
         this.profiles = profiles;
@@ -62,12 +62,12 @@ public class ConfigContainer {
     }
 
     /**
-     * Return autoStore
+     * Return is autoStore specified from reading and parsing Zowe Global Team Configuration
      *
-     * @return autoStore string value from reading and parsing Zowe Global Team Configuration
+     * @return boolean true or false
      * @author Frank Giordano
      */
-    public Boolean getAutoStore() {
+    public Boolean isAutoStore() {
         return autoStore;
     }
 

--- a/src/main/java/zowe/client/sdk/teamconfig/model/Partition.java
+++ b/src/main/java/zowe/client/sdk/teamconfig/model/Partition.java
@@ -39,10 +39,10 @@ public class Partition {
      *
      * @param name       partition name
      * @param properties hashmap of property values
-     * @param profiles   list oof Profiles
+     * @param profiles   list of Profiles
      * @author Frank Giordano
      */
-    public Partition(String name, Map<String, String> properties, List<Profile> profiles) {
+    public Partition(final String name, final Map<String, String> properties, final List<Profile> profiles) {
         this.name = name;
         this.properties = properties;
         this.profiles = profiles;

--- a/src/main/java/zowe/client/sdk/teamconfig/model/Profile.java
+++ b/src/main/java/zowe/client/sdk/teamconfig/model/Profile.java
@@ -47,7 +47,7 @@ public class Profile {
      * @author Frank Giordano
      */
     @SuppressWarnings("unchecked")
-    public Profile(String name, JSONObject obj, JSONArray secure) throws Exception {
+    public Profile(final String name, final JSONObject obj, final JSONArray secure) throws Exception {
         this.name = name;
         this.secure = secure;
         properties = (Map<String, String>) JsonParseResponseFactory.buildParser(ParseType.PROPS)

--- a/src/main/java/zowe/client/sdk/teamconfig/model/Profile.java
+++ b/src/main/java/zowe/client/sdk/teamconfig/model/Profile.java
@@ -50,7 +50,8 @@ public class Profile {
     public Profile(String name, JSONObject obj, JSONArray secure) throws Exception {
         this.name = name;
         this.secure = secure;
-        properties = (Map<String, String>) JsonParseResponseFactory.buildParser(obj, ParseType.PROPS).parseResponse();
+        properties = (Map<String, String>) JsonParseResponseFactory.buildParser(ParseType.PROPS)
+                .setJsonObject(obj).parseResponse();
     }
 
     /**

--- a/src/main/java/zowe/client/sdk/teamconfig/model/ProfileDao.java
+++ b/src/main/java/zowe/client/sdk/teamconfig/model/ProfileDao.java
@@ -49,7 +49,8 @@ public class ProfileDao {
      * @param port     port value from Zowe Global Team Configuration
      * @author Frank Giordano
      */
-    public ProfileDao(Profile profile, String user, String password, String host, String port) {
+    public ProfileDao(final Profile profile, final String user, final String password, final String host,
+                      final String port) {
         this.profile = profile;
         this.user = user;
         this.password = password;

--- a/src/main/java/zowe/client/sdk/teamconfig/service/KeyTarService.java
+++ b/src/main/java/zowe/client/sdk/teamconfig/service/KeyTarService.java
@@ -49,7 +49,7 @@ public class KeyTarService {
      * @param keyTar IKeyTar implementation Object
      * @author Frank Giordano
      */
-    public KeyTarService(IKeyTar keyTar) {
+    public KeyTarService(final IKeyTar keyTar) {
         this.keyTar = keyTar;
     }
 

--- a/src/main/java/zowe/client/sdk/teamconfig/service/TeamConfigService.java
+++ b/src/main/java/zowe/client/sdk/teamconfig/service/TeamConfigService.java
@@ -15,7 +15,6 @@ import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import zowe.client.sdk.parse.JsonParseResponse;
 import zowe.client.sdk.parse.JsonParseResponseFactory;
 import zowe.client.sdk.parse.type.ParseType;
 import zowe.client.sdk.teamconfig.keytar.KeyTarConfig;
@@ -68,9 +67,8 @@ public class TeamConfigService {
                             (JSONArray) profileTypeJsonObj.get("secure")));
                 }
             } else if ("properties".equalsIgnoreCase(keyObj)) {
-                final JsonParseResponse parse = JsonParseResponseFactory.buildParser(
-                        (JSONObject) jsonObject.get(keyObj), ParseType.PROPS);
-                properties = (Map<String, String>) parse.parseResponse();
+                properties = (Map<String, String>) JsonParseResponseFactory.buildParser(ParseType.PROPS)
+                        .setJsonObject((JSONObject) jsonObject.get(keyObj)).parseResponse();
             }
         }
         return new Partition(name, properties, profiles);

--- a/src/main/java/zowe/client/sdk/teamconfig/service/TeamConfigService.java
+++ b/src/main/java/zowe/client/sdk/teamconfig/service/TeamConfigService.java
@@ -51,7 +51,7 @@ public class TeamConfigService {
      * @author Frank Giordano
      */
     @SuppressWarnings("unchecked")
-    private Partition getPartition(String name, JSONObject jsonObject) throws Exception {
+    private Partition getPartition(final String name, final JSONObject jsonObject) throws Exception {
         final Set<String> keyObjs = jsonObject.keySet();
         final List<Profile> profiles = new ArrayList<>();
         Map<String, String> properties = new HashMap<>();
@@ -82,7 +82,7 @@ public class TeamConfigService {
      * @throws Exception error processing
      * @author Frank Giordano
      */
-    public ConfigContainer getTeamConfig(KeyTarConfig config) throws Exception {
+    public ConfigContainer getTeamConfig(final KeyTarConfig config) throws Exception {
         ValidateUtils.checkNullParameter(config == null, "config is null");
         final JSONParser parser = new JSONParser();
         Object obj;
@@ -102,7 +102,7 @@ public class TeamConfigService {
      * @throws Exception error processing
      * @author Frank Giordano
      */
-    private boolean isPartition(Set<String> profileKeyObj) throws Exception {
+    private boolean isPartition(final Set<String> profileKeyObj) throws Exception {
         final Iterator<String> itr = profileKeyObj.iterator();
         if (itr.hasNext()) {
             String keyVal = itr.next();
@@ -121,7 +121,7 @@ public class TeamConfigService {
      * @author Frank Giordano
      */
     @SuppressWarnings("unchecked")
-    private ConfigContainer parseJson(JSONObject jsonObj) throws Exception {
+    private ConfigContainer parseJson(final JSONObject jsonObj) throws Exception {
         String schema = null;
         Boolean autoStore = null;
         final List<Profile> profiles = new ArrayList<>();
@@ -154,7 +154,7 @@ public class TeamConfigService {
                     defaults.put(key, value);
                 }
             } else if (SectionType.AUTOSTORE.getValue().equals(keySectionVal)) {
-                autoStore = (Boolean) jsonObj.get(SectionType.AUTOSTORE.getValue());
+                autoStore = (boolean) jsonObj.get(SectionType.AUTOSTORE.getValue());
             }
         }
 

--- a/src/main/java/zowe/client/sdk/teamconfig/types/SectionType.java
+++ b/src/main/java/zowe/client/sdk/teamconfig/types/SectionType.java
@@ -24,7 +24,7 @@ public enum SectionType {
 
     private final String value;
 
-    SectionType(String value) {
+    SectionType(final String value) {
         this.value = value;
     }
 

--- a/src/main/java/zowe/client/sdk/utility/EncodeUtils.java
+++ b/src/main/java/zowe/client/sdk/utility/EncodeUtils.java
@@ -38,7 +38,7 @@ public final class EncodeUtils {
      * @return encoded String or original string
      * @author Frank Giordano
      */
-    public static String encodeURIComponent(String value) {
+    public static String encodeURIComponent(final String value) {
         ValidateUtils.checkNullParameter(value == null, "str is null");
         ValidateUtils.checkIllegalParameter(value.isBlank(), "str not specified");
         return URLEncoder.encode(value, StandardCharsets.UTF_8)
@@ -57,7 +57,7 @@ public final class EncodeUtils {
      * @return encoded String
      * @author Frank Giordano
      */
-    public static String encodeAuthComponent(ZosConnection connection) {
+    public static String encodeAuthComponent(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         return Base64.getEncoder().encodeToString((connection.getUser() + ":" +
                 connection.getPassword()).getBytes(StandardCharsets.UTF_8));

--- a/src/main/java/zowe/client/sdk/utility/FileUtils.java
+++ b/src/main/java/zowe/client/sdk/utility/FileUtils.java
@@ -41,7 +41,7 @@ public final class FileUtils {
      * @return same value string back to caller if valid
      * @author Frank Giordano
      */
-    public static String validatePermission(String value) {
+    public static String validatePermission(final String value) {
         ValidateUtils.checkNullParameter(value == null, "permission value is null");
         ValidateUtils.checkIllegalParameter(value.length() != 9, "specify 9 character permission");
         Pattern p = Pattern.compile("(rwx|rw-|r--|r-x|--x|-wx|-w-)+");
@@ -59,7 +59,7 @@ public final class FileUtils {
      * @return same value string back to caller if valid
      * @author Frank Giordano
      */
-    public static String validatePath(String value) {
+    public static String validatePath(final String value) {
         ValidateUtils.checkNullParameter(value == null, "path value is null");
         Pattern p = Pattern.compile("\\/.*");
         Matcher m = p.matcher(value);

--- a/src/main/java/zowe/client/sdk/utility/RestUtils.java
+++ b/src/main/java/zowe/client/sdk/utility/RestUtils.java
@@ -44,7 +44,7 @@ public final class RestUtils {
      * @throws Exception http error code
      * @author Frank Giordano
      */
-    public static Response getResponse(ZoweRequest request) throws Exception {
+    public static Response getResponse(final ZoweRequest request) throws Exception {
         final Response response = request.executeRequest();
 
         final String errMsg = "no response status code returned";
@@ -83,10 +83,10 @@ public final class RestUtils {
      * Checks if statusCode is an error http code or not
      *
      * @param statusCode http code value
-     * @return boolean value
+     * @return boolean true or false
      * @author Frank Giordano
      */
-    public static boolean isHttpError(int statusCode) {
+    public static boolean isHttpError(final int statusCode) {
         return !((statusCode >= 200 && statusCode <= 299) || (statusCode >= 100 && statusCode <= 199));
     }
 
@@ -94,10 +94,10 @@ public final class RestUtils {
      * Checks if url is a valid http or https url.
      *
      * @param url string value
-     * @return boolean value
+     * @return boolean true or false
      * @author Frank Giordano
      */
-    public static boolean isUrlNotValid(String url) {
+    public static boolean isUrlNotValid(final String url) {
         try {
             new URL(url).toURI();
             return false;

--- a/src/main/java/zowe/client/sdk/utility/ValidateUtils.java
+++ b/src/main/java/zowe/client/sdk/utility/ValidateUtils.java
@@ -36,7 +36,7 @@ public final class ValidateUtils {
      * @throws IllegalStateException with message "Connection data not setup properly"
      * @author Frank Giordano
      */
-    public static void checkConnection(ZosConnection connection) {
+    public static void checkConnection(final ZosConnection connection) {
         if (connection == null || connection.getZosmfPort() == null || connection.getHost() == null ||
                 connection.getPassword() == null || connection.getUser() == null ||
                 connection.getZosmfPort().isBlank() || connection.getHost().isBlank() ||
@@ -53,7 +53,7 @@ public final class ValidateUtils {
      * @throws IllegalArgumentException with message
      * @author Frank Giordano
      */
-    public static void checkIllegalParameter(boolean check, String msg) {
+    public static void checkIllegalParameter(final boolean check, final String msg) {
         Optional<String> message = Optional.ofNullable(msg);
         if (check) {
             throw new IllegalArgumentException(message.orElse("empty message specified"));
@@ -68,7 +68,7 @@ public final class ValidateUtils {
      * @throws IllegalArgumentException with message
      * @author Frank Giordano
      */
-    public static void checkNullParameter(boolean check, String msg) {
+    public static void checkNullParameter(final boolean check, final String msg) {
         Optional<String> message = Optional.ofNullable(msg);
         if (check) {
             throw new NullPointerException(message.orElse("empty message specified"));
@@ -82,7 +82,7 @@ public final class ValidateUtils {
      * @throws IllegalStateException with message "Connection data not setup properly"
      * @author Frank Giordano
      */
-    public static void checkSshConnection(SshConnection connection) {
+    public static void checkSshConnection(final SshConnection connection) {
         if (connection == null || connection.getHost() == null || connection.getPassword() == null ||
                 connection.getUser() == null || connection.getHost().isBlank() ||
                 connection.getPassword().isBlank() || connection.getUser().isBlank()) {

--- a/src/main/java/zowe/client/sdk/utility/timer/Timer.java
+++ b/src/main/java/zowe/client/sdk/utility/timer/Timer.java
@@ -34,7 +34,7 @@ public class Timer {
      * @param waitTime in milliseconds
      * @author Frank Giordano
      */
-    public Timer(int waitTime) {
+    public Timer(final int waitTime) {
         this.waitTime = waitTime;
         this.endTime = System.currentTimeMillis();
     }
@@ -46,7 +46,7 @@ public class Timer {
      * @author Frank Giordano
      */
     public Timer initialize() {
-        long currentTime = System.currentTimeMillis();
+        final long currentTime = System.currentTimeMillis();
         endTime = currentTime + waitTime;
         return this;
     }

--- a/src/main/java/zowe/client/sdk/utility/timer/WaitUtil.java
+++ b/src/main/java/zowe/client/sdk/utility/timer/WaitUtil.java
@@ -30,7 +30,7 @@ public final class WaitUtil {
      * @param time in milliseconds
      * @author Frank Giordano
      */
-    public static void wait(int time) {
+    public static void wait(final int time) {
         final Timer timer = new Timer(time).initialize();
         while (!timer.isEnded()) {
         }

--- a/src/main/java/zowe/client/sdk/zosconsole/input/IssueConsoleParams.java
+++ b/src/main/java/zowe/client/sdk/zosconsole/input/IssueConsoleParams.java
@@ -49,7 +49,7 @@ public class IssueConsoleParams {
      * @param command console command to issue
      * @author Frank Giordano
      */
-    public IssueConsoleParams(String command) {
+    public IssueConsoleParams(final String command) {
         ValidateUtils.checkNullParameter(command == null, "command is null");
         ValidateUtils.checkIllegalParameter(command.isBlank(), "command not specified");
         this.cmd = Optional.of(command);
@@ -81,7 +81,7 @@ public class IssueConsoleParams {
      * @param solKey value
      * @author Frank Giordano
      */
-    public void setSolKey(String solKey) {
+    public void setSolKey(final String solKey) {
         this.solKey = Optional.ofNullable(solKey);
     }
 
@@ -101,14 +101,14 @@ public class IssueConsoleParams {
      * @param system value
      * @author Frank Giordano
      */
-    public void setSystem(String system) {
+    public void setSystem(final String system) {
         this.system = Optional.ofNullable(system);
     }
 
     /**
-     * Retrieve processResponse value
+     * Retrieve is processResponse specified
      *
-     * @return processResponse value
+     * @return boolean true or false
      * @author Frank Giordano
      */
     public boolean isProcessResponse() {

--- a/src/main/java/zowe/client/sdk/zosconsole/method/IssueConsole.java
+++ b/src/main/java/zowe/client/sdk/zosconsole/method/IssueConsole.java
@@ -12,7 +12,6 @@ package zowe.client.sdk.zosconsole.method;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import zowe.client.sdk.core.ZosConnection;
-import zowe.client.sdk.parse.JsonParseResponse;
 import zowe.client.sdk.parse.JsonParseResponseFactory;
 import zowe.client.sdk.parse.type.ParseType;
 import zowe.client.sdk.rest.JsonPutRequest;
@@ -134,9 +133,9 @@ public class IssueConsole {
         final String jsonStr = RestUtils.getResponse(request).getResponsePhrase()
                 .orElseThrow(() -> new IllegalStateException("no issue console response phrase")).toString();
         final JSONObject jsonObject = (JSONObject) new JSONParser().parse(jsonStr);
-        final JsonParseResponse parser = JsonParseResponseFactory.buildParser(jsonObject, ParseType.MVS_CONSOLE);
         return ConsoleResponseService.getInstance()
-                .buildConsoleResponse((ZosmfIssueResponse) parser.parseResponse(), params.isProcessResponse());
+                .buildConsoleResponse((ZosmfIssueResponse) JsonParseResponseFactory.buildParser(ParseType.MVS_CONSOLE)
+                        .setJsonObject(jsonObject).parseResponse(), params.isProcessResponse());
     }
 
 }

--- a/src/main/java/zowe/client/sdk/zosconsole/method/IssueConsole.java
+++ b/src/main/java/zowe/client/sdk/zosconsole/method/IssueConsole.java
@@ -47,7 +47,7 @@ public class IssueConsole {
      * @param connection connection information, see ZOSConnection object
      * @author Frank Giordano
      */
-    public IssueConsole(ZosConnection connection) {
+    public IssueConsole(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
     }
@@ -61,7 +61,7 @@ public class IssueConsole {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public IssueConsole(ZosConnection connection, ZoweRequest request) throws Exception {
+    public IssueConsole(final ZosConnection connection, final ZoweRequest request) throws Exception {
         ValidateUtils.checkConnection(connection);
         ValidateUtils.checkNullParameter(request == null, "request is null");
         this.connection = connection;
@@ -82,7 +82,7 @@ public class IssueConsole {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public ConsoleResponse issueCommand(String command) throws Exception {
+    public ConsoleResponse issueCommand(final String command) throws Exception {
         return issueCommandCommon(ConsoleConstants.RES_DEF_CN, new IssueConsoleParams(command));
     }
 
@@ -98,7 +98,7 @@ public class IssueConsole {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public ConsoleResponse issueCommand(String command, String consoleName) throws Exception {
+    public ConsoleResponse issueCommand(final String command, final String consoleName) throws Exception {
         return issueCommandCommon(consoleName, new IssueConsoleParams(command));
     }
 
@@ -110,7 +110,8 @@ public class IssueConsole {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public ConsoleResponse issueCommandCommon(String consoleName, IssueConsoleParams params) throws Exception {
+    public ConsoleResponse issueCommandCommon(final String consoleName, final IssueConsoleParams params)
+            throws Exception {
         ValidateUtils.checkNullParameter(params == null, "params is null");
         ValidateUtils.checkNullParameter(consoleName == null, "consoleName is null");
         ValidateUtils.checkIllegalParameter(consoleName.isBlank(), "consoleName not specified");

--- a/src/main/java/zowe/client/sdk/zosconsole/response/ConsoleResponse.java
+++ b/src/main/java/zowe/client/sdk/zosconsole/response/ConsoleResponse.java
@@ -72,7 +72,7 @@ public class ConsoleResponse {
      * @param cmdResponseUrl value
      * @author Frank Giordano
      */
-    public void setCmdResponseUrl(String cmdResponseUrl) {
+    public void setCmdResponseUrl(final String cmdResponseUrl) {
         this.cmdResponseUrl = Optional.ofNullable(cmdResponseUrl);
     }
 
@@ -92,7 +92,7 @@ public class ConsoleResponse {
      * @param commandResponse value
      * @author Frank Giordano
      */
-    public void setCommandResponse(String commandResponse) {
+    public void setCommandResponse(final String commandResponse) {
         this.commandResponse = Optional.ofNullable(commandResponse);
     }
 
@@ -112,12 +112,12 @@ public class ConsoleResponse {
      * @param failureResponse value
      * @author Frank Giordano
      */
-    public void setFailureResponse(String failureResponse) {
+    public void setFailureResponse(final String failureResponse) {
         this.failureResponse = Optional.ofNullable(failureResponse);
     }
 
     /**
-     * Retrieve keywordDetected specified
+     * Retrieve is keywordDetected specified
      *
      * @return keywordDetected true or false is keywordDetected seen
      * @author Frank Giordano
@@ -152,14 +152,14 @@ public class ConsoleResponse {
      * @param lastResponseKey value
      * @author Frank Giordano
      */
-    public void setLastResponseKey(String lastResponseKey) {
+    public void setLastResponseKey(final String lastResponseKey) {
         this.lastResponseKey = Optional.ofNullable(lastResponseKey);
     }
 
     /**
-     * Retrieve success specified
+     * Retrieve is success
      *
-     * @return boolean value
+     * @return boolean true or false
      * @author Frank Giordano
      */
     public boolean isSuccess() {
@@ -192,7 +192,7 @@ public class ConsoleResponse {
      * @param zosmfResponse value
      * @author Frank Giordano
      */
-    public void setZosmfResponse(ZosmfIssueResponse zosmfResponse) {
+    public void setZosmfResponse(final ZosmfIssueResponse zosmfResponse) {
         this.zosmfResponse = Optional.ofNullable(zosmfResponse);
     }
 

--- a/src/main/java/zowe/client/sdk/zosconsole/response/ZosmfIssueResponse.java
+++ b/src/main/java/zowe/client/sdk/zosconsole/response/ZosmfIssueResponse.java
@@ -60,7 +60,7 @@ public class ZosmfIssueResponse {
      * @param cmdResponse value
      * @author Frank Giordano
      */
-    public void setCmdResponse(String cmdResponse) {
+    public void setCmdResponse(final String cmdResponse) {
         this.cmdResponse = Optional.ofNullable(cmdResponse);
     }
 
@@ -80,7 +80,7 @@ public class ZosmfIssueResponse {
      * @param cmdResponseKey value
      * @author Frank Giordano
      */
-    public void setCmdResponseKey(String cmdResponseKey) {
+    public void setCmdResponseKey(final String cmdResponseKey) {
         this.cmdResponseKey = Optional.ofNullable(cmdResponseKey);
     }
 
@@ -100,7 +100,7 @@ public class ZosmfIssueResponse {
      * @param cmdResponseUri value
      * @author Frank Giordano
      */
-    public void setCmdResponseUri(String cmdResponseUri) {
+    public void setCmdResponseUri(final String cmdResponseUri) {
         this.cmdResponseUri = Optional.ofNullable(cmdResponseUri);
     }
 
@@ -120,7 +120,7 @@ public class ZosmfIssueResponse {
      * @param cmdResponseUrl value
      * @author Frank Giordano
      */
-    public void setCmdResponseUrl(String cmdResponseUrl) {
+    public void setCmdResponseUrl(final String cmdResponseUrl) {
         this.cmdResponseUrl = Optional.ofNullable(cmdResponseUrl);
     }
 
@@ -140,7 +140,7 @@ public class ZosmfIssueResponse {
      * @param solKeyDetected value
      * @author Frank Giordano
      */
-    public void setSolKeyDetected(String solKeyDetected) {
+    public void setSolKeyDetected(final String solKeyDetected) {
         this.solKeyDetected = Optional.ofNullable(solKeyDetected);
     }
 

--- a/src/main/java/zowe/client/sdk/zosconsole/service/ConsoleResponseService.java
+++ b/src/main/java/zowe/client/sdk/zosconsole/service/ConsoleResponseService.java
@@ -53,7 +53,7 @@ public final class ConsoleResponseService {
      * @return response         console response to be populated, see ConsoleResponse object
      * @author Frank Giordano
      */
-    public ConsoleResponse buildConsoleResponse(ZosmfIssueResponse zosmfResponse, boolean processResponses) {
+    public ConsoleResponse buildConsoleResponse(final ZosmfIssueResponse zosmfResponse, boolean processResponses) {
         ValidateUtils.checkNullParameter(zosmfResponse == null, "zosmfResponse is null");
         ConsoleResponse consoleResponse = new ConsoleResponse();
         consoleResponse.setZosmfResponse(zosmfResponse);

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/input/CopyParams.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/input/CopyParams.java
@@ -51,7 +51,7 @@ public class CopyParams {
      */
     private final boolean copyAllMembers;
 
-    private CopyParams(CopyParams.Builder builder) {
+    private CopyParams(final CopyParams.Builder builder) {
         this.fromVolser = Optional.ofNullable(builder.fromVolser);
         this.fromDataSet = Optional.ofNullable(builder.fromDataSet);
         this.toVolser = Optional.ofNullable(builder.toVolser);
@@ -101,9 +101,9 @@ public class CopyParams {
     }
 
     /**
-     * Retrieve copyAllMembers value
+     * Retrieve is copyAllMembers specified
      *
-     * @return copyAllMembers value
+     * @return boolean true or false
      * @author Frank Giordano
      */
     public boolean isCopyAllMembers() {
@@ -111,9 +111,9 @@ public class CopyParams {
     }
 
     /**
-     * Retrieve replace value
+     * Retrieve is replace specified
      *
-     * @return replace value
+     * @return boolean true or false
      * @author Leonid Baranov
      */
     public boolean isReplace() {
@@ -144,36 +144,36 @@ public class CopyParams {
             return new CopyParams(this);
         }
 
-        public CopyParams.Builder copyAllMembers(boolean value) {
+        public CopyParams.Builder copyAllMembers(final boolean value) {
             this.copyAllMembers = value;
             return this;
         }
 
-        public CopyParams.Builder fromDataSet(String dataSet) {
+        public CopyParams.Builder fromDataSet(final String dataSet) {
             ValidateUtils.checkNullParameter(dataSet == null, "fromDataSet is null");
             ValidateUtils.checkNullParameter(dataSet.isEmpty(), "fromDataSet not specified");
             this.fromDataSet = dataSet;
             return this;
         }
 
-        public CopyParams.Builder fromVolser(String volser) {
+        public CopyParams.Builder fromVolser(final String volser) {
             this.fromVolser = volser;
             return this;
         }
 
-        public CopyParams.Builder replace(boolean replace) {
+        public CopyParams.Builder replace(final boolean replace) {
             this.replace = replace;
             return this;
         }
 
-        public CopyParams.Builder toDataSet(String dataSet) {
+        public CopyParams.Builder toDataSet(final String dataSet) {
             ValidateUtils.checkNullParameter(dataSet == null, "toDataSet is null");
             ValidateUtils.checkNullParameter(dataSet.isEmpty(), "toDataSet not specified");
             this.toDataSet = dataSet;
             return this;
         }
 
-        public CopyParams.Builder toVolser(String volser) {
+        public CopyParams.Builder toVolser(final String volser) {
             this.toVolser = volser;
             return this;
         }

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/input/CreateParams.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/input/CreateParams.java
@@ -101,7 +101,7 @@ public class CreateParams {
      * The indicator that we need to show the attributes
      * DO NOT SEND THIS TO ZOSMF
      */
-    private final Optional<Boolean> showAttributes;
+    private final boolean showAttributes;
 
     /**
      * The abstraction of Allocation unit and Primary Space
@@ -114,7 +114,7 @@ public class CreateParams {
      */
     private final Optional<String> responseTimeout;
 
-    private CreateParams(CreateParams.Builder builder) {
+    private CreateParams(final CreateParams.Builder builder) {
         this.volser = Optional.ofNullable(builder.volser);
         this.unit = Optional.ofNullable(builder.unit);
         this.dsorg = Optional.ofNullable(builder.dsorg);
@@ -154,7 +154,7 @@ public class CreateParams {
         this.mgntclass = Optional.ofNullable(builder.mgntclass);
         this.dataclass = Optional.ofNullable(builder.dataclass);
         this.dsntype = Optional.ofNullable(builder.dsntype);
-        this.showAttributes = Optional.ofNullable(builder.showAttributes);
+        this.showAttributes = builder.showAttributes;
         this.size = Optional.ofNullable(builder.size);
         this.responseTimeout = Optional.ofNullable(builder.responseTimeout);
     }
@@ -290,12 +290,12 @@ public class CreateParams {
     }
 
     /**
-     * Retrieve showAttributes value
+     * Retrieve is showAttributes specified
      *
-     * @return showAttributes value
+     * @return boolean true or false
      * @author Leonid Baranov
      */
-    public Optional<Boolean> getShowAttributes() {
+    public boolean isShowAttributes() {
         return showAttributes;
     }
 
@@ -380,21 +380,21 @@ public class CreateParams {
         private String mgntclass;
         private String dataclass;
         private String dsntype;
-        private Boolean showAttributes;
+        private boolean showAttributes;
         private String size;
         private String responseTimeout;
 
-        public CreateParams.Builder alcunit(String alcunit) {
+        public CreateParams.Builder alcunit(final String alcunit) {
             this.alcunit = alcunit;
             return this;
         }
 
-        public CreateParams.Builder avgblk(Integer avgblk) {
+        public CreateParams.Builder avgblk(final Integer avgblk) {
             this.avgblk = avgblk;
             return this;
         }
 
-        public CreateParams.Builder blksize(Integer blksize) {
+        public CreateParams.Builder blksize(final Integer blksize) {
             this.blksize = blksize;
             return this;
         }
@@ -403,77 +403,77 @@ public class CreateParams {
             return new CreateParams(this);
         }
 
-        public CreateParams.Builder dataclass(String dataclass) {
+        public CreateParams.Builder dataclass(final String dataclass) {
             this.dataclass = dataclass;
             return this;
         }
 
-        public CreateParams.Builder dirblk(Integer dirblk) {
+        public CreateParams.Builder dirblk(final Integer dirblk) {
             this.dirblk = dirblk;
             return this;
         }
 
-        public CreateParams.Builder dsntype(String dsntype) {
+        public CreateParams.Builder dsntype(final String dsntype) {
             this.dsntype = dsntype;
             return this;
         }
 
-        public CreateParams.Builder dsorg(String dsorg) {
+        public CreateParams.Builder dsorg(final String dsorg) {
             this.dsorg = dsorg;
             return this;
         }
 
-        public CreateParams.Builder lrecl(Integer lrecl) {
+        public CreateParams.Builder lrecl(final Integer lrecl) {
             this.lrecl = lrecl;
             return this;
         }
 
-        public CreateParams.Builder mgntclass(String mgntclass) {
+        public CreateParams.Builder mgntclass(final String mgntclass) {
             this.mgntclass = mgntclass;
             return this;
         }
 
-        public CreateParams.Builder primary(Integer primary) {
+        public CreateParams.Builder primary(final Integer primary) {
             this.primary = primary;
             return this;
         }
 
-        public CreateParams.Builder recfm(String recfm) {
+        public CreateParams.Builder recfm(final String recfm) {
             this.recfm = recfm;
             return this;
         }
 
-        public CreateParams.Builder responseTimeout(String responseTimeout) {
+        public CreateParams.Builder responseTimeout(final String responseTimeout) {
             this.responseTimeout = responseTimeout;
             return this;
         }
 
-        public CreateParams.Builder secondary(Integer secondary) {
+        public CreateParams.Builder secondary(final Integer secondary) {
             this.secondary = secondary;
             return this;
         }
 
-        public CreateParams.Builder showAttributes(Boolean showAttributes) {
+        public CreateParams.Builder showAttributes(final boolean showAttributes) {
             this.showAttributes = showAttributes;
             return this;
         }
 
-        public CreateParams.Builder size(String size) {
+        public CreateParams.Builder size(final String size) {
             this.size = size;
             return this;
         }
 
-        public CreateParams.Builder storclass(String storclass) {
+        public CreateParams.Builder storclass(final String storclass) {
             this.storclass = storclass;
             return this;
         }
 
-        public CreateParams.Builder unit(String unit) {
+        public CreateParams.Builder unit(final String unit) {
             this.unit = unit;
             return this;
         }
 
-        public CreateParams.Builder volser(String volser) {
+        public CreateParams.Builder volser(final String volser) {
             this.volser = volser;
             return this;
         }

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/input/DownloadParams.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/input/DownloadParams.java
@@ -11,6 +11,7 @@ package zowe.client.sdk.zosfiles.dsn.input;
 
 import java.util.HashMap;
 import java.util.Optional;
+import java.util.OptionalLong;
 
 /**
  * This interface defines the options that can be sent into the download data set function
@@ -53,7 +54,7 @@ public class DownloadParams {
      * by making too many requests at once.
      * Default: 1
      */
-    private final Optional<Integer> maxConcurrentRequests;
+    private final OptionalLong maxConcurrentRequests;
 
     /**
      * The indicator to force return of ETag.
@@ -87,7 +88,7 @@ public class DownloadParams {
     /**
      * Code page encoding
      */
-    private final Optional<Integer> encoding;
+    private final OptionalLong encoding;
 
     /**
      * The volume on which the data set is stored
@@ -110,12 +111,20 @@ public class DownloadParams {
         this.directory = Optional.ofNullable(builder.directory);
         this.excludePatterns = Optional.ofNullable(builder.excludePatterns);
         this.extensionMap = Optional.ofNullable(builder.extensionMap);
-        this.maxConcurrentRequests = Optional.ofNullable(builder.maxConcurrentRequests);
+        if (builder.maxConcurrentRequests == null) {
+            this.maxConcurrentRequests = OptionalLong.empty();
+        } else {
+            this.maxConcurrentRequests = OptionalLong.of(builder.maxConcurrentRequests);
+        }
         this.returnEtag = Optional.ofNullable(builder.returnEtag);
         this.preserveOriginalLetterCase = Optional.ofNullable(builder.preserveOriginalLetterCase);
         this.failFast = Optional.ofNullable(builder.failFast);
         this.binary = Optional.ofNullable(builder.binary);
-        this.encoding = Optional.ofNullable(builder.encoding);
+        if (builder.encoding == null) {
+            this.encoding = OptionalLong.empty();
+        } else {
+            this.encoding = OptionalLong.of(builder.encoding);
+        }
         this.volume = Optional.ofNullable(builder.volume);
         this.task = Optional.ofNullable(builder.task);
         this.responseTimeout = Optional.ofNullable(builder.responseTimeout);
@@ -147,7 +156,7 @@ public class DownloadParams {
      * @return encoding value
      * @author Nikunj Goyal
      */
-    public Optional<Integer> getEncoding() {
+    public OptionalLong getEncoding() {
         return encoding;
     }
 
@@ -207,7 +216,7 @@ public class DownloadParams {
      * @return maxConcurrentRequests value
      * @author Nikunj Goyal
      */
-    public Optional<Integer> getNaxConcurrentRequests() {
+    public OptionalLong getNaxConcurrentRequests() {
         return maxConcurrentRequests;
     }
 
@@ -288,12 +297,12 @@ public class DownloadParams {
         private String directory;
         private String[] excludePatterns;
         private HashMap<String, String> extensionMap;
-        private Integer maxConcurrentRequests;
+        private Long maxConcurrentRequests;
         private Boolean returnEtag;
         private Boolean preserveOriginalLetterCase;
         private Boolean failFast;
         private Boolean binary;
-        private Integer encoding;
+        private Long encoding;
         private String volume;
         private String task;
         private String responseTimeout;
@@ -312,7 +321,7 @@ public class DownloadParams {
             return this;
         }
 
-        public DownloadParams.Builder encoding(Integer encoding) {
+        public DownloadParams.Builder encoding(Long encoding) {
             this.encoding = encoding;
             return this;
         }
@@ -342,7 +351,7 @@ public class DownloadParams {
             return this;
         }
 
-        public DownloadParams.Builder maxConcurrentRequests(Integer maxConcurrentRequests) {
+        public DownloadParams.Builder maxConcurrentRequests(Long maxConcurrentRequests) {
             this.maxConcurrentRequests = maxConcurrentRequests;
             return this;
         }

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/input/DownloadParams.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/input/DownloadParams.java
@@ -62,7 +62,7 @@ public class DownloadParams {
      * If it is not present, the default is to only send an Etag for data sets smaller than a system determined length,
      * which is at least 8 MB.
      */
-    private final Optional<Boolean> returnEtag;
+    private final boolean returnEtag;
 
     /**
      * Indicates if the created directories and files use the original letter case, which is for data sets always uppercase.
@@ -70,7 +70,7 @@ public class DownloadParams {
      * If the option "directory" or "file" is provided, this option doesn't have any effect.
      * This option has only effect on automatically generated directories and files.
      */
-    private final Optional<Boolean> preserveOriginalLetterCase;
+    private final boolean preserveOriginalLetterCase;
 
     /**
      * Indicates if a download operation for multiple files/data sets should fail as soon as the first failure happens.
@@ -78,12 +78,12 @@ public class DownloadParams {
      * If set to false, individual download failures will be reported after all other downloads have completed.
      * The default value is true for backward compatibility.
      */
-    private final Optional<Boolean> failFast;
+    private final boolean failFast;
 
     /**
      * The indicator to view the data set or USS file in binary mode
      */
-    private final Optional<Boolean> binary;
+    private final boolean binary;
 
     /**
      * Code page encoding
@@ -105,7 +105,7 @@ public class DownloadParams {
      */
     private final Optional<String> responseTimeout;
 
-    private DownloadParams(DownloadParams.Builder builder) {
+    private DownloadParams(final DownloadParams.Builder builder) {
         this.file = Optional.ofNullable(builder.file);
         this.extension = Optional.ofNullable(builder.extension);
         this.directory = Optional.ofNullable(builder.directory);
@@ -116,10 +116,10 @@ public class DownloadParams {
         } else {
             this.maxConcurrentRequests = OptionalLong.of(builder.maxConcurrentRequests);
         }
-        this.returnEtag = Optional.ofNullable(builder.returnEtag);
-        this.preserveOriginalLetterCase = Optional.ofNullable(builder.preserveOriginalLetterCase);
-        this.failFast = Optional.ofNullable(builder.failFast);
-        this.binary = Optional.ofNullable(builder.binary);
+        this.returnEtag = builder.returnEtag;
+        this.preserveOriginalLetterCase = builder.preserveOriginalLetterCase;
+        this.failFast = builder.failFast;
+        this.binary = builder.binary;
         if (builder.encoding == null) {
             this.encoding = OptionalLong.empty();
         } else {
@@ -131,12 +131,12 @@ public class DownloadParams {
     }
 
     /**
-     * Retrieve binary value
+     * Retrieve is binary specified
      *
-     * @return binary value
+     * @return boolean true or false
      * @author Nikunj Goyal
      */
-    public Optional<Boolean> getBinary() {
+    public boolean isBinary() {
         return binary;
     }
 
@@ -191,12 +191,12 @@ public class DownloadParams {
     }
 
     /**
-     * Retrieve failFast value
+     * Retrieve is failFast specified
      *
-     * @return failFast value
+     * @return boolean true or false
      * @author Nikunj Goyal
      */
-    public Optional<Boolean> getFailFast() {
+    public boolean isFailFast() {
         return failFast;
     }
 
@@ -221,12 +221,12 @@ public class DownloadParams {
     }
 
     /**
-     * Retrieve preserveOriginalLetterCase value
+     * Retrieve is preserveOriginalLetterCase specified
      *
-     * @return preserveOriginalLetterCase value
+     * @return boolean true or false
      * @author Nikunj Goyal
      */
-    public Optional<Boolean> getPreserveOriginalLetterCase() {
+    public boolean isPreserveOriginalLetterCase() {
         return preserveOriginalLetterCase;
     }
 
@@ -241,12 +241,12 @@ public class DownloadParams {
     }
 
     /**
-     * Retrieve returnEtag value
+     * Retrieve is returnEtag specified
      *
-     * @return returnEtag value
+     * @return true or false
      * @author Nikunj Goyal
      */
-    public Optional<Boolean> getReturnEtag() {
+    public boolean isReturnEtag() {
         return returnEtag;
     }
 
@@ -298,16 +298,16 @@ public class DownloadParams {
         private String[] excludePatterns;
         private HashMap<String, String> extensionMap;
         private Long maxConcurrentRequests;
-        private Boolean returnEtag;
-        private Boolean preserveOriginalLetterCase;
-        private Boolean failFast;
-        private Boolean binary;
+        private boolean returnEtag;
+        private boolean preserveOriginalLetterCase;
+        private boolean failFast;
+        private boolean binary;
         private Long encoding;
         private String volume;
         private String task;
         private String responseTimeout;
 
-        public DownloadParams.Builder binary(Boolean binary) {
+        public DownloadParams.Builder binary(final boolean binary) {
             this.binary = binary;
             return this;
         }
@@ -316,67 +316,67 @@ public class DownloadParams {
             return new DownloadParams(this);
         }
 
-        public DownloadParams.Builder directory(String directory) {
+        public DownloadParams.Builder directory(final String directory) {
             this.directory = directory;
             return this;
         }
 
-        public DownloadParams.Builder encoding(Long encoding) {
+        public DownloadParams.Builder encoding(final Long encoding) {
             this.encoding = encoding;
             return this;
         }
 
-        public DownloadParams.Builder excludePatterns(String[] excludePatterns) {
+        public DownloadParams.Builder excludePatterns(final String[] excludePatterns) {
             this.excludePatterns = excludePatterns;
             return this;
         }
 
-        public DownloadParams.Builder extension(String extension) {
+        public DownloadParams.Builder extension(final String extension) {
             this.extension = extension;
             return this;
         }
 
-        public DownloadParams.Builder extensionMap(HashMap<String, String> extensionMap) {
+        public DownloadParams.Builder extensionMap(final HashMap<String, String> extensionMap) {
             this.extensionMap = extensionMap;
             return this;
         }
 
-        public DownloadParams.Builder failFast(Boolean failFast) {
+        public DownloadParams.Builder failFast(final boolean failFast) {
             this.failFast = failFast;
             return this;
         }
 
-        public DownloadParams.Builder file(String file) {
+        public DownloadParams.Builder file(final String file) {
             this.file = file;
             return this;
         }
 
-        public DownloadParams.Builder maxConcurrentRequests(Long maxConcurrentRequests) {
+        public DownloadParams.Builder maxConcurrentRequests(final Long maxConcurrentRequests) {
             this.maxConcurrentRequests = maxConcurrentRequests;
             return this;
         }
 
-        public DownloadParams.Builder preserveOriginalLetterCase(Boolean preserveOriginalLetterCase) {
+        public DownloadParams.Builder preserveOriginalLetterCase(final boolean preserveOriginalLetterCase) {
             this.preserveOriginalLetterCase = preserveOriginalLetterCase;
             return this;
         }
 
-        public DownloadParams.Builder responseTimeout(String responseTimeout) {
+        public DownloadParams.Builder responseTimeout(final String responseTimeout) {
             this.responseTimeout = responseTimeout;
             return this;
         }
 
-        public DownloadParams.Builder returnEtag(Boolean returnEtag) {
+        public DownloadParams.Builder returnEtag(final boolean returnEtag) {
             this.returnEtag = returnEtag;
             return this;
         }
 
-        public DownloadParams.Builder task(String task) {
+        public DownloadParams.Builder task(final String task) {
             this.task = task;
             return this;
         }
 
-        public DownloadParams.Builder volume(String volume) {
+        public DownloadParams.Builder volume(final String volume) {
             this.volume = volume;
             return this;
         }

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/input/ListParams.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/input/ListParams.java
@@ -57,7 +57,7 @@ public class ListParams {
      */
     private final Optional<String> responseTimeout;
 
-    private ListParams(ListParams.Builder builder) {
+    private ListParams(final ListParams.Builder builder) {
         this.volume = Optional.ofNullable(builder.volume);
         this.attribute = Optional.ofNullable(builder.attribute);
         this.maxLength = Optional.ofNullable(builder.maxLength);
@@ -160,7 +160,7 @@ public class ListParams {
         private String pattern;
         private String responseTimeout;
 
-        public ListParams.Builder attribute(AttributeType attribute) {
+        public ListParams.Builder attribute(final AttributeType attribute) {
             this.attribute = attribute;
             return this;
         }
@@ -169,32 +169,32 @@ public class ListParams {
             return new ListParams(this);
         }
 
-        public ListParams.Builder maxLength(String maxLength) {
+        public ListParams.Builder maxLength(final String maxLength) {
             this.maxLength = maxLength;
             return this;
         }
 
-        public ListParams.Builder pattern(String pattern) {
+        public ListParams.Builder pattern(final String pattern) {
             this.pattern = pattern;
             return this;
         }
 
-        public ListParams.Builder recall(String recall) {
+        public ListParams.Builder recall(final String recall) {
             this.recall = recall;
             return this;
         }
 
-        public ListParams.Builder responseTimeout(String responseTimeout) {
+        public ListParams.Builder responseTimeout(final String responseTimeout) {
             this.responseTimeout = responseTimeout;
             return this;
         }
 
-        public ListParams.Builder start(String start) {
+        public ListParams.Builder start(final String start) {
             this.start = start;
             return this;
         }
 
-        public ListParams.Builder volume(String volume) {
+        public ListParams.Builder volume(final String volume) {
             this.volume = volume;
             return this;
         }

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/input/ZosFilesParams.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/input/ZosFilesParams.java
@@ -31,7 +31,7 @@ public class ZosFilesParams {
      * @param responseTimeout response time out value
      * @author Leonid Baranov
      */
-    public ZosFilesParams(String responseTimeout) {
+    public ZosFilesParams(final String responseTimeout) {
         this.responseTimeout = Optional.ofNullable(responseTimeout);
     }
 

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnCopy.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnCopy.java
@@ -43,7 +43,7 @@ public class DsnCopy {
      * @param connection is a connection, see ZOSConnection object
      * @author Leonid Baranov
      */
-    public DsnCopy(ZosConnection connection) {
+    public DsnCopy(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
     }
@@ -57,7 +57,7 @@ public class DsnCopy {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public DsnCopy(ZosConnection connection, ZoweRequest request) throws Exception {
+    public DsnCopy(final ZosConnection connection, final ZoweRequest request) throws Exception {
         ValidateUtils.checkConnection(connection);
         ValidateUtils.checkNullParameter(request == null, "request is null");
         this.connection = connection;
@@ -88,8 +88,8 @@ public class DsnCopy {
      * @throws Exception error processing copy request
      * @author Leonid Baranov
      */
-    public Response copy(String fromDataSetName, String toDataSetName, boolean replace, boolean copyAllMembers)
-            throws Exception {
+    public Response copy(final String fromDataSetName, final String toDataSetName, final boolean replace,
+                         final boolean copyAllMembers) throws Exception {
         return copyCommon(new CopyParams.Builder()
                 .fromDataSet(fromDataSetName)
                 .toDataSet(toDataSetName)
@@ -107,7 +107,7 @@ public class DsnCopy {
      * @author Leonid Baranov
      * @author Frank Giordano
      */
-    public Response copyCommon(CopyParams params) throws Exception {
+    public Response copyCommon(final CopyParams params) throws Exception {
         ValidateUtils.checkNullParameter(params == null, "params is null");
 
         final String url = setUrl(params);
@@ -132,10 +132,9 @@ public class DsnCopy {
      *
      * @param params CopyParams object
      * @return url string value
-     * @throws Exception processing error
      * @author Frank Giordano
      */
-    private String setUrl(CopyParams params) throws Exception {
+    private String setUrl(final CopyParams params) {
         final String toDataSetNameErrMsg = "toDataSetName not specified";
         final String toDataSet = params.getToDataSet()
                 .orElseThrow(() -> new IllegalArgumentException(toDataSetNameErrMsg));
@@ -156,10 +155,9 @@ public class DsnCopy {
      *
      * @param params CopyParams object
      * @return map containing key-value pairs for the from-dataset parent json value
-     * @throws Exception processing error
      * @author Frank Giordano
      */
-    private Map<String, Object> setFromDataSetMapValues(CopyParams params) throws Exception {
+    private Map<String, Object> setFromDataSetMapValues(final CopyParams params) {
         final String fromDataSetNameErrMsg = "fromDataSetName not specified";
         String fromDataSetName = params.getFromDataSet()
                 .orElseThrow(() -> new IllegalStateException(fromDataSetNameErrMsg));
@@ -188,10 +186,10 @@ public class DsnCopy {
      * Is a member name included in fromDataSetName string value
      *
      * @param fromDataSetName string value representing a data set notation
-     * @return true or false boolean value
+     * @return boolean true or false
      * @author Frank Giordano
      */
-    private boolean isMemberNameIncluded(String fromDataSetName) {
+    private boolean isMemberNameIncluded(final String fromDataSetName) {
         return fromDataSetName.indexOf("(") > 0;
     }
 

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnCreate.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnCreate.java
@@ -43,7 +43,7 @@ public class DsnCreate {
      * @param connection connection information, see ZOSConnection object
      * @author Leonid Baranov
      */
-    public DsnCreate(ZosConnection connection) {
+    public DsnCreate(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
     }
@@ -57,7 +57,7 @@ public class DsnCreate {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public DsnCreate(ZosConnection connection, ZoweRequest request) throws Exception {
+    public DsnCreate(final ZosConnection connection, final ZoweRequest request) throws Exception {
         ValidateUtils.checkConnection(connection);
         ValidateUtils.checkNullParameter(request == null, "request is null");
         this.connection = connection;
@@ -76,7 +76,7 @@ public class DsnCreate {
      * @throws Exception error processing request
      * @author Leonid Baranov
      */
-    public Response create(String dataSetName, CreateParams params) throws Exception {
+    public Response create(final String dataSetName, final CreateParams params) throws Exception {
         ValidateUtils.checkNullParameter(params == null, "params is null");
         ValidateUtils.checkNullParameter(dataSetName == null, "dataSetName is null");
         ValidateUtils.checkIllegalParameter(dataSetName.isBlank(), "dataSetName not specified");

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnDelete.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnDelete.java
@@ -38,7 +38,7 @@ public class DsnDelete {
      * @param connection connection information, see ZOSConnection object
      * @author Leonid Baranov
      */
-    public DsnDelete(ZosConnection connection) {
+    public DsnDelete(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
     }
@@ -52,7 +52,7 @@ public class DsnDelete {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public DsnDelete(ZosConnection connection, ZoweRequest request) throws Exception {
+    public DsnDelete(final ZosConnection connection, final ZoweRequest request) throws Exception {
         ValidateUtils.checkConnection(connection);
         ValidateUtils.checkNullParameter(request == null, "request is null");
         this.connection = connection;
@@ -71,7 +71,7 @@ public class DsnDelete {
      * @throws Exception error processing request
      * @author Frank Giordano
      */
-    public Response delete(String dataSetName, String memberName) throws Exception {
+    public Response delete(final String dataSetName, final String memberName) throws Exception {
         ValidateUtils.checkNullParameter(dataSetName == null, "dataSetName is null");
         ValidateUtils.checkIllegalParameter(dataSetName.isBlank(), "dataSetName not specified");
         ValidateUtils.checkNullParameter(memberName == null, "memberName is null");
@@ -88,7 +88,7 @@ public class DsnDelete {
      * @throws Exception error processing request
      * @author Leonid Baranov
      */
-    public Response delete(String dataSetName) throws Exception {
+    public Response delete(final String dataSetName) throws Exception {
         ValidateUtils.checkNullParameter(dataSetName == null, "dataSetName is null");
         ValidateUtils.checkIllegalParameter(dataSetName.isBlank(), "dataSetName not specified");
 

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnGet.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnGet.java
@@ -49,7 +49,7 @@ public class DsnGet {
      * @param connection connection information, see ZOSConnection object
      * @author Nikunj Goyal
      */
-    public DsnGet(ZosConnection connection) {
+    public DsnGet(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
     }
@@ -63,7 +63,7 @@ public class DsnGet {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public DsnGet(ZosConnection connection, ZoweRequest request) throws Exception {
+    public DsnGet(final ZosConnection connection, final ZoweRequest request) throws Exception {
         ValidateUtils.checkConnection(connection);
         ValidateUtils.checkNullParameter(request == null, "request is null");
         this.connection = connection;
@@ -81,7 +81,7 @@ public class DsnGet {
      * @throws Exception error processing request
      * @author Frank Giordano
      */
-    public Dataset getDsnInfo(String dataSetName) throws Exception {
+    public Dataset getDsnInfo(final String dataSetName) throws Exception {
         ValidateUtils.checkNullParameter(dataSetName == null, "dataSetName is null");
         ValidateUtils.checkIllegalParameter(dataSetName.isBlank(), "dataSetName not specified");
         Dataset emptyDataSet = new Dataset.Builder().dsname(dataSetName).build();
@@ -119,7 +119,7 @@ public class DsnGet {
      * @throws Exception error processing request
      * @author Nikunj Goyal
      */
-    public InputStream get(String dataSetName, DownloadParams params) throws Exception {
+    public InputStream get(final String dataSetName, final DownloadParams params) throws Exception {
         ValidateUtils.checkNullParameter(params == null, "params is null");
         ValidateUtils.checkNullParameter(dataSetName == null, "dataSetName is null");
         ValidateUtils.checkIllegalParameter(dataSetName.isBlank(), "dataSetName not specified");
@@ -135,7 +135,7 @@ public class DsnGet {
         String key, value;
         final Map<String, String> headers = new HashMap<>();
 
-        if (params.getBinary().orElse(false)) {
+        if (params.isBinary()) {
             key = ZosmfHeaders.HEADERS.get("X_IBM_BINARY").get(0);
             value = ZosmfHeaders.HEADERS.get("X_IBM_BINARY").get(1);
             headers.put(key, value);
@@ -145,7 +145,7 @@ public class DsnGet {
             headers.put(key, value);
         }
 
-        if (params.getReturnEtag().orElse(false)) {
+        if (params.isReturnEtag()) {
             key = ZosmfHeaders.HEADERS.get("X_IBM_RETURN_ETAG").get(0);
             value = ZosmfHeaders.HEADERS.get("X_IBM_RETURN_ETAG").get(1);
             headers.put(key, value);

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnList.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnList.java
@@ -150,9 +150,11 @@ public class DsnList {
         final JSONArray items = (JSONArray) jsonObject.get(ZosFilesConstants.RESPONSE_ITEMS);
         for (final Object obj : items) {
             if (datasetLst == null) {
-                memberLst.add((T) JsonParseResponseFactory.buildParser((JSONObject) obj, ParseType.MEMBER).parseResponse());
+                memberLst.add((T) JsonParseResponseFactory.buildParser(ParseType.MEMBER)
+                        .setJsonObject((JSONObject) obj).parseResponse());
             } else {
-                datasetLst.add((T) JsonParseResponseFactory.buildParser((JSONObject) obj, ParseType.DATASET).parseResponse());
+                datasetLst.add((T) JsonParseResponseFactory.buildParser(ParseType.MEMBER)
+                        .setJsonObject((JSONObject) obj).parseResponse());
             }
         }
 

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnList.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnList.java
@@ -123,7 +123,7 @@ public class DsnList {
             }
         }
 
-        if (RestUtils.isHttpError(response.getStatusCode().get())) {
+        if (RestUtils.isHttpError(response.getStatusCode().getAsInt())) {
             if (response.getStatusText().isEmpty()) {
                 LOG.debug("no no dsn list status text returned");
                 if (datasetLst == null) {
@@ -132,9 +132,9 @@ public class DsnList {
                     return datasetLst;
                 }
             }
-            LOG.debug("rest status code {}", response.getStatusCode().get());
+            LOG.debug("rest status code {}", response.getStatusCode().getAsInt());
             LOG.debug("rest status text {}", response.getStatusText().get());
-            throw new Exception(response.getStatusCode().get() + " - " + response.getResponsePhrase().get());
+            throw new Exception(response.getStatusCode().getAsInt() + " - " + response.getResponsePhrase().get());
         }
 
         final String jsonStr = response.getResponsePhrase().get().toString();

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnList.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnList.java
@@ -155,7 +155,7 @@ public class DsnList {
                 memberLst.add((T) JsonParseResponseFactory.buildParser(ParseType.MEMBER)
                         .setJsonObject((JSONObject) obj).parseResponse());
             } else {
-                datasetLst.add((T) JsonParseResponseFactory.buildParser(ParseType.MEMBER)
+                datasetLst.add((T) JsonParseResponseFactory.buildParser(ParseType.DATASET)
                         .setJsonObject((JSONObject) obj).parseResponse());
             }
         }

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnList.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnList.java
@@ -48,7 +48,7 @@ public class DsnList {
      * @param connection connection information, see ZosConnection object
      * @author Frank Giordano
      */
-    public DsnList(ZosConnection connection) {
+    public DsnList(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
     }
@@ -62,7 +62,7 @@ public class DsnList {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public DsnList(ZosConnection connection, ZoweRequest request) throws Exception {
+    public DsnList(final ZosConnection connection, final ZoweRequest request) throws Exception {
         ValidateUtils.checkConnection(connection);
         ValidateUtils.checkNullParameter(request == null, "request is null");
         this.connection = connection;
@@ -81,7 +81,8 @@ public class DsnList {
      * @return response object with http response info
      * @author Frank Giordano
      */
-    private Response getResponse(ListParams params, Map<String, String> headers, String url) throws Exception {
+    private Response getResponse(final ListParams params, final Map<String, String> headers, final String url)
+            throws Exception {
         setHeaders(params, headers);
         if (request == null) {
             request = ZoweRequestFactory.buildRequest(connection, ZoweRequestType.GET_JSON);
@@ -104,7 +105,8 @@ public class DsnList {
      * @author Frank Giordano
      */
     @SuppressWarnings("unchecked")
-    private <T> java.util.List<T> getResult(Response response, List<T> datasetLst, List<T> memberLst) throws Exception {
+    private <T> java.util.List<T> getResult(final Response response, final List<T> datasetLst, final List<T> memberLst)
+            throws Exception {
         if (response.getStatusCode().isEmpty()) {
             LOG.debug("no dsn list status code returned");
             if (datasetLst == null) {
@@ -174,7 +176,7 @@ public class DsnList {
      * @throws Exception error processing request
      * @author Nikunj Goyal
      */
-    public java.util.List<Dataset> listDsn(String dataSetName, ListParams params) throws Exception {
+    public java.util.List<Dataset> listDsn(final String dataSetName, final ListParams params) throws Exception {
         ValidateUtils.checkNullParameter(params == null, "params is null");
         ValidateUtils.checkNullParameter(dataSetName == null, "dataSetName is null");
         ValidateUtils.checkIllegalParameter(dataSetName.isBlank(), "dataSetName not specified");
@@ -205,7 +207,7 @@ public class DsnList {
      * @throws Exception error processing request
      * @author Nikunj Goyal
      */
-    public java.util.List<Member> listDsnMembers(String dataSetName, ListParams params) throws Exception {
+    public java.util.List<Member> listDsnMembers(final String dataSetName, final ListParams params) throws Exception {
         ValidateUtils.checkNullParameter(params == null, "params is null");
         ValidateUtils.checkNullParameter(dataSetName == null, "dataSetName is null");
         ValidateUtils.checkIllegalParameter(dataSetName.isBlank(), "dataSetName not specified");
@@ -231,7 +233,7 @@ public class DsnList {
      * @param headers list of headers for http request
      * @author Nikunj Goyal
      */
-    private void setHeaders(ListParams params, Map<String, String> headers) {
+    private void setHeaders(final ListParams params, final Map<String, String> headers) {
         String key = ZosmfHeaders.HEADERS.get("ACCEPT_ENCODING").get(0);
         String value = ZosmfHeaders.HEADERS.get("ACCEPT_ENCODING").get(1);
         headers.put(key, value);

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnRename.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnRename.java
@@ -43,7 +43,7 @@ public class DsnRename {
      * @param connection connection information, see ZOSConnection object
      * @author Frank Giordano
      */
-    public DsnRename(ZosConnection connection) {
+    public DsnRename(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
     }
@@ -57,7 +57,7 @@ public class DsnRename {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public DsnRename(ZosConnection connection, ZoweRequest request) throws Exception {
+    public DsnRename(final ZosConnection connection, final ZoweRequest request) throws Exception {
         ValidateUtils.checkConnection(connection);
         ValidateUtils.checkNullParameter(request == null, "request is null");
         this.connection = connection;
@@ -75,7 +75,7 @@ public class DsnRename {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public Response dataSetName(String dataSetName, String newDataSetName) throws Exception {
+    public Response dataSetName(final String dataSetName, final String newDataSetName) throws Exception {
         ValidateUtils.checkNullParameter(dataSetName == null, "dataSetName is null");
         ValidateUtils.checkIllegalParameter(dataSetName.isBlank(), "dataSetName not specified");
         ValidateUtils.checkNullParameter(newDataSetName == null, "newDataSetName is null");
@@ -95,7 +95,8 @@ public class DsnRename {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public Response memberName(String fromDataSetName, String memberName, String newMemberName) throws Exception {
+    public Response memberName(final String fromDataSetName, final String memberName, final String newMemberName)
+            throws Exception {
         ValidateUtils.checkNullParameter(fromDataSetName == null, "fromDataSetName is null");
         ValidateUtils.checkIllegalParameter(fromDataSetName.isBlank(), "fromDataSetName not specified");
         ValidateUtils.checkNullParameter(memberName == null, "memberName is null");
@@ -113,7 +114,7 @@ public class DsnRename {
      * @param args new or current dataset name and/or new member name
      * @author Frank Giordano
      */
-    private void setUrl(String... args) {
+    private void setUrl(final String... args) {
         url = "https://" + connection.getHost() + ":" + connection.getZosmfPort() + ZosFilesConstants.RESOURCE +
                 ZosFilesConstants.RES_DS_FILES + "/" + EncodeUtils.encodeURIComponent(args[0]);
         if (args.length > 1) {
@@ -131,7 +132,7 @@ public class DsnRename {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    private Response executeCommon(String... args) throws Exception {
+    private Response executeCommon(final String... args) throws Exception {
         final Map<String, Object> renameMap = new HashMap<>();
         renameMap.put("request", "rename");
 

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnWrite.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnWrite.java
@@ -38,7 +38,7 @@ public class DsnWrite {
      * @param connection connection information, see ZOSConnection object
      * @author Leonid Baranov
      */
-    public DsnWrite(ZosConnection connection) {
+    public DsnWrite(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
     }
@@ -52,7 +52,7 @@ public class DsnWrite {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public DsnWrite(ZosConnection connection, ZoweRequest request) throws Exception {
+    public DsnWrite(final ZosConnection connection, final ZoweRequest request) throws Exception {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
         if (!(request instanceof TextPutRequest)) {
@@ -72,7 +72,7 @@ public class DsnWrite {
      * @throws Exception error processing request
      * @author Frank Giordano
      */
-    public Response write(String dataSetName, String memberName, String content) throws Exception {
+    public Response write(final String dataSetName, final String memberName, final String content) throws Exception {
         ValidateUtils.checkNullParameter(dataSetName == null, "dataSetName is null");
         ValidateUtils.checkIllegalParameter(dataSetName.isBlank(), "dataSetName not specified");
         ValidateUtils.checkNullParameter(memberName == null, "memberName is null");
@@ -90,7 +90,7 @@ public class DsnWrite {
      * @throws Exception error processing request
      * @author Leonid Baranov
      */
-    public Response write(String dataSetName, String content) throws Exception {
+    public Response write(final String dataSetName, final String content) throws Exception {
         ValidateUtils.checkNullParameter(content == null, "content is null");
         ValidateUtils.checkNullParameter(dataSetName == null, "dataSetName is null");
         ValidateUtils.checkIllegalParameter(dataSetName.isBlank(), "dataSetName not specified");

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/response/Dataset.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/response/Dataset.java
@@ -114,7 +114,7 @@ public class Dataset {
      */
     private final Optional<String> vol;
 
-    private Dataset(Dataset.Builder builder) {
+    private Dataset(final Dataset.Builder builder) {
         this.dsname = Optional.ofNullable(builder.dsname);
         this.blksz = Optional.ofNullable(builder.blksz);
         this.catnm = Optional.ofNullable(builder.catnm);
@@ -377,97 +377,97 @@ public class Dataset {
         private String used;
         private String vol;
 
-        public Dataset.Builder dsname(String dsname) {
+        public Dataset.Builder dsname(final String dsname) {
             this.dsname = dsname;
             return this;
         }
 
-        public Dataset.Builder blksz(String blksz) {
+        public Dataset.Builder blksz(final String blksz) {
             this.blksz = blksz;
             return this;
         }
 
-        public Dataset.Builder catnm(String catnm) {
+        public Dataset.Builder catnm(final String catnm) {
             this.catnm = catnm;
             return this;
         }
 
-        public Dataset.Builder cdate(String cdate) {
+        public Dataset.Builder cdate(final String cdate) {
             this.cdate = cdate;
             return this;
         }
 
-        public Dataset.Builder dev(String dev) {
+        public Dataset.Builder dev(final String dev) {
             this.dev = dev;
             return this;
         }
 
-        public Dataset.Builder dsntp(String dsntp) {
+        public Dataset.Builder dsntp(final String dsntp) {
             this.dsntp = dsntp;
             return this;
         }
 
-        public Dataset.Builder dsorg(String dsorg) {
+        public Dataset.Builder dsorg(final String dsorg) {
             this.dsorg = dsorg;
             return this;
         }
 
-        public Dataset.Builder edate(String edate) {
+        public Dataset.Builder edate(final String edate) {
             this.edate = edate;
             return this;
         }
 
-        public Dataset.Builder extx(String extx) {
+        public Dataset.Builder extx(final String extx) {
             this.extx = extx;
             return this;
         }
 
-        public Dataset.Builder lrectl(String lrectl) {
+        public Dataset.Builder lrectl(final String lrectl) {
             this.lrectl = lrectl;
             return this;
         }
 
-        public Dataset.Builder migr(String migr) {
+        public Dataset.Builder migr(final String migr) {
             this.migr = migr;
             return this;
         }
 
-        public Dataset.Builder mvol(String mvol) {
+        public Dataset.Builder mvol(final String mvol) {
             this.mvol = mvol;
             return this;
         }
 
-        public Dataset.Builder ovf(String ovf) {
+        public Dataset.Builder ovf(final String ovf) {
             this.ovf = ovf;
             return this;
         }
 
-        public Dataset.Builder rdate(String rdate) {
+        public Dataset.Builder rdate(final String rdate) {
             this.rdate = rdate;
             return this;
         }
 
-        public Dataset.Builder recfm(String recfm) {
+        public Dataset.Builder recfm(final String recfm) {
             this.recfm = recfm;
             return this;
         }
 
-        public Dataset.Builder sizex(String sizex) {
+        public Dataset.Builder sizex(final String sizex) {
             this.sizex = sizex;
             return this;
         }
 
-        public Dataset.Builder spacu(String spacu) {
+        public Dataset.Builder spacu(final String spacu) {
             this.spacu = spacu;
             return this;
         }
 
-        public Dataset.Builder used(String used) {
+        public Dataset.Builder used(final String used) {
             this.used = used;
             return this;
         }
 
-        public Dataset.Builder vol(String vol) {
+        public Dataset.Builder vol(final String vol) {
             this.vol = vol;
             return this;
         }

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/response/Member.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/response/Member.java
@@ -80,7 +80,7 @@ public class Member {
      */
     private final Optional<String> sclm;
 
-    private Member(Member.Builder builder) {
+    private Member(final Member.Builder builder) {
         this.member = Optional.ofNullable(builder.member);
         if (builder.vers == null) {
             this.vers = OptionalLong.empty();
@@ -273,62 +273,62 @@ public class Member {
         private String user;
         private String sclm;
 
-        public Member.Builder member(String member) {
+        public Member.Builder member(final String member) {
             this.member = member;
             return this;
         }
 
-        public Member.Builder vers(Long vers) {
+        public Member.Builder vers(final Long vers) {
             this.vers = vers;
             return this;
         }
 
-        public Member.Builder mod(Long mod) {
+        public Member.Builder mod(final Long mod) {
             this.mod = mod;
             return this;
         }
 
-        public Member.Builder c4date(String c4date) {
+        public Member.Builder c4date(final String c4date) {
             this.c4date = c4date;
             return this;
         }
 
-        public Member.Builder m4date(String m4date) {
+        public Member.Builder m4date(final String m4date) {
             this.m4date = m4date;
             return this;
         }
 
-        public Member.Builder cnorc(Long cnorc) {
+        public Member.Builder cnorc(final Long cnorc) {
             this.cnorc = cnorc;
             return this;
         }
 
-        public Member.Builder inorc(Long inorc) {
+        public Member.Builder inorc(final Long inorc) {
             this.inorc = inorc;
             return this;
         }
 
-        public Member.Builder mnorc(Long mnorc) {
+        public Member.Builder mnorc(final Long mnorc) {
             this.mnorc = mnorc;
             return this;
         }
 
-        public Member.Builder mtime(String mtime) {
+        public Member.Builder mtime(final String mtime) {
             this.mtime = mtime;
             return this;
         }
 
-        public Member.Builder msec(String msec) {
+        public Member.Builder msec(final String msec) {
             this.msec = msec;
             return this;
         }
 
-        public Member.Builder user(String user) {
+        public Member.Builder user(final String user) {
             this.user = user;
             return this;
         }
 
-        public Member.Builder sclm(String sclm) {
+        public Member.Builder sclm(final String sclm) {
             this.sclm = sclm;
             return this;
         }

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/input/ChangeModeParams.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/input/ChangeModeParams.java
@@ -46,7 +46,7 @@ public class ChangeModeParams {
      * @param builder ChangeModeParams.Builder builder
      * @author James Kostrewski
      */
-    public ChangeModeParams(ChangeModeParams.Builder builder) {
+    public ChangeModeParams(final ChangeModeParams.Builder builder) {
         this.mode = Optional.of(builder.mode);
         this.recursive = builder.recursive;
         this.linkType = Optional.ofNullable(builder.linkType);
@@ -63,9 +63,9 @@ public class ChangeModeParams {
     }
 
     /**
-     * Is recursive value true or false
+     * Is recursive specified
      *
-     * @return recursive value
+     * @return boolean true or false
      * @author James Kostrewski
      */
     public boolean isRecursive() {
@@ -101,19 +101,19 @@ public class ChangeModeParams {
             return new ChangeModeParams(this);
         }
 
-        public ChangeModeParams.Builder mode(String mode) {
+        public ChangeModeParams.Builder mode(final String mode) {
             ValidateUtils.checkNullParameter(mode == null, "mode is null");
             ValidateUtils.checkIllegalParameter(mode.isBlank(), "mode not specified");
             this.mode = mode;
             return this;
         }
 
-        public ChangeModeParams.Builder recursive(boolean recursive) {
+        public ChangeModeParams.Builder recursive(final boolean recursive) {
             this.recursive = recursive;
             return this;
         }
 
-        public ChangeModeParams.Builder linktype(LinkType type) {
+        public ChangeModeParams.Builder linktype(final LinkType type) {
             this.linkType = type;
             return this;
         }

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/input/ChangeOwnerParams.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/input/ChangeOwnerParams.java
@@ -49,7 +49,7 @@ public class ChangeOwnerParams {
      * @param builder ChangeOwnerParams.Builder builder
      * @author James Kostrewski
      */
-    public ChangeOwnerParams(ChangeOwnerParams.Builder builder) {
+    public ChangeOwnerParams(final ChangeOwnerParams.Builder builder) {
         this.owner = Optional.ofNullable(builder.owner);
         this.group = Optional.ofNullable(builder.group);
         this.recursive = builder.recursive;
@@ -77,9 +77,9 @@ public class ChangeOwnerParams {
     }
 
     /**
-     * Is recursive value true or false
+     * Is recursive specified
      *
-     * @return recursive value
+     * @return boolean true or false
      * @author James Kostrewski
      */
     public boolean isRecursive() {
@@ -117,24 +117,24 @@ public class ChangeOwnerParams {
             return new ChangeOwnerParams(this);
         }
 
-        public ChangeOwnerParams.Builder owner(String owner) {
+        public ChangeOwnerParams.Builder owner(final String owner) {
             ValidateUtils.checkNullParameter(owner == null, "owner is null");
             ValidateUtils.checkIllegalParameter(owner.isBlank(), "owner not specified");
             this.owner = owner;
             return this;
         }
 
-        public ChangeOwnerParams.Builder group(String group) {
+        public ChangeOwnerParams.Builder group(final String group) {
             this.group = group;
             return this;
         }
 
-        public ChangeOwnerParams.Builder recursive(boolean recursive) {
+        public ChangeOwnerParams.Builder recursive(final boolean recursive) {
             this.recursive = recursive;
             return this;
         }
 
-        public ChangeOwnerParams.Builder linktype(LinkType type) {
+        public ChangeOwnerParams.Builder linktype(final LinkType type) {
             this.linkType = type;
             return this;
         }

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/input/ChangeTagParams.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/input/ChangeTagParams.java
@@ -64,7 +64,7 @@ public class ChangeTagParams {
      * @param builder ChangeTagParams.Builder builder
      * @author James Kostrewski
      */
-    public ChangeTagParams(ChangeTagParams.Builder builder) {
+    public ChangeTagParams(final ChangeTagParams.Builder builder) {
         this.action = Optional.ofNullable(builder.action);
         this.type = Optional.ofNullable(builder.type);
         this.codeset = Optional.ofNullable(builder.codeset);
@@ -103,9 +103,9 @@ public class ChangeTagParams {
     }
 
     /**
-     * Retrieve recursive value
+     * Retrieve is recursive specified
      *
-     * @return recursive value
+     * @return boolean true or false
      * @author James Kostrewski
      */
     public boolean isRecursive() {
@@ -151,7 +151,7 @@ public class ChangeTagParams {
          * @return Builder object
          * @author James Kostrewski
          */
-        public ChangeTagParams.Builder action(ChangeTagAction action) {
+        public ChangeTagParams.Builder action(final ChangeTagAction action) {
             ValidateUtils.checkNullParameter(action == null, "action is null");
             this.action = action;
             return this;
@@ -164,7 +164,7 @@ public class ChangeTagParams {
          * @return Builder object
          * @author James Kostrewski
          */
-        public ChangeTagParams.Builder type(ChangeTagType type) {
+        public ChangeTagParams.Builder type(final ChangeTagType type) {
             this.type = type;
             return this;
         }
@@ -176,7 +176,7 @@ public class ChangeTagParams {
          * @return Builder object
          * @author James Kostrewski
          */
-        public ChangeTagParams.Builder codeset(String codeset) {
+        public ChangeTagParams.Builder codeset(final String codeset) {
             this.codeset = codeset;
             return this;
         }
@@ -188,7 +188,7 @@ public class ChangeTagParams {
          * @return Builder object
          * @author James Kostrewski
          */
-        public ChangeTagParams.Builder recursive(boolean recursive) {
+        public ChangeTagParams.Builder recursive(final boolean recursive) {
             this.recursive = recursive;
             return this;
         }
@@ -200,7 +200,7 @@ public class ChangeTagParams {
          * @return Builder object
          * @author James Kostrewski
          */
-        public ChangeTagParams.Builder links(LinkType links) {
+        public ChangeTagParams.Builder links(final LinkType links) {
             this.links = links;
             return this;
         }

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/input/CopyParams.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/input/CopyParams.java
@@ -43,7 +43,7 @@ public class CopyParams {
      * @param builder CopyParams.Builder builder
      * @author James Kostrewski
      */
-    public CopyParams(CopyParams.Builder builder) {
+    public CopyParams(final CopyParams.Builder builder) {
         this.from = Optional.ofNullable(builder.from);
         this.overwrite = builder.overwrite;
         this.recursive = builder.recursive;
@@ -60,9 +60,9 @@ public class CopyParams {
     }
 
     /**
-     * Retrieve overwrite value
+     * Retrieve is overwrite specified
      *
-     * @return overwrite value
+     * @return boolean true or false
      * @author James Kostrewski
      */
     public boolean isOverwrite() {
@@ -70,9 +70,9 @@ public class CopyParams {
     }
 
     /**
-     * Is recursive value true or false
+     * Is recursive specified
      *
-     * @return recursive value
+     * @return boolean true or false
      * @author James Kostrewski
      */
     public boolean isRecursive() {
@@ -98,19 +98,19 @@ public class CopyParams {
             return new CopyParams(this);
         }
 
-        public CopyParams.Builder from(String from) {
+        public CopyParams.Builder from(final String from) {
             ValidateUtils.checkNullParameter(from == null, "from is null");
             ValidateUtils.checkIllegalParameter(from.isBlank(), "from not specified");
             this.from = from;
             return this;
         }
 
-        public CopyParams.Builder overwrite(boolean overwrite) {
+        public CopyParams.Builder overwrite(final boolean overwrite) {
             this.overwrite = overwrite;
             return this;
         }
 
-        public CopyParams.Builder recursive(boolean recursive) {
+        public CopyParams.Builder recursive(final boolean recursive) {
             this.recursive = recursive;
             return this;
         }

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/input/CreateParams.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/input/CreateParams.java
@@ -56,7 +56,7 @@ public class CreateParams {
      * @param mode permission string value
      * @author James Kostrewski
      */
-    public CreateParams(CreateType type, String mode) {
+    public CreateParams(final CreateType type, final String mode) {
         ValidateUtils.checkNullParameter(type == null, "type is null");
         ValidateUtils.checkNullParameter(mode == null, "mode is null");
         this.type = type;

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/input/GetParams.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/input/GetParams.java
@@ -82,7 +82,7 @@ public class GetParams {
      * @param builder GetParams.Builder builder
      * @author James Kostrewski
      */
-    public GetParams(GetParams.Builder builder) {
+    public GetParams(final GetParams.Builder builder) {
         this.search = Optional.ofNullable(builder.search);
         this.research = Optional.ofNullable(builder.research);
         this.insensitive = builder.insensitive;
@@ -117,9 +117,9 @@ public class GetParams {
     }
 
     /**
-     * Retrieve insensitive value
+     * Retrieve is insensitive specified
      *
-     * @return insensitive value
+     * @return boolean true or false
      * @author James Kostrewski
      */
     public boolean isInsensitive() {
@@ -147,9 +147,9 @@ public class GetParams {
     }
 
     /**
-     * Retrieve binary value
+     * Retrieve is binary specified
      *
-     * @return binary value
+     * @return boolean true or false
      * @author James Kostrewski
      */
     public boolean isBinary() {
@@ -157,9 +157,9 @@ public class GetParams {
     }
 
     /**
-     * Retrieve recordsRange value
+     * Retrieve is recordsRange specified
      *
-     * @return recordsRange value
+     * @return boolean true or false
      * @author James Kostrewski
      */
     public Optional<String> getRecordsRange() {
@@ -194,7 +194,7 @@ public class GetParams {
             return new GetParams(this);
         }
 
-        public GetParams.Builder search(String search) throws Exception {
+        public GetParams.Builder search(final String search) throws Exception {
             if (this.research != null) {
                 throw new IllegalStateException("cannot specify both search and research parameters");
             }
@@ -203,7 +203,7 @@ public class GetParams {
             return this;
         }
 
-        public GetParams.Builder research(String research) throws Exception {
+        public GetParams.Builder research(final String research) {
             if (this.search != null) {
                 throw new IllegalStateException("cannot specify both search and research parameters");
             }
@@ -212,24 +212,24 @@ public class GetParams {
             return this;
         }
 
-        public GetParams.Builder insensitive(boolean insensitive) {
+        public GetParams.Builder insensitive(final boolean insensitive) {
             this.insensitive = insensitive;
             queryCount++;
             return this;
         }
 
-        public GetParams.Builder maxreturnsize(int maxreturnsize) {
+        public GetParams.Builder maxreturnsize(final int maxreturnsize) {
             this.maxreturnsize = maxreturnsize;
             queryCount++;
             return this;
         }
 
-        public GetParams.Builder binary(boolean binary) {
+        public GetParams.Builder binary(final boolean binary) {
             this.binary = binary;
             return this;
         }
 
-        public GetParams.Builder recordsRange(String recordsRange) {
+        public GetParams.Builder recordsRange(final String recordsRange) {
             this.recordsRange = recordsRange;
             return this;
         }

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/input/ListParams.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/input/ListParams.java
@@ -117,7 +117,7 @@ public class ListParams {
      * @param builder ListParams.Builder builder
      * @author Frank Giordano
      */
-    public ListParams(ListParams.Builder builder) {
+    public ListParams(final ListParams.Builder builder) {
         this.path = Optional.of(builder.path);
         if (builder.maxLength == null) {
             this.maxLength = OptionalInt.empty();
@@ -245,9 +245,9 @@ public class ListParams {
     }
 
     /**
-     * Retrieve filesys value
+     * Retrieve is filesys specified
      *
-     * @return filesys value
+     * @return boolean true or false
      * @author Frank Giordano
      */
     public boolean isFilesys() {
@@ -255,9 +255,9 @@ public class ListParams {
     }
 
     /**
-     * Retrieve symlinks value
+     * Retrieve is symlinks specified
      *
-     * @return symlinks value
+     * @return boolean true or false
      * @author Frank Giordano
      */
     public boolean isSymlinks() {
@@ -301,64 +301,64 @@ public class ListParams {
             return new ListParams(this);
         }
 
-        public ListParams.Builder path(String path) {
+        public ListParams.Builder path(final String path) {
             ValidateUtils.checkNullParameter(path == null, "path is null");
             ValidateUtils.checkIllegalParameter(path.isBlank(), "path not specified");
             this.path = path;
             return this;
         }
 
-        public ListParams.Builder maxLength(int maxLength) {
+        public ListParams.Builder maxLength(final int maxLength) {
             this.maxLength = maxLength;
             return this;
         }
 
-        public ListParams.Builder group(String group) {
+        public ListParams.Builder group(final String group) {
             this.group = group;
             return this;
         }
 
-        public ListParams.Builder user(String user) {
+        public ListParams.Builder user(final String user) {
             this.user = user;
             return this;
         }
 
-        public ListParams.Builder mtime(String mtime) {
+        public ListParams.Builder mtime(final String mtime) {
             this.mtime = mtime;
             return this;
         }
 
-        public ListParams.Builder size(int size) {
+        public ListParams.Builder size(final int size) {
             this.size = size;
             return this;
         }
 
-        public ListParams.Builder name(String name) {
+        public ListParams.Builder name(final String name) {
             this.name = name;
             return this;
         }
 
-        public ListParams.Builder perm(String perm) {
+        public ListParams.Builder perm(final String perm) {
             this.perm = perm;
             return this;
         }
 
-        public ListParams.Builder type(ListFilterType type) {
+        public ListParams.Builder type(final ListFilterType type) {
             this.type = type;
             return this;
         }
 
-        public ListParams.Builder depth(int depth) {
+        public ListParams.Builder depth(final int depth) {
             this.depth = depth;
             return this;
         }
 
-        public ListParams.Builder filesys(boolean filesys) {
+        public ListParams.Builder filesys(final boolean filesys) {
             this.filesys = filesys;
             return this;
         }
 
-        public ListParams.Builder symlinks(boolean symlinks) {
+        public ListParams.Builder symlinks(final boolean symlinks) {
             this.symlinks = symlinks;
             return this;
         }

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/input/ListZfsParams.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/input/ListZfsParams.java
@@ -49,7 +49,7 @@ public class ListZfsParams {
      * @param builder ListZfsParams.Builder builder
      * @author Frank Giordano
      */
-    public ListZfsParams(ListZfsParams.Builder builder) {
+    public ListZfsParams(final ListZfsParams.Builder builder) {
         if (builder.maxLength == null) {
             this.maxLength = OptionalInt.empty();
         } else {
@@ -108,12 +108,12 @@ public class ListZfsParams {
             return new ListZfsParams(this);
         }
 
-        public ListZfsParams.Builder maxLength(int maxLength) {
+        public ListZfsParams.Builder maxLength(final int maxLength) {
             this.maxLength = maxLength;
             return this;
         }
 
-        public ListZfsParams.Builder path(String path) throws Exception {
+        public ListZfsParams.Builder path(final String path) throws Exception {
             ValidateUtils.checkNullParameter(path == null, "path is null");
             ValidateUtils.checkIllegalParameter(path.isBlank(), "path not specified");
             if (this.fsname != null) {
@@ -123,7 +123,7 @@ public class ListZfsParams {
             return this;
         }
 
-        public ListZfsParams.Builder fsname(String fsname) throws Exception {
+        public ListZfsParams.Builder fsname(final String fsname) throws Exception {
             ValidateUtils.checkNullParameter(fsname == null, "fsname is null");
             ValidateUtils.checkIllegalParameter(fsname.isBlank(), "fsname not specified");
             if (this.path != null) {

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/input/MountParams.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/input/MountParams.java
@@ -54,7 +54,7 @@ public class MountParams {
      * @param builder MountParams.Builder builder
      * @author Frank Giordano
      */
-    public MountParams(MountParams.Builder builder) {
+    public MountParams(final MountParams.Builder builder) {
         this.action = Optional.ofNullable(builder.action);
         this.mountPoint = Optional.ofNullable(builder.mountPoint);
         this.fsType = Optional.ofNullable(builder.fsType);
@@ -122,26 +122,26 @@ public class MountParams {
             return new MountParams(this);
         }
 
-        public MountParams.Builder action(MountActionType action) {
+        public MountParams.Builder action(final MountActionType action) {
             this.action = action;
             return this;
         }
 
-        public MountParams.Builder mountPoint(String mountPoint) {
+        public MountParams.Builder mountPoint(final String mountPoint) {
             ValidateUtils.checkNullParameter(mountPoint == null, "mountPoint is null");
             ValidateUtils.checkIllegalParameter(mountPoint.isBlank(), "mountPoint not specified");
             this.mountPoint = mountPoint;
             return this;
         }
 
-        public MountParams.Builder fsType(String fsType) {
+        public MountParams.Builder fsType(final String fsType) {
             ValidateUtils.checkNullParameter(fsType == null, "fsType is null");
             ValidateUtils.checkIllegalParameter(fsType.isBlank(), "fsType not specified");
             this.fsType = fsType;
             return this;
         }
 
-        public MountParams.Builder mode(MountModeType mode) {
+        public MountParams.Builder mode(final MountModeType mode) {
             this.mode = mode;
             return this;
         }

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/input/WriteParams.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/input/WriteParams.java
@@ -53,7 +53,7 @@ public class WriteParams {
      * @param builder WriteParams.Builder builder
      * @author Frank Giordano
      */
-    public WriteParams(WriteParams.Builder builder) {
+    public WriteParams(final WriteParams.Builder builder) {
         this.textContent = Optional.ofNullable(builder.textContent);
         this.binaryContent = Optional.ofNullable(builder.binaryContent);
         this.fileEncoding = Optional.ofNullable(builder.fileEncoding);
@@ -92,9 +92,9 @@ public class WriteParams {
     }
 
     /**
-     * Retrieve crlf value
+     * Retrieve is crlf specified
      *
-     * @return crlf value
+     * @return boolean true or false
      * @author Frank Giordano
      */
     public boolean isCrlf() {
@@ -102,9 +102,9 @@ public class WriteParams {
     }
 
     /**
-     * Retrieve binary value
+     * Retrieve is binary specified
      *
-     * @return binary value
+     * @return boolean true or false
      * @author Frank Giordano
      */
     public boolean isBinary() {
@@ -134,27 +134,27 @@ public class WriteParams {
             return new WriteParams(this);
         }
 
-        public WriteParams.Builder textContent(String textContent) {
+        public WriteParams.Builder textContent(final String textContent) {
             this.textContent = textContent;
             return this;
         }
 
-        public WriteParams.Builder binaryContent(byte[] binaryContent) {
+        public WriteParams.Builder binaryContent(final byte[] binaryContent) {
             this.binaryContent = binaryContent;
             return this;
         }
 
-        public WriteParams.Builder fileEncoding(String fileEncoding) {
+        public WriteParams.Builder fileEncoding(final String fileEncoding) {
             this.fileEncoding = fileEncoding;
             return this;
         }
 
-        public WriteParams.Builder crlf(boolean crlf) {
+        public WriteParams.Builder crlf(final boolean crlf) {
             this.crlf = crlf;
             return this;
         }
 
-        public WriteParams.Builder binary(boolean binary) {
+        public WriteParams.Builder binary(final boolean binary) {
             this.binary = binary;
             return this;
         }

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeMode.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeMode.java
@@ -45,7 +45,7 @@ public class UssChangeMode {
      * @param connection connection information, see ZosConnection object
      * @author James Kostrewski
      */
-    public UssChangeMode(ZosConnection connection) {
+    public UssChangeMode(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
     }
@@ -59,7 +59,7 @@ public class UssChangeMode {
      * @throws Exception processing error
      * @author James Kostrewski
      */
-    public UssChangeMode(ZosConnection connection, ZoweRequest request) throws Exception {
+    public UssChangeMode(final ZosConnection connection, final ZoweRequest request) throws Exception {
         ValidateUtils.checkConnection(connection);
         ValidateUtils.checkNullParameter(request == null, "request is null");
         this.connection = connection;
@@ -79,7 +79,7 @@ public class UssChangeMode {
      * @author James Kostrewsk
      * @author Frank Giordano
      */
-    public Response change(String targetPath, ChangeModeParams params) throws Exception {
+    public Response change(final String targetPath, final ChangeModeParams params) throws Exception {
         ValidateUtils.checkNullParameter(targetPath == null, "targetPath is null");
         ValidateUtils.checkIllegalParameter(targetPath.isBlank(), "targetPath not specified");
         ValidateUtils.checkNullParameter(params == null, "params is null");

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeOwner.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeOwner.java
@@ -43,7 +43,7 @@ public class UssChangeOwner {
      * @param connection connection information, see ZosConnection object
      * @author James Kostrewski
      */
-    public UssChangeOwner(ZosConnection connection) {
+    public UssChangeOwner(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
     }
@@ -57,7 +57,7 @@ public class UssChangeOwner {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public UssChangeOwner(ZosConnection connection, ZoweRequest request) throws Exception {
+    public UssChangeOwner(final ZosConnection connection, final ZoweRequest request) throws Exception {
         ValidateUtils.checkConnection(connection);
         ValidateUtils.checkNullParameter(request == null, "request is null");
         this.connection = connection;
@@ -76,7 +76,7 @@ public class UssChangeOwner {
      * @throws Exception processing error
      * @author James Kostrewski
      */
-    public Response change(String targetPath, String owner) throws Exception {
+    public Response change(final String targetPath, final String owner) throws Exception {
         return change(targetPath, new ChangeOwnerParams.Builder().owner(owner).build());
     }
 
@@ -90,7 +90,7 @@ public class UssChangeOwner {
      * @author James Kostrewski
      * @author Frank Giordano
      */
-    public Response change(String targetPath, ChangeOwnerParams params) throws Exception {
+    public Response change(final String targetPath, final ChangeOwnerParams params) throws Exception {
         ValidateUtils.checkNullParameter(targetPath == null, "targetPath is null");
         ValidateUtils.checkIllegalParameter(targetPath.isBlank(), "targetPath not specified");
         ValidateUtils.checkNullParameter(params == null, "params is null");

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeTag.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeTag.java
@@ -48,7 +48,7 @@ public class UssChangeTag {
      * @param connection connection information, see ZosConnection object
      * @author James Kostrewski
      */
-    public UssChangeTag(ZosConnection connection) {
+    public UssChangeTag(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
     }
@@ -62,7 +62,7 @@ public class UssChangeTag {
      * @throws Exception processing error
      * @author James Kostrewski
      */
-    public UssChangeTag(ZosConnection connection, ZoweRequest request) throws Exception {
+    public UssChangeTag(final ZosConnection connection, final ZoweRequest request) throws Exception {
         ValidateUtils.checkConnection(connection);
         ValidateUtils.checkNullParameter(request == null, "request is null");
         this.connection = connection;
@@ -80,7 +80,7 @@ public class UssChangeTag {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public Response changeToBinary(String fileNamePath) throws Exception {
+    public Response changeToBinary(final String fileNamePath) throws Exception {
         return changeCommon(fileNamePath, new ChangeTagParams.Builder()
                 .action(ChangeTagAction.SET).type(ChangeTagType.BINARY).build());
     }
@@ -94,7 +94,7 @@ public class UssChangeTag {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public Response changeToText(String fileNamePath, String codeSet) throws Exception {
+    public Response changeToText(final String fileNamePath, final String codeSet) throws Exception {
         ValidateUtils.checkNullParameter(codeSet == null, "codeSet is null");
         ValidateUtils.checkIllegalParameter(codeSet.isBlank(), "codeSet not specified");
 
@@ -110,7 +110,7 @@ public class UssChangeTag {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public Response remove(String fileNamePath) throws Exception {
+    public Response remove(final String fileNamePath) throws Exception {
         return changeCommon(fileNamePath, new ChangeTagParams.Builder().action(ChangeTagAction.REMOVE).build());
     }
 
@@ -122,7 +122,7 @@ public class UssChangeTag {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public Response retrieve(String fileNamePath) throws Exception {
+    public Response retrieve(final String fileNamePath) throws Exception {
         return changeCommon(fileNamePath, new ChangeTagParams.Builder().action(ChangeTagAction.LIST).build());
     }
 
@@ -135,7 +135,7 @@ public class UssChangeTag {
      * @throws Exception processing error
      * @author James Kostrewski
      */
-    public Response changeCommon(String fileNamePath, ChangeTagParams params) throws Exception {
+    public Response changeCommon(final String fileNamePath, final ChangeTagParams params) throws Exception {
         ValidateUtils.checkNullParameter(fileNamePath == null, "fileNamePath is null");
         ValidateUtils.checkIllegalParameter(fileNamePath.isBlank(), "fileNamePath not specified");
         ValidateUtils.checkNullParameter(params == null, "params is null");

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssCopy.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssCopy.java
@@ -45,7 +45,7 @@ public class UssCopy {
      * @param connection connection information, see ZosConnection object
      * @author James Kostrewski
      */
-    public UssCopy(ZosConnection connection) {
+    public UssCopy(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
     }
@@ -59,7 +59,7 @@ public class UssCopy {
      * @throws Exception processing error
      * @author James Kostrewski
      */
-    public UssCopy(ZosConnection connection, ZoweRequest request) throws Exception {
+    public UssCopy(final ZosConnection connection, final ZoweRequest request) throws Exception {
         ValidateUtils.checkConnection(connection);
         ValidateUtils.checkNullParameter(request == null, "request is null");
         this.connection = connection;
@@ -79,7 +79,7 @@ public class UssCopy {
      * @author James Kostrewski
      * @author Frank Giordano
      */
-    public Response copy(String fromPath, String targetPath) throws Exception {
+    public Response copy(final String fromPath, final String targetPath) throws Exception {
         return copy(targetPath, new CopyParams.Builder().from(fromPath).build());
     }
 
@@ -93,7 +93,7 @@ public class UssCopy {
      * @author James Kostrewski
      * @author Frank Giordano
      */
-    public Response copy(String targetPath, CopyParams params) throws Exception {
+    public Response copy(final String targetPath, final CopyParams params) throws Exception {
         ValidateUtils.checkNullParameter(targetPath == null, "targetPath is null");
         ValidateUtils.checkIllegalParameter(targetPath.isBlank(), "targetPath not specified");
         ValidateUtils.checkNullParameter(params == null, "params is null");

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssCreate.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssCreate.java
@@ -45,7 +45,7 @@ public class UssCreate {
      * @param connection connection information, see ZosConnection object
      * @author James Kostrewski
      */
-    public UssCreate(ZosConnection connection) {
+    public UssCreate(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
     }
@@ -60,7 +60,7 @@ public class UssCreate {
      * @author James Kostrewski
      * @author Frank Giordano
      */
-    public UssCreate(ZosConnection connection, ZoweRequest request) throws Exception {
+    public UssCreate(final ZosConnection connection, final ZoweRequest request) throws Exception {
         ValidateUtils.checkConnection(connection);
         ValidateUtils.checkNullParameter(request == null, "request is null");
         this.connection = connection;
@@ -80,7 +80,7 @@ public class UssCreate {
      * @author James Kostrewski
      * @author Frank Giordano
      */
-    public Response create(String targetPath, CreateParams params) throws Exception {
+    public Response create(final String targetPath, final CreateParams params) throws Exception {
         ValidateUtils.checkNullParameter(targetPath == null, "targetPath is null");
         ValidateUtils.checkIllegalParameter(targetPath.isBlank(), "targetPath not specified");
         ValidateUtils.checkNullParameter(params == null, "params is null");

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssDelete.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssDelete.java
@@ -42,7 +42,7 @@ public class UssDelete {
      * @param connection connection information, see ZosConnection object
      * @author James Kostrewski
      */
-    public UssDelete(ZosConnection connection) {
+    public UssDelete(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
     }
@@ -57,7 +57,7 @@ public class UssDelete {
      * @author James Kostrewski
      * @author Frank Giordano
      */
-    public UssDelete(ZosConnection connection, ZoweRequest request) throws Exception {
+    public UssDelete(final ZosConnection connection, final ZoweRequest request) throws Exception {
         ValidateUtils.checkConnection(connection);
         ValidateUtils.checkNullParameter(request == null, "request is null");
         this.connection = connection;
@@ -75,7 +75,7 @@ public class UssDelete {
      * @throws Exception processing error
      * @author James Kostrewski
      */
-    public Response delete(String targetPath) throws Exception {
+    public Response delete(final String targetPath) throws Exception {
         return delete(targetPath, false);
     }
 
@@ -88,7 +88,7 @@ public class UssDelete {
      * @throws Exception processing error
      * @author James Kostrewski
      */
-    public Response delete(String targetPath, boolean recursive) throws Exception {
+    public Response delete(final String targetPath, final boolean recursive) throws Exception {
         ValidateUtils.checkNullParameter(targetPath == null, "targetPath is null");
         ValidateUtils.checkIllegalParameter(targetPath.isBlank(), "targetPath not specified");
 
@@ -116,7 +116,7 @@ public class UssDelete {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public Response zfsDelete(String fileSystemName) throws Exception {
+    public Response zfsDelete(final String fileSystemName) throws Exception {
         ValidateUtils.checkNullParameter(fileSystemName == null, "file system name is null");
         ValidateUtils.checkIllegalParameter(fileSystemName.isBlank(), "file system name not specified");
 

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssGet.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssGet.java
@@ -43,7 +43,7 @@ public class UssGet {
      * @author Frank Giordano
      * @author James Kostrewski
      */
-    public UssGet(ZosConnection connection) {
+    public UssGet(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
     }
@@ -57,7 +57,7 @@ public class UssGet {
      * @author Frank Giordano
      * @author James Kostrewski
      */
-    public UssGet(ZosConnection connection, ZoweRequest request) {
+    public UssGet(final ZosConnection connection, final ZoweRequest request) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
         this.request = request;
@@ -72,7 +72,7 @@ public class UssGet {
      * @author Frank Giordano
      * @author James Kostrewski
      */
-    public byte[] getBinary(String fileNamePath) throws Exception {
+    public byte[] getBinary(final String fileNamePath) throws Exception {
         GetParams params = new GetParams.Builder().binary(true).build();
         Response response = getCommon(fileNamePath, params);
         return (byte[]) response.getResponsePhrase().orElse(new byte[0]);
@@ -87,7 +87,7 @@ public class UssGet {
      * @author Frank Giordano
      * @author James Kostrewski
      */
-    public String getText(String fileNamePath) throws Exception {
+    public String getText(final String fileNamePath) throws Exception {
         GetParams params = new GetParams.Builder().build();
         Response response = getCommon(fileNamePath, params);
         return (String) response.getResponsePhrase().orElse("");
@@ -103,7 +103,7 @@ public class UssGet {
      * @author Frank Giordano
      * @author James Kostrewski
      */
-    public Response getCommon(String fileNamePath, GetParams params) throws Exception {
+    public Response getCommon(final String fileNamePath, final GetParams params) throws Exception {
         ValidateUtils.checkNullParameter(fileNamePath == null, "fileNamePath is null");
         ValidateUtils.checkIllegalParameter(fileNamePath.isBlank(), "fileNamePath not specified");
         ValidateUtils.checkNullParameter(params == null, "params is null");

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssList.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssList.java
@@ -133,9 +133,9 @@ public class UssList {
                 response.getResponsePhrase().orElseThrow(() -> new IllegalStateException(errMsg))));
         final JSONArray jsonArray = (JSONArray) jsonObject.get("items");
         if (jsonArray != null) {
-            for (final Object obj : jsonArray) {
-                items.add((UnixFile) JsonParseResponseFactory
-                        .buildParser((JSONObject) obj, ParseType.UNIX_FILE).parseResponse());
+            for (final Object jsonObj : jsonArray) {
+                items.add((UnixFile) JsonParseResponseFactory.buildParser(ParseType.UNIX_FILE)
+                        .setJsonObject((JSONObject) jsonObj).parseResponse());
             }
         }
 
@@ -196,8 +196,9 @@ public class UssList {
                     }
                 } catch (Exception ignored) {
                 }
-                UnixZfsParseResponse parse = (UnixZfsParseResponse) JsonParseResponseFactory
-                        .buildParser(jsonObj, ParseType.UNIX_ZFS);
+
+                final UnixZfsParseResponse parse = (UnixZfsParseResponse) JsonParseResponseFactory
+                        .buildParser(ParseType.UNIX_ZFS).setJsonObject(jsonObj);
                 parse.setModeStr(modeStr.toString());
                 items.add(parse.parseResponse());
             }

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssList.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssList.java
@@ -55,7 +55,7 @@ public class UssList {
      * @param connection connection information, see ZosConnection object
      * @author Frank Giordano
      */
-    public UssList(ZosConnection connection) {
+    public UssList(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
     }
@@ -69,7 +69,7 @@ public class UssList {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public UssList(ZosConnection connection, ZoweRequest request) throws Exception {
+    public UssList(final ZosConnection connection, final ZoweRequest request) throws Exception {
         ValidateUtils.checkConnection(connection);
         ValidateUtils.checkNullParameter(request == null, "request is null");
         this.connection = connection;
@@ -87,7 +87,7 @@ public class UssList {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public List<UnixFile> fileList(ListParams params) throws Exception {
+    public List<UnixFile> fileList(final ListParams params) throws Exception {
         ValidateUtils.checkNullParameter(params == null, "params is null");
 
         final StringBuilder url = new StringBuilder("https://" + connection.getHost() + ":" +
@@ -150,7 +150,7 @@ public class UssList {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public List<UnixZfs> zfsList(ListZfsParams params) throws Exception {
+    public List<UnixZfs> zfsList(final ListZfsParams params) throws Exception {
         ValidateUtils.checkNullParameter(params == null, "params is null");
         ValidateUtils.checkIllegalParameter(params.getPath().isEmpty() && params.getFsname().isEmpty(),
                 "no path or fsname specified");

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssMount.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssMount.java
@@ -47,7 +47,7 @@ public class UssMount {
      * @param connection connection information, see ZosConnection object
      * @author Frank Giordano
      */
-    public UssMount(ZosConnection connection) {
+    public UssMount(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
     }
@@ -61,7 +61,7 @@ public class UssMount {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public UssMount(ZosConnection connection, ZoweRequest request) throws Exception {
+    public UssMount(final ZosConnection connection, final ZoweRequest request) throws Exception {
         ValidateUtils.checkConnection(connection);
         ValidateUtils.checkNullParameter(request == null, "request is null");
         this.connection = connection;
@@ -81,7 +81,7 @@ public class UssMount {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public Response mount(String fileSystemName, String mountPoint, String fsType) throws Exception {
+    public Response mount(final String fileSystemName, final String mountPoint, final String fsType) throws Exception {
         return mountCommon(fileSystemName,
                 new MountParams.Builder()
                         .action(MountActionType.MOUNT)
@@ -99,7 +99,7 @@ public class UssMount {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public Response unmount(String fileSystemName) throws Exception {
+    public Response unmount(final String fileSystemName) throws Exception {
         return mountCommon(fileSystemName, new MountParams.Builder().action(MountActionType.UNMOUNT).build());
     }
 
@@ -112,7 +112,7 @@ public class UssMount {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public Response mountCommon(String fileSystemName, MountParams params) throws Exception {
+    public Response mountCommon(final String fileSystemName, final MountParams params) throws Exception {
         ValidateUtils.checkNullParameter(fileSystemName == null, "file system name is null");
         ValidateUtils.checkIllegalParameter(fileSystemName.isBlank(), "file system name not specified");
         ValidateUtils.checkNullParameter(params == null, "params is null");

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssMove.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssMove.java
@@ -44,7 +44,7 @@ public class UssMove {
      * @param connection connection information, see ZosConnection object
      * @author James Kostrewski
      */
-    public UssMove(ZosConnection connection) {
+    public UssMove(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
     }
@@ -58,7 +58,7 @@ public class UssMove {
      * @throws Exception processing error
      * @author James Kostrewski
      */
-    public UssMove(ZosConnection connection, ZoweRequest request) throws Exception {
+    public UssMove(final ZosConnection connection, final ZoweRequest request) throws Exception {
         ValidateUtils.checkConnection(connection);
         ValidateUtils.checkNullParameter(request == null, "request is null");
         this.connection = connection;
@@ -78,7 +78,7 @@ public class UssMove {
      * @author James Kostrewski
      * @author Frank Giordano
      */
-    public Response move(String fromPath, String targetPath) throws Exception {
+    public Response move(final String fromPath, final String targetPath) throws Exception {
         return moveCommon(fromPath, targetPath, true);
     }
 
@@ -92,7 +92,7 @@ public class UssMove {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public Response move(String fromPath, String targetPath, boolean overwrite) throws Exception {
+    public Response move(final String fromPath, final String targetPath, final boolean overwrite) throws Exception {
         return moveCommon(fromPath, targetPath, overwrite);
     }
 
@@ -107,7 +107,8 @@ public class UssMove {
      * @author James Kostrewski
      * @author Frank Giordano
      */
-    private Response moveCommon(String fromPath, String targetPath, boolean overwrite) throws Exception {
+    private Response moveCommon(final String fromPath, final String targetPath, final boolean overwrite)
+            throws Exception {
         ValidateUtils.checkNullParameter(fromPath == null, "fromPath is null");
         ValidateUtils.checkIllegalParameter(fromPath.isBlank(), "fromPath not specified");
         ValidateUtils.checkNullParameter(targetPath == null, "targetPath is null");

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssWrite.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssWrite.java
@@ -45,7 +45,7 @@ public class UssWrite {
      * @param connection connection information, see ZosConnection object
      * @author Frank Giordano
      */
-    public UssWrite(ZosConnection connection) {
+    public UssWrite(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
     }
@@ -58,7 +58,7 @@ public class UssWrite {
      * @param request    any compatible ZoweRequest Interface object
      * @author Frank Giordano
      */
-    public UssWrite(ZosConnection connection, ZoweRequest request) {
+    public UssWrite(final ZosConnection connection, final ZoweRequest request) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
         this.request = request;
@@ -74,7 +74,7 @@ public class UssWrite {
      * @author Frank Giordano
      * @author James Kostrewski
      */
-    public Response writeText(String fileNamePath, String content) throws Exception {
+    public Response writeText(final String fileNamePath, final String content) throws Exception {
         return writeCommon(fileNamePath, new WriteParams.Builder().textContent(content).build());
     }
 
@@ -88,7 +88,7 @@ public class UssWrite {
      * @author Frank Giordano
      * @author James Kostrewski
      */
-    public Response writeBinary(String fileNamePath, byte[] content) throws Exception {
+    public Response writeBinary(final String fileNamePath, final byte[] content) throws Exception {
         return writeCommon(fileNamePath, new WriteParams.Builder().binaryContent(content).binary(true).build());
     }
 
@@ -102,7 +102,7 @@ public class UssWrite {
      * @author James Kostrewski
      * @author Frank Giordano
      */
-    public Response writeCommon(String fileNamePath, WriteParams params) throws Exception {
+    public Response writeCommon(final String fileNamePath, final WriteParams params) throws Exception {
         ValidateUtils.checkNullParameter(fileNamePath == null, "fileNamePath is null");
         ValidateUtils.checkIllegalParameter(fileNamePath.isBlank(), "fileNamePath not specified");
         ValidateUtils.checkNullParameter(params == null, "params is null");

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/response/UnixFile.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/response/UnixFile.java
@@ -60,7 +60,7 @@ public class UnixFile {
      */
     private final Optional<String> mtime;
 
-    public UnixFile(UnixFile.Builder builder) {
+    public UnixFile(final UnixFile.Builder builder) {
         this.name = Optional.ofNullable(builder.name);
         this.mode = Optional.ofNullable(builder.mode);
         if (builder.size == null) {
@@ -144,42 +144,42 @@ public class UnixFile {
             return new UnixFile(this);
         }
 
-        public UnixFile.Builder name(String name) {
+        public UnixFile.Builder name(final String name) {
             this.name = name;
             return this;
         }
 
-        public UnixFile.Builder mode(String mode) {
+        public UnixFile.Builder mode(final String mode) {
             this.mode = mode;
             return this;
         }
 
-        public UnixFile.Builder size(Long size) {
+        public UnixFile.Builder size(final Long size) {
             this.size = size;
             return this;
         }
 
-        public UnixFile.Builder uid(Long uid) {
+        public UnixFile.Builder uid(final Long uid) {
             this.uid = uid;
             return this;
         }
 
-        public UnixFile.Builder user(String user) {
+        public UnixFile.Builder user(final String user) {
             this.user = user;
             return this;
         }
 
-        public UnixFile.Builder gid(Long gid) {
+        public UnixFile.Builder gid(final Long gid) {
             this.gid = gid;
             return this;
         }
 
-        public UnixFile.Builder group(String group) {
+        public UnixFile.Builder group(final String group) {
             this.group = group;
             return this;
         }
 
-        public UnixFile.Builder mtime(String mtime) {
+        public UnixFile.Builder mtime(final String mtime) {
             this.mtime = mtime;
             return this;
         }

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/response/UnixZfs.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/response/UnixZfs.java
@@ -103,7 +103,7 @@ public class UnixZfs {
      */
     private final boolean moreRows;
 
-    public UnixZfs(UnixZfs.Builder builder) {
+    public UnixZfs(final UnixZfs.Builder builder) {
         this.name = Optional.ofNullable(builder.name);
         this.mountpoint = Optional.ofNullable(builder.mountpoint);
         this.fstname = Optional.ofNullable(builder.fstname);
@@ -279,87 +279,87 @@ public class UnixZfs {
             return new UnixZfs(this);
         }
 
-        public UnixZfs.Builder name(String name) {
+        public UnixZfs.Builder name(final String name) {
             this.name = name;
             return this;
         }
 
-        public UnixZfs.Builder mountpoint(String mountpoint) {
+        public UnixZfs.Builder mountpoint(final String mountpoint) {
             this.mountpoint = mountpoint;
             return this;
         }
 
-        public UnixZfs.Builder fstname(String fstname) {
+        public UnixZfs.Builder fstname(final String fstname) {
             this.fstname = fstname;
             return this;
         }
 
-        public UnixZfs.Builder status(String status) {
+        public UnixZfs.Builder status(final String status) {
             this.status = status;
             return this;
         }
 
-        public UnixZfs.Builder mode(String mode) {
+        public UnixZfs.Builder mode(final String mode) {
             this.mode = mode;
             return this;
         }
 
-        public UnixZfs.Builder dev(Long dev) {
+        public UnixZfs.Builder dev(final Long dev) {
             this.dev = dev;
             return this;
         }
 
-        public UnixZfs.Builder fstype(Long fstype) {
+        public UnixZfs.Builder fstype(final Long fstype) {
             this.fstype = fstype;
             return this;
         }
 
-        public UnixZfs.Builder bsize(Long bsize) {
+        public UnixZfs.Builder bsize(final Long bsize) {
             this.bsize = bsize;
             return this;
         }
 
-        public UnixZfs.Builder bavail(Long bavail) {
+        public UnixZfs.Builder bavail(final Long bavail) {
             this.bavail = bavail;
             return this;
         }
 
-        public UnixZfs.Builder blocks(Long blocks) {
+        public UnixZfs.Builder blocks(final Long blocks) {
             this.blocks = blocks;
             return this;
         }
 
-        public UnixZfs.Builder sysname(String sysname) {
+        public UnixZfs.Builder sysname(final String sysname) {
             this.sysname = sysname;
             return this;
         }
 
-        public UnixZfs.Builder readibc(Long readibc) {
+        public UnixZfs.Builder readibc(final Long readibc) {
             this.readibc = readibc;
             return this;
         }
 
-        public UnixZfs.Builder writeibc(Long writeibc) {
+        public UnixZfs.Builder writeibc(final Long writeibc) {
             this.writeibc = writeibc;
             return this;
         }
 
-        public UnixZfs.Builder diribc(Long diribc) {
+        public UnixZfs.Builder diribc(final Long diribc) {
             this.diribc = diribc;
             return this;
         }
 
-        public UnixZfs.Builder returnedRows(Long returnedRows) {
+        public UnixZfs.Builder returnedRows(final Long returnedRows) {
             this.returnedRows = returnedRows;
             return this;
         }
 
-        public UnixZfs.Builder totalRows(Long totalRows) {
+        public UnixZfs.Builder totalRows(final Long totalRows) {
             this.totalRows = totalRows;
             return this;
         }
 
-        public UnixZfs.Builder moreRows(boolean moreRows) {
+        public UnixZfs.Builder moreRows(final boolean moreRows) {
             this.moreRows = moreRows;
             return this;
         }

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/types/ChangeTagAction.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/types/ChangeTagAction.java
@@ -25,7 +25,7 @@ public enum ChangeTagAction {
 
     private final String value;
 
-    ChangeTagAction(String value) {
+    ChangeTagAction(final String value) {
         this.value = value;
     }
 

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/types/ChangeTagType.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/types/ChangeTagType.java
@@ -25,7 +25,7 @@ public enum ChangeTagType {
 
     private final String value;
 
-    ChangeTagType(String value) {
+    ChangeTagType(final String value) {
         this.value = value;
     }
 

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/types/CreateType.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/types/CreateType.java
@@ -24,7 +24,7 @@ public enum CreateType {
 
     private final String value;
 
-    CreateType(String value) {
+    CreateType(final String value) {
         this.value = value;
     }
 

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/types/LinkType.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/types/LinkType.java
@@ -25,7 +25,7 @@ public enum LinkType {
 
     private final String value;
 
-    LinkType(String value) {
+    LinkType(final String value) {
         this.value = value;
     }
 

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/types/ListFilterType.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/types/ListFilterType.java
@@ -28,7 +28,7 @@ public enum ListFilterType {
 
     private final String value;
 
-    ListFilterType(String value) {
+    ListFilterType(final String value) {
         this.value = value;
     }
 

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/types/MountActionType.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/types/MountActionType.java
@@ -24,7 +24,7 @@ public enum MountActionType {
 
     private final String value;
 
-    MountActionType(String value) {
+    MountActionType(final String value) {
         this.value = value;
     }
 

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/types/MountModeType.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/types/MountModeType.java
@@ -24,7 +24,7 @@ public enum MountModeType {
 
     private final String value;
 
-    MountModeType(String value) {
+    MountModeType(final String value) {
         this.value = value;
     }
 

--- a/src/main/java/zowe/client/sdk/zosjobs/input/CommonJobParams.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/input/CommonJobParams.java
@@ -37,7 +37,7 @@ public class CommonJobParams {
      * Step data is an optional parameter that indicates whether the service returns information about each step in
      * the job that completed, such as the step name, step number, and completion code.
      */
-    private final Boolean stepData;
+    private final boolean stepData;
 
     /**
      * CommonJobParams constructor, no step data information included.
@@ -46,7 +46,7 @@ public class CommonJobParams {
      * @param jobName job name value
      * @author Frank Giordano
      */
-    public CommonJobParams(String jobId, String jobName) {
+    public CommonJobParams(final String jobId, final String jobName) {
         validateParameters(jobId, jobName);
         this.jobId = Optional.of(jobId);
         this.jobName = Optional.of(jobName);
@@ -61,7 +61,7 @@ public class CommonJobParams {
      * @param stepData determines whether step data is included in rest call
      * @author Frank Giordano
      */
-    public CommonJobParams(String jobId, String jobName, Boolean stepData) {
+    public CommonJobParams(final String jobId, final String jobName, final boolean stepData) {
         validateParameters(jobId, jobName);
         this.jobId = Optional.of(jobId);
         this.jobName = Optional.of(jobName);
@@ -91,10 +91,10 @@ public class CommonJobParams {
     /**
      * Determines whether step data is included in rest call
      *
-     * @return true or false
+     * @return boolean true or false
      * @author Frank Giordano
      */
-    public Boolean isStepData() {
+    public boolean isStepData() {
         return stepData;
     }
 
@@ -105,7 +105,7 @@ public class CommonJobParams {
      * @param jobName job name value
      * @author Frank Giordano
      */
-    private void validateParameters(String jobId, final String jobName) {
+    private void validateParameters(final String jobId, final String jobName) {
         ValidateUtils.checkNullParameter(jobId == null, "job id is null");
         ValidateUtils.checkIllegalParameter(jobId.isBlank(), "job id not specified");
         ValidateUtils.checkNullParameter(jobName == null, "job name is null");

--- a/src/main/java/zowe/client/sdk/zosjobs/input/GetJobParams.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/input/GetJobParams.java
@@ -45,7 +45,7 @@ public class GetJobParams {
      */
     private final Optional<String> jobId;
 
-    private GetJobParams(Builder builder) {
+    private GetJobParams(final Builder builder) {
         this.owner = Optional.ofNullable(builder.owner);
         this.prefix = Optional.ofNullable(builder.prefix);
         if (builder.maxJobs == null) {
@@ -116,7 +116,7 @@ public class GetJobParams {
         public Builder() {
         }
 
-        public Builder(String owner) {
+        public Builder(final String owner) {
             ValidateUtils.checkNullParameter(owner == null, "owner is null");
             ValidateUtils.checkIllegalParameter(owner.isBlank(), "owner not specified");
             this.owner = owner;
@@ -126,19 +126,19 @@ public class GetJobParams {
             return new GetJobParams(this);
         }
 
-        public Builder jobId(String jobId) {
+        public Builder jobId(final String jobId) {
             ValidateUtils.checkNullParameter(jobId == null, "job id is null");
             ValidateUtils.checkIllegalParameter(jobId.isBlank(), "job id not specified");
             this.jobId = jobId;
             return this;
         }
 
-        public Builder maxJobs(Integer maxJobs) {
+        public Builder maxJobs(final Integer maxJobs) {
             this.maxJobs = maxJobs;
             return this;
         }
 
-        public Builder prefix(String prefix) {
+        public Builder prefix(final String prefix) {
             ValidateUtils.checkNullParameter(prefix == null, "prefix is null");
             ValidateUtils.checkIllegalParameter(prefix.isBlank(), "prefix not specified");
             this.prefix = prefix;

--- a/src/main/java/zowe/client/sdk/zosjobs/input/JobFile.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/input/JobFile.java
@@ -90,7 +90,7 @@ public class JobFile {
      */
     private final Optional<String> procStep;
 
-    private JobFile(Builder builder) {
+    private JobFile(final Builder builder) {
         this.jobId = Optional.ofNullable(builder.jobId);
         this.jobName = Optional.ofNullable(builder.jobName);
         this.recfm = Optional.ofNullable(builder.recfm);
@@ -304,72 +304,72 @@ public class JobFile {
             return new JobFile(this);
         }
 
-        public Builder byteCount(Long byteCount) {
+        public Builder byteCount(final Long byteCount) {
             this.byteCount = byteCount;
             return this;
         }
 
-        public Builder classs(String classs) {
+        public Builder classs(final String classs) {
             this.classs = classs;
             return this;
         }
 
-        public Builder ddName(String ddName) {
+        public Builder ddName(final String ddName) {
             this.ddName = ddName;
             return this;
         }
 
-        public Builder id(Long id) {
+        public Builder id(final Long id) {
             this.id = id;
             return this;
         }
 
-        public Builder jobCorrelator(String jobCorrelator) {
+        public Builder jobCorrelator(final String jobCorrelator) {
             this.jobCorrelator = jobCorrelator;
             return this;
         }
 
-        public Builder jobId(String jobId) {
+        public Builder jobId(final String jobId) {
             this.jobId = jobId;
             return this;
         }
 
-        public Builder jobName(String jobName) {
+        public Builder jobName(final String jobName) {
             this.jobName = jobName;
             return this;
         }
 
-        public Builder lrecl(Long lrecl) {
+        public Builder lrecl(final Long lrecl) {
             this.lrecl = lrecl;
             return this;
         }
 
-        public Builder procStep(String procStep) {
+        public Builder procStep(final String procStep) {
             this.procStep = procStep;
             return this;
         }
 
-        public Builder recfm(String recfm) {
+        public Builder recfm(final String recfm) {
             this.recfm = recfm;
             return this;
         }
 
-        public Builder recordCount(Long recordCount) {
+        public Builder recordCount(final Long recordCount) {
             this.recordCount = recordCount;
             return this;
         }
 
-        public Builder recordsUrl(String recordsUrl) {
+        public Builder recordsUrl(final String recordsUrl) {
             this.recordsUrl = recordsUrl;
             return this;
         }
 
-        public Builder stepName(String stepName) {
+        public Builder stepName(final String stepName) {
             this.stepName = stepName;
             return this;
         }
 
-        public Builder subSystem(String subSystem) {
+        public Builder subSystem(final String subSystem) {
             this.subSystem = subSystem;
             return this;
         }

--- a/src/main/java/zowe/client/sdk/zosjobs/input/JobFile.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/input/JobFile.java
@@ -10,6 +10,7 @@
 package zowe.client.sdk.zosjobs.input;
 
 import java.util.Optional;
+import java.util.OptionalLong;
 
 /**
  * Represents the name and details of an output (spool) DD for a z/OS batch job
@@ -37,12 +38,12 @@ public class JobFile {
     /**
      * Total bytes in the spool file
      */
-    private final Optional<Long> byteCount;
+    private final OptionalLong byteCount;
 
     /**
      * Total records (roughly equivalent to lines) in the spool file
      */
-    private final Optional<Long> recordCount;
+    private final OptionalLong recordCount;
 
     /**
      * Unique identifier of job (substitute of job name and job id)
@@ -57,7 +58,7 @@ public class JobFile {
     /**
      * Identifier for this spool file. Each JobFile for a single batch job will have a unique ID
      */
-    private final Optional<Long> id;
+    private final OptionalLong id;
 
     /**
      * DD name of job spool file
@@ -72,7 +73,7 @@ public class JobFile {
     /**
      * Job DD lrecl (logical record length - how many bytes each record is)
      */
-    private final Optional<Long> lrecl;
+    private final OptionalLong lrecl;
 
     /**
      * The primary or secondary JES subsystem. If this value is null, the job was processed by the primary subsystem.
@@ -93,14 +94,30 @@ public class JobFile {
         this.jobId = Optional.ofNullable(builder.jobId);
         this.jobName = Optional.ofNullable(builder.jobName);
         this.recfm = Optional.ofNullable(builder.recfm);
-        this.byteCount = Optional.ofNullable(builder.byteCount);
-        this.recordCount = Optional.ofNullable(builder.recordCount);
+        if (builder.byteCount == null) {
+            this.byteCount = OptionalLong.empty();
+        } else {
+            this.byteCount = OptionalLong.of(builder.byteCount);
+        }
+        if (builder.recordCount == null) {
+            this.recordCount = OptionalLong.empty();
+        } else {
+            this.recordCount = OptionalLong.of(builder.recordCount);
+        }
         this.jobCorrelator = Optional.ofNullable(builder.jobCorrelator);
         this.classs = Optional.ofNullable(builder.classs);
-        this.id = Optional.ofNullable(builder.id);
+        if (builder.id == null) {
+            this.id = OptionalLong.empty();
+        } else {
+            this.id = OptionalLong.of(builder.id);
+        }
         this.ddName = Optional.ofNullable(builder.ddName);
         this.recordsUrl = Optional.ofNullable(builder.recordsUrl);
-        this.lrecl = Optional.ofNullable(builder.lrecl);
+        if (builder.lrecl == null) {
+            this.lrecl = OptionalLong.empty();
+        } else {
+            this.lrecl = OptionalLong.of(builder.lrecl);
+        }
         this.subSystem = Optional.ofNullable(builder.subSystem);
         this.stepName = Optional.ofNullable(builder.stepName);
         this.procStep = Optional.ofNullable(builder.procStep);
@@ -112,7 +129,7 @@ public class JobFile {
      * @return byteCount value
      * @author Frank Giordano
      */
-    public Optional<Long> getByteCount() {
+    public OptionalLong getByteCount() {
         return byteCount;
     }
 
@@ -142,7 +159,7 @@ public class JobFile {
      * @return id value
      * @author Frank Giordano
      */
-    public Optional<Long> getId() {
+    public OptionalLong getId() {
         return id;
     }
 
@@ -182,7 +199,7 @@ public class JobFile {
      * @return lrecl value
      * @author Frank Giordano
      */
-    public Optional<Long> getLrecl() {
+    public OptionalLong getLrecl() {
         return lrecl;
     }
 
@@ -212,7 +229,7 @@ public class JobFile {
      * @return recordCount value
      * @author Frank Giordano
      */
-    public Optional<Long> getRecordCount() {
+    public OptionalLong getRecordCount() {
         return recordCount;
     }
 

--- a/src/main/java/zowe/client/sdk/zosjobs/input/ModifyJobParams.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/input/ModifyJobParams.java
@@ -41,7 +41,7 @@ public class ModifyJobParams {
      */
     private final Optional<String> version;
 
-    private ModifyJobParams(ModifyJobParams.Builder builder) {
+    private ModifyJobParams(final ModifyJobParams.Builder builder) {
         this.jobName = Optional.ofNullable(builder.jobName);
         this.jobId = Optional.ofNullable(builder.jobId);
         this.version = Optional.ofNullable(builder.version);
@@ -92,7 +92,7 @@ public class ModifyJobParams {
         private final String jobId;
         private String version;
 
-        public Builder(String jobName, String jobId) {
+        public Builder(final String jobName, final String jobId) {
             ValidateUtils.checkNullParameter(jobName == null, "job name is null");
             ValidateUtils.checkIllegalParameter(jobName.isBlank(), "job name not specified");
             ValidateUtils.checkNullParameter(jobId == null, "job id is null");
@@ -105,7 +105,7 @@ public class ModifyJobParams {
             return new ModifyJobParams(this);
         }
 
-        public ModifyJobParams.Builder version(String version) {
+        public ModifyJobParams.Builder version(final String version) {
             this.version = version;
             return this;
         }

--- a/src/main/java/zowe/client/sdk/zosjobs/input/MonitorJobWaitForParams.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/input/MonitorJobWaitForParams.java
@@ -68,7 +68,7 @@ public class MonitorJobWaitForParams {
      */
     private OptionalInt lineLimit;
 
-    private MonitorJobWaitForParams(MonitorJobWaitForParams.Builder builder) {
+    private MonitorJobWaitForParams(final MonitorJobWaitForParams.Builder builder) {
         this.jobId = Optional.ofNullable(builder.jobId);
         this.jobName = Optional.ofNullable(builder.jobName);
         this.watchDelay = builder.watchDelay;
@@ -93,7 +93,7 @@ public class MonitorJobWaitForParams {
      * @param attempts number of attempts to get status
      * @author Frank Giordano
      */
-    public void setAttempts(int attempts) {
+    public void setAttempts(final int attempts) {
         this.attempts = OptionalInt.of(attempts);
     }
 
@@ -133,7 +133,7 @@ public class MonitorJobWaitForParams {
      * @param jobStatus job status type, see JobStatus.Type object
      * @author Frank Giordano
      */
-    public void setJobStatus(JobStatus.Type jobStatus) {
+    public void setJobStatus(final JobStatus.Type jobStatus) {
         this.jobStatus = Optional.ofNullable(jobStatus);
     }
 
@@ -153,7 +153,7 @@ public class MonitorJobWaitForParams {
      * @param lineLimit number of lines to inspect
      * @author Frank Giordano
      */
-    public void setLineLimit(int lineLimit) {
+    public void setLineLimit(final int lineLimit) {
         this.lineLimit = OptionalInt.of(lineLimit);
     }
 
@@ -173,7 +173,7 @@ public class MonitorJobWaitForParams {
      * @param watchDelay delay of polling operation in milliseconds
      * @author Frank Giordano
      */
-    public void setWatchDelay(int watchDelay) {
+    public void setWatchDelay(final int watchDelay) {
         this.watchDelay = OptionalInt.of(watchDelay);
     }
 
@@ -198,7 +198,7 @@ public class MonitorJobWaitForParams {
         private OptionalInt attempts = OptionalInt.empty();
         private OptionalInt lineLimit = OptionalInt.empty();
 
-        public Builder(String jobName, String jobId) {
+        public Builder(final String jobName, final String jobId) {
             ValidateUtils.checkNullParameter(jobName == null, "job name is null");
             ValidateUtils.checkIllegalParameter(jobName.isBlank(), JobsConstants.JOB_NAME_ERROR_MSG);
             ValidateUtils.checkNullParameter(jobId == null, "job id is null");
@@ -207,7 +207,7 @@ public class MonitorJobWaitForParams {
             this.jobId = jobId;
         }
 
-        public MonitorJobWaitForParams.Builder attempts(int attempts) {
+        public MonitorJobWaitForParams.Builder attempts(final int attempts) {
             this.attempts = OptionalInt.of(attempts);
             return this;
         }
@@ -216,17 +216,17 @@ public class MonitorJobWaitForParams {
             return new MonitorJobWaitForParams(this);
         }
 
-        public MonitorJobWaitForParams.Builder jobStatus(JobStatus.Type jobStatus) {
+        public MonitorJobWaitForParams.Builder jobStatus(final JobStatus.Type jobStatus) {
             this.jobStatus = jobStatus;
             return this;
         }
 
-        public MonitorJobWaitForParams.Builder lineLimit(int lineLimit) {
+        public MonitorJobWaitForParams.Builder lineLimit(final int lineLimit) {
             this.lineLimit = OptionalInt.of(lineLimit);
             return this;
         }
 
-        public MonitorJobWaitForParams.Builder watchDelay(int watchDelay) {
+        public MonitorJobWaitForParams.Builder watchDelay(final int watchDelay) {
             this.watchDelay = OptionalInt.of(watchDelay);
             return this;
         }

--- a/src/main/java/zowe/client/sdk/zosjobs/input/SubmitJclParams.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/input/SubmitJclParams.java
@@ -60,7 +60,7 @@ public class SubmitJclParams {
      * @param internalReaderLrecl internal reader LRECL
      * @author Frank Giordano
      */
-    public SubmitJclParams(String jcl, String internalReaderRecfm, String internalReaderLrecl) {
+    public SubmitJclParams(final String jcl, final String internalReaderRecfm, final String internalReaderLrecl) {
         ValidateUtils.checkNullParameter(jcl == null, "jcl is null");
         ValidateUtils.checkIllegalParameter(jcl.isBlank(), "jcl not specified");
         this.jcl = Optional.of(jcl);
@@ -77,8 +77,8 @@ public class SubmitJclParams {
      * @param jclSymbols          Map of JCL symbolic substitution
      * @author Frank Giordano
      */
-    public SubmitJclParams(String jcl, String internalReaderRecfm, String internalReaderLrecl,
-                           Map<String, String> jclSymbols) {
+    public SubmitJclParams(final String jcl, final String internalReaderRecfm, final String internalReaderLrecl,
+                           final Map<String, String> jclSymbols) {
         ValidateUtils.checkNullParameter(jcl == null, "jcl is null");
         ValidateUtils.checkIllegalParameter(jcl.isBlank(), "jcl not specified");
         this.jcl = Optional.of(jcl);
@@ -105,7 +105,7 @@ public class SubmitJclParams {
      *                            An integer value that specifies the internal reader logical record length (LRECL).
      * @author Frank Giordano
      */
-    public void setInternalReaderLrecl(String internalReaderLrecl) {
+    public void setInternalReaderLrecl(final String internalReaderLrecl) {
         this.internalReaderLrecl = Optional.ofNullable(internalReaderLrecl);
     }
 
@@ -127,7 +127,7 @@ public class SubmitJclParams {
      *                            A single character that specifies the internal reader record format: F or V.
      * @author Frank Giordano
      */
-    public void setInternalReaderRecfm(String internalReaderRecfm) {
+    public void setInternalReaderRecfm(final String internalReaderRecfm) {
         this.internalReaderRecfm = Optional.ofNullable(internalReaderRecfm);
     }
 
@@ -141,7 +141,7 @@ public class SubmitJclParams {
         return jcl;
     }
 
-    public void setJcl(String jcl) {
+    public void setJcl(final String jcl) {
         this.jcl = Optional.ofNullable(jcl);
     }
 
@@ -161,7 +161,7 @@ public class SubmitJclParams {
      * @param jclSymbols Map of JCL symbolic substitution
      * @author Frank Giordano
      */
-    public void setJclSymbols(Map<String, String> jclSymbols) {
+    public void setJclSymbols(final Map<String, String> jclSymbols) {
         this.jclSymbols = Optional.ofNullable(jclSymbols);
     }
 

--- a/src/main/java/zowe/client/sdk/zosjobs/input/SubmitJobParams.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/input/SubmitJobParams.java
@@ -41,7 +41,7 @@ public class SubmitJobParams {
      * @param jobDataSet z/OS data set which should contain syntactically correct JCL
      * @author Frank Giordano
      */
-    public SubmitJobParams(String jobDataSet) {
+    public SubmitJobParams(final String jobDataSet) {
         this.jobDataSet = Optional.ofNullable(jobDataSet);
     }
 
@@ -52,7 +52,7 @@ public class SubmitJobParams {
      * @param jclSymbols Map for JCL symbolic substitution
      * @author Frank Giordano
      */
-    public SubmitJobParams(String jobDataSet, Map<String, String> jclSymbols) {
+    public SubmitJobParams(final String jobDataSet, final Map<String, String> jclSymbols) {
         ValidateUtils.checkNullParameter(jobDataSet == null, "jobDataSet is null");
         ValidateUtils.checkIllegalParameter(jobDataSet.isEmpty(), "jobDataSet not specified");
         this.jobDataSet = Optional.of(jobDataSet);
@@ -75,7 +75,7 @@ public class SubmitJobParams {
      * @param jclSymbols Map for JCL symbolic substitution
      * @author Frank Giordano
      */
-    public void setJclSymbols(Map<String, String> jclSymbols) {
+    public void setJclSymbols(final Map<String, String> jclSymbols) {
         this.jclSymbols = Optional.ofNullable(jclSymbols);
     }
 
@@ -95,7 +95,7 @@ public class SubmitJobParams {
      * @param jobDataSet z/OS data set which should contain syntactically correct JCL
      * @author Frank Giordano
      */
-    public void setJobDataSet(String jobDataSet) {
+    public void setJobDataSet(final String jobDataSet) {
         this.jobDataSet = Optional.ofNullable(jobDataSet);
     }
 

--- a/src/main/java/zowe/client/sdk/zosjobs/methods/JobCancel.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/methods/JobCancel.java
@@ -46,7 +46,7 @@ public class JobCancel {
      * @param connection connection information, see ZOSConnection object
      * @author Nikunj Goyal
      */
-    public JobCancel(ZosConnection connection) {
+    public JobCancel(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
     }
@@ -60,7 +60,7 @@ public class JobCancel {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public JobCancel(ZosConnection connection, ZoweRequest request) throws Exception {
+    public JobCancel(final ZosConnection connection, final ZoweRequest request) throws Exception {
         ValidateUtils.checkConnection(connection);
         ValidateUtils.checkNullParameter(request == null, "request is null");
         this.connection = connection;
@@ -84,7 +84,7 @@ public class JobCancel {
      * @throws Exception error canceling
      * @author Nikunj goyal
      */
-    public Response cancel(String jobName, String jobId, String version) throws Exception {
+    public Response cancel(final String jobName, final String jobId, final String version) throws Exception {
         return this.cancelCommon(new ModifyJobParams.Builder(jobName, jobId).version(version).build());
     }
 
@@ -101,7 +101,7 @@ public class JobCancel {
      * @throws Exception error canceling
      * @author Frank Giordano
      */
-    public Response cancelByJob(Job job, String version) throws Exception {
+    public Response cancelByJob(final Job job, final String version) throws Exception {
         return this.cancelCommon(
                 new ModifyJobParams.Builder(job.getJobName().orElse(""), job.getJobId().orElse(""))
                         .version(version)
@@ -117,7 +117,7 @@ public class JobCancel {
      * @author Nikunj Goyal
      * @author Frank Giordano
      */
-    public Response cancelCommon(ModifyJobParams params) throws Exception {
+    public Response cancelCommon(final ModifyJobParams params) throws Exception {
         ValidateUtils.checkNullParameter(params == null, "params is null");
 
         // generate full url request

--- a/src/main/java/zowe/client/sdk/zosjobs/methods/JobDelete.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/methods/JobDelete.java
@@ -42,7 +42,7 @@ public class JobDelete {
      * @param connection connection information, see ZOSConnection object
      * @author Nikunj Goyal
      */
-    public JobDelete(ZosConnection connection) {
+    public JobDelete(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
     }
@@ -56,7 +56,7 @@ public class JobDelete {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public JobDelete(ZosConnection connection, ZoweRequest request) throws Exception {
+    public JobDelete(final ZosConnection connection, final ZoweRequest request) throws Exception {
         ValidateUtils.checkConnection(connection);
         ValidateUtils.checkNullParameter(request == null, "request is null");
         this.connection = connection;
@@ -76,7 +76,7 @@ public class JobDelete {
      * @throws Exception error deleting
      * @author Nikunj goyal
      */
-    public Response delete(String jobName, String jobId, String version) throws Exception {
+    public Response delete(final String jobName, final String jobId, final String version) throws Exception {
         return deleteCommon(new ModifyJobParams.Builder(jobName, jobId).version(version).build());
     }
 
@@ -89,7 +89,7 @@ public class JobDelete {
      * @author Nikunj Goyal
      * @author Frank Giordano
      */
-    public Response deleteCommon(ModifyJobParams params) throws Exception {
+    public Response deleteCommon(final ModifyJobParams params) throws Exception {
         ValidateUtils.checkNullParameter(params == null, "params is null");
 
         final String url = "https://" + connection.getHost() + ":" + connection.getZosmfPort() + JobsConstants.RESOURCE +
@@ -139,7 +139,7 @@ public class JobDelete {
      * @throws Exception error deleting
      * @author Frank Giordano
      */
-    public Response deleteByJob(Job job, String version) throws Exception {
+    public Response deleteByJob(final Job job, final String version) throws Exception {
         return this.deleteCommon(
                 new ModifyJobParams.Builder(job.getJobName().orElse(""), job.getJobId().orElse(""))
                         .version(version)

--- a/src/main/java/zowe/client/sdk/zosjobs/methods/JobGet.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/methods/JobGet.java
@@ -50,7 +50,7 @@ public class JobGet {
      * @param connection connection information, see ZOSConnection object
      * @author Frank Giordano
      */
-    public JobGet(ZosConnection connection) {
+    public JobGet(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
     }
@@ -63,7 +63,7 @@ public class JobGet {
      * @param request    any compatible ZoweRequest Interface object
      * @author Frank Giordano
      */
-    public JobGet(ZosConnection connection, ZoweRequest request) {
+    public JobGet(final ZosConnection connection, final ZoweRequest request) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
         this.request = request;
@@ -78,7 +78,7 @@ public class JobGet {
      * @throws Exception error on getting jcl content
      * @author Frank Giordano
      */
-    public String getJcl(String jobName, String jobId) throws Exception {
+    public String getJcl(final String jobName, final String jobId) throws Exception {
         return getJclCommon(new CommonJobParams(jobId, jobName));
     }
 
@@ -92,7 +92,7 @@ public class JobGet {
      * @throws Exception error on getting jcl content
      * @author Frank Giordano
      */
-    public String getJclByJob(Job job) throws Exception {
+    public String getJclByJob(final Job job) throws Exception {
         ValidateUtils.checkNullParameter(job == null, "job is null");
         return getJclCommon(new CommonJobParams(job.getJobId().orElse(""), job.getJobName().orElse("")));
     }
@@ -105,7 +105,7 @@ public class JobGet {
      * @throws Exception error on getting jcl content
      * @author Frank Giordano
      */
-    public String getJclCommon(CommonJobParams params) throws Exception {
+    public String getJclCommon(final CommonJobParams params) throws Exception {
         ValidateUtils.checkNullParameter(params == null, "params is null");
 
         url = "https://" + connection.getHost() + ":" + connection.getZosmfPort() + JobsConstants.RESOURCE + "/" +
@@ -133,7 +133,7 @@ public class JobGet {
      * @throws Exception error on getting job
      * @author Frank Giordano
      */
-    public Job getById(String jobId) throws Exception {
+    public Job getById(final String jobId) throws Exception {
         final List<Job> jobs = getCommon(new GetJobParams.Builder("*").jobId(jobId).build());
         if (jobs.isEmpty()) {
             throw new IllegalStateException("job not found");
@@ -164,7 +164,7 @@ public class JobGet {
      * @throws Exception error on getting a list of jobs
      * @author Frank Giordano
      */
-    public List<Job> getByOwner(String owner) throws Exception {
+    public List<Job> getByOwner(final String owner) throws Exception {
         return getCommon(new GetJobParams.Builder(owner).build());
     }
 
@@ -179,7 +179,7 @@ public class JobGet {
      * @throws Exception error on getting a list of jobs
      * @author Frank Giordano
      */
-    public List<Job> getByOwnerAndPrefix(String owner, String prefix) throws Exception {
+    public List<Job> getByOwnerAndPrefix(final String owner, final String prefix) throws Exception {
         return getCommon(new GetJobParams.Builder(owner).prefix(prefix).build());
     }
 
@@ -191,7 +191,7 @@ public class JobGet {
      * @throws Exception error on getting a list of jobs
      * @author Frank Giordano
      */
-    public List<Job> getByPrefix(String prefix) throws Exception {
+    public List<Job> getByPrefix(final String prefix) throws Exception {
         return getCommon(new GetJobParams.Builder("*").prefix(prefix).build());
     }
 
@@ -204,7 +204,7 @@ public class JobGet {
      * @author Frank Giordano
      */
     @SuppressWarnings("unchecked")
-    public List<Job> getCommon(GetJobParams params) throws Exception {
+    public List<Job> getCommon(final GetJobParams params) throws Exception {
         List<Job> jobs = new ArrayList<>();
 
         url = "https://" + connection.getHost() + ":" + connection.getZosmfPort()
@@ -264,7 +264,7 @@ public class JobGet {
      * @throws Exception error on getting spool content
      * @author Frank Giordano
      */
-    public String getSpoolContent(JobFile jobFile) throws Exception {
+    public String getSpoolContent(final JobFile jobFile) throws Exception {
         return getSpoolContentCommon(jobFile);
     }
 
@@ -278,7 +278,7 @@ public class JobGet {
      * @throws Exception error on getting spool content
      * @author Frank Giordano
      */
-    public String getSpoolContent(String jobName, String jobId, int spoolId) throws Exception {
+    public String getSpoolContent(final String jobName, final String jobId, final int spoolId) throws Exception {
         ValidateUtils.checkIllegalParameter(spoolId <= 0, "spool id not specified");
 
         CommonJobParams params = new CommonJobParams(jobId, jobName);
@@ -306,7 +306,7 @@ public class JobGet {
      * @throws Exception error on getting spool content
      * @author Frank Giordano
      */
-    public String getSpoolContentCommon(JobFile jobFile) throws Exception {
+    public String getSpoolContentCommon(final JobFile jobFile) throws Exception {
         ValidateUtils.checkNullParameter(jobFile == null, "jobFile is null");
 
         url = "https://" + connection.getHost() + ":" + connection.getZosmfPort() + JobsConstants.RESOURCE + "/" +
@@ -336,7 +336,7 @@ public class JobGet {
      * @throws Exception error on getting spool files info
      * @author Frank Giordano
      */
-    public List<JobFile> getSpoolFiles(String jobName, String jobId) throws Exception {
+    public List<JobFile> getSpoolFiles(final String jobName, final String jobId) throws Exception {
         return getSpoolFilesCommon(new CommonJobParams(jobId, jobName));
     }
 
@@ -349,7 +349,7 @@ public class JobGet {
      * @author Frank Giordano
      */
     @SuppressWarnings("unchecked")
-    public List<JobFile> getSpoolFilesCommon(CommonJobParams params) throws Exception {
+    public List<JobFile> getSpoolFilesCommon(final CommonJobParams params) throws Exception {
         ValidateUtils.checkNullParameter(params == null, "params is null");
 
         url = "https://" + connection.getHost() + ":" + connection.getZosmfPort() + JobsConstants.RESOURCE + "/" +
@@ -391,9 +391,10 @@ public class JobGet {
      * @throws Exception error on getting spool files info
      * @author Frank Giordano
      */
-    public List<JobFile> getSpoolFilesByJob(Job job) throws Exception {
+    public List<JobFile> getSpoolFilesByJob(final Job job) throws Exception {
         ValidateUtils.checkNullParameter(job == null, "job is null");
-        return getSpoolFilesCommon(new CommonJobParams(job.getJobId().orElse(""), job.getJobName().orElse("")));
+        return getSpoolFilesCommon(new CommonJobParams(job.getJobId().orElse(""),
+                job.getJobName().orElse("")));
     }
 
     /**
@@ -405,7 +406,7 @@ public class JobGet {
      * @throws Exception error getting job status
      * @author Frank Giordano
      */
-    public Job getStatus(String jobName, String jobId) throws Exception {
+    public Job getStatus(final String jobName, final String jobId) throws Exception {
         return getStatusCommon(new CommonJobParams(jobId, jobName, true));
     }
 
@@ -417,7 +418,7 @@ public class JobGet {
      * @throws Exception error getting job status
      * @author Frank Giordano
      */
-    public Job getStatusCommon(CommonJobParams params) throws Exception {
+    public Job getStatusCommon(final CommonJobParams params) throws Exception {
         ValidateUtils.checkNullParameter(params == null, "params is null");
 
         url = "https://" + connection.getHost() + ":" + connection.getZosmfPort() + JobsConstants.RESOURCE + "/" +
@@ -452,10 +453,10 @@ public class JobGet {
      * @throws Exception error getting job status
      * @author Frank Giordano
      */
-    public Job getStatusByJob(Job job) throws Exception {
+    public Job getStatusByJob(final Job job) throws Exception {
         ValidateUtils.checkNullParameter(job == null, "job is null");
-        return getStatusCommon(
-                new CommonJobParams(job.getJobId().orElse(""), job.getJobName().orElse(""), true));
+        return getStatusCommon(new CommonJobParams(job.getJobId().orElse(""),
+                job.getJobName().orElse(""), true));
     }
 
     /**
@@ -467,7 +468,7 @@ public class JobGet {
      * @throws Exception error getting job status
      * @author Frank Giordano
      */
-    public String getStatusValue(String jobName, String jobId) throws Exception {
+    public String getStatusValue(final String jobName, final String jobId) throws Exception {
         final Job job = getStatusCommon(new CommonJobParams(jobId, jobName));
         return job.getStatus().orElseThrow(() -> new IllegalStateException("job status not returned"));
     }
@@ -480,10 +481,10 @@ public class JobGet {
      * @throws Exception error getting job status
      * @author Frank Giordano
      */
-    public String getStatusValueByJob(Job job) throws Exception {
+    public String getStatusValueByJob(final Job job) throws Exception {
         ValidateUtils.checkNullParameter(job == null, "job is null");
-        final Job result = getStatusCommon(
-                new CommonJobParams(job.getJobId().orElse(""), job.getJobName().orElse("")));
+        final Job result = getStatusCommon(new CommonJobParams(job.getJobId().orElse(""),
+                job.getJobName().orElse("")));
         return result.getStatus().orElseThrow(() -> new IllegalStateException("job status not returned"));
     }
 

--- a/src/main/java/zowe/client/sdk/zosjobs/methods/JobGet.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/methods/JobGet.java
@@ -15,7 +15,6 @@ import org.json.simple.parser.JSONParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zowe.client.sdk.core.ZosConnection;
-import zowe.client.sdk.parse.JsonParseResponse;
 import zowe.client.sdk.parse.JsonParseResponseFactory;
 import zowe.client.sdk.parse.type.ParseType;
 import zowe.client.sdk.rest.*;
@@ -249,10 +248,9 @@ public class JobGet {
         final String jsonStr = RestUtils.getResponse(request).getResponsePhrase()
                 .orElseThrow(() -> new IllegalStateException("no get job response phrase")).toString();
         final JSONArray results = (JSONArray) new JSONParser().parse(jsonStr);
-        for (final Object itemJsonObj : results) {
-            final JsonParseResponse parser = JsonParseResponseFactory
-                    .buildParser((JSONObject) itemJsonObj, ParseType.JOB);
-            jobs.add((Job) parser.parseResponse());
+        for (final Object jsonObj : results) {
+            jobs.add((Job) JsonParseResponseFactory.buildParser(ParseType.JOB)
+                    .setJsonObject((JSONObject) jsonObj).parseResponse());
         }
 
         return jobs;
@@ -376,8 +374,8 @@ public class JobGet {
         final JSONArray results = (JSONArray) new JSONParser().parse(jsonStr);
         for (final Object obj : results) {
             final JSONObject jsonObj = (JSONObject) obj;
-            final JsonParseResponse parser = JsonParseResponseFactory.buildParser(jsonObj, ParseType.JOB_FILE);
-            files.add((JobFile) parser.parseResponse());
+            files.add((JobFile) JsonParseResponseFactory.buildParser(ParseType.JOB_FILE).
+                    setJsonObject(jsonObj).parseResponse());
         }
 
         return files;
@@ -439,8 +437,7 @@ public class JobGet {
         final String jsonStr = RestUtils.getResponse(request).getResponsePhrase()
                 .orElseThrow(() -> new IllegalStateException("no job get response phrase")).toString();
         final JSONObject jsonObject = (JSONObject) new JSONParser().parse(jsonStr);
-        final JsonParseResponse parser = JsonParseResponseFactory.buildParser(jsonObject, ParseType.JOB);
-        return (Job) parser.parseResponse();
+        return (Job) JsonParseResponseFactory.buildParser(ParseType.JOB).setJsonObject(jsonObject).parseResponse();
     }
 
     /**

--- a/src/main/java/zowe/client/sdk/zosjobs/methods/JobMonitor.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/methods/JobMonitor.java
@@ -65,7 +65,7 @@ public class JobMonitor {
      * @param connection connection information, see ZOSConnection object
      * @author Frank Giordano
      */
-    public JobMonitor(ZosConnection connection) {
+    public JobMonitor(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
     }
@@ -77,7 +77,7 @@ public class JobMonitor {
      * @param attempts   number of attempts to get status
      * @author Frank Giordano
      */
-    public JobMonitor(ZosConnection connection, int attempts) {
+    public JobMonitor(final ZosConnection connection, final int attempts) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
         this.attempts = attempts;
@@ -91,7 +91,7 @@ public class JobMonitor {
      * @param watchDelay delay time in milliseconds to wait each time requesting status
      * @author Frank Giordano
      */
-    public JobMonitor(ZosConnection connection, int attempts, int watchDelay) {
+    public JobMonitor(final ZosConnection connection, final int attempts, final int watchDelay) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
         this.attempts = attempts;
@@ -107,7 +107,7 @@ public class JobMonitor {
      * @param lineLimit  number of line to inspect job output
      * @author Frank Giordano
      */
-    public JobMonitor(ZosConnection connection, int attempts, int watchDelay, int lineLimit) {
+    public JobMonitor(final ZosConnection connection, final int attempts, final int watchDelay, final int lineLimit) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
         this.attempts = attempts;
@@ -124,7 +124,7 @@ public class JobMonitor {
      * @throws Exception error processing check request
      * @author Frank Giordano
      */
-    private boolean checkMessage(MonitorJobWaitForParams params, String message) throws Exception {
+    private boolean checkMessage(final MonitorJobWaitForParams params, final String message) throws Exception {
         final JobGet getJobs = new JobGet(connection);
         final GetJobParams filter =
                 new GetJobParams.Builder("*")
@@ -164,7 +164,7 @@ public class JobMonitor {
      * @throws Exception error processing check request
      * @author Frank Giordano
      */
-    private CheckJobStatus checkStatus(MonitorJobWaitForParams params) throws Exception {
+    private CheckJobStatus checkStatus(final MonitorJobWaitForParams params) throws Exception {
         return checkStatus(params, false);
     }
 
@@ -176,12 +176,13 @@ public class JobMonitor {
      * @throws Exception error processing check request
      * @author Frank Giordano
      */
-    private CheckJobStatus checkStatus(MonitorJobWaitForParams params, boolean getStepData) throws Exception {
+    private CheckJobStatus checkStatus(final MonitorJobWaitForParams params, final boolean isStepData)
+            throws Exception {
         final JobGet getJobs = new JobGet(connection);
         final String statusNameCheck = params.getJobStatus().orElse(DEFAULT_STATUS).toString();
 
         final Job job = getJobs.getStatusCommon(
-                new CommonJobParams(params.getJobId().orElse(""), params.getJobName().orElse(""), getStepData));
+                new CommonJobParams(params.getJobId().orElse(""), params.getJobName().orElse(""), isStepData));
 
         if (statusNameCheck.equals(job.getStatus().orElse(DEFAULT_STATUS.toString()))) {
             return new CheckJobStatus(true, job);
@@ -213,7 +214,7 @@ public class JobMonitor {
      * @return int index of status order or -1 if none found
      * @author Frank Giordano
      */
-    private int getOrderIndexOfStatus(String statusName) {
+    private int getOrderIndexOfStatus(final String statusName) {
         for (int i = 0; i < JobStatus.Order.length; i++) {
             if (statusName.equals(JobStatus.Order[i])) {
                 return i;
@@ -230,7 +231,7 @@ public class JobMonitor {
      * @throws Exception error processing running status check
      * @author Frank Giordano
      */
-    public boolean isRunning(MonitorJobWaitForParams params) throws Exception {
+    public boolean isRunning(final MonitorJobWaitForParams params) throws Exception {
         ValidateUtils.checkNullParameter(params == null, "params is null");
         final JobGet getJobs = new JobGet(connection);
         final String jobName = params.getJobName()
@@ -250,7 +251,7 @@ public class JobMonitor {
      * @throws Exception error processing poll check request
      * @author Frank Giordano
      */
-    private boolean pollByMessage(MonitorJobWaitForParams params, String message) throws Exception {
+    private boolean pollByMessage(final MonitorJobWaitForParams params, final String message) throws Exception {
         final int timeoutVal = params.getWatchDelay().orElse(DEFAULT_WATCH_DELAY);
         boolean messageFound;  // no assigment boolean means by default it is false
         boolean shouldContinue;
@@ -286,7 +287,7 @@ public class JobMonitor {
      * @throws Exception error processing poll check request
      * @author Frank Giordano
      */
-    private Job pollByStatus(MonitorJobWaitForParams params) throws Exception {
+    private Job pollByStatus(final MonitorJobWaitForParams params) throws Exception {
         final int timeoutVal = params.getWatchDelay().orElse(DEFAULT_WATCH_DELAY);
         boolean expectedStatus;  // no assigment boolean means by default it is false
         boolean shouldContinue;
@@ -338,7 +339,7 @@ public class JobMonitor {
      * @throws Exception error processing wait check request
      * @author Frank Giordano
      */
-    public boolean waitByMessage(Job job, String message) throws Exception {
+    public boolean waitByMessage(final Job job, final String message) throws Exception {
         ValidateUtils.checkNullParameter(job == null, "job is null");
         return waitMessageCommon(
                 new MonitorJobWaitForParams.Builder(job.getJobName().orElse(""), job.getJobId().orElse(""))
@@ -362,7 +363,7 @@ public class JobMonitor {
      * @throws Exception error processing wait check request
      * @author Frank Giordano
      */
-    public boolean waitByMessage(String jobName, String jobId, String message) throws Exception {
+    public boolean waitByMessage(final String jobName, final String jobId, final String message) throws Exception {
         return waitMessageCommon(
                 new MonitorJobWaitForParams.Builder(jobName, jobId)
                         .jobStatus(JobStatus.Type.OUTPUT)
@@ -383,7 +384,7 @@ public class JobMonitor {
      * @throws Exception error processing wait check request
      * @author Frank Giordano
      */
-    public Job waitByOutputStatus(Job job) throws Exception {
+    public Job waitByOutputStatus(final Job job) throws Exception {
         ValidateUtils.checkNullParameter(job == null, "job is null");
         return waitStatusCommon(
                 new MonitorJobWaitForParams.Builder(job.getJobName().orElse(""), job.getJobId().orElse(""))
@@ -406,7 +407,7 @@ public class JobMonitor {
      * @throws Exception error processing wait check request
      * @author Frank Giordano
      */
-    public Job waitByOutputStatus(String jobName, String jobId) throws Exception {
+    public Job waitByOutputStatus(final String jobName, final String jobId) throws Exception {
         return waitStatusCommon(
                 new MonitorJobWaitForParams.Builder(jobName, jobId)
                         .jobStatus(JobStatus.Type.OUTPUT)
@@ -427,7 +428,7 @@ public class JobMonitor {
      * @throws Exception error processing wait check request
      * @author Frank Giordano
      */
-    public Job waitByStatus(Job job, JobStatus.Type statusType) throws Exception {
+    public Job waitByStatus(final Job job, final JobStatus.Type statusType) throws Exception {
         ValidateUtils.checkNullParameter(job == null, "job is null");
         return waitStatusCommon(
                 new MonitorJobWaitForParams.Builder(job.getJobName().orElse(""), job.getJobId().orElse(""))
@@ -451,7 +452,8 @@ public class JobMonitor {
      * @throws Exception error processing wait check request
      * @author Frank Giordano
      */
-    public Job waitByStatus(String jobName, String jobId, JobStatus.Type statusType) throws Exception {
+    public Job waitByStatus(final String jobName, final String jobId, final JobStatus.Type statusType)
+            throws Exception {
         return waitStatusCommon(
                 new MonitorJobWaitForParams.Builder(jobName, jobId)
                         .jobStatus(statusType)
@@ -469,7 +471,7 @@ public class JobMonitor {
      * @throws Exception error processing wait check request
      * @author Frank Giordano
      */
-    public boolean waitMessageCommon(MonitorJobWaitForParams params, String message) throws Exception {
+    public boolean waitMessageCommon(final MonitorJobWaitForParams params, final String message) throws Exception {
         ValidateUtils.checkNullParameter(params == null, "params is null");
         ValidateUtils.checkIllegalParameter(params.getJobName().isEmpty(), JobsConstants.JOB_NAME_ERROR_MSG);
         ValidateUtils.checkIllegalParameter(params.getJobId().isEmpty(), JobsConstants.JOB_ID_ERROR_MSG);
@@ -499,7 +501,7 @@ public class JobMonitor {
      * @throws Exception error processing wait check request
      * @author Frank Giordano
      */
-    public Job waitStatusCommon(MonitorJobWaitForParams params) throws Exception {
+    public Job waitStatusCommon(final MonitorJobWaitForParams params) throws Exception {
         ValidateUtils.checkNullParameter(params == null, "params is null");
         ValidateUtils.checkIllegalParameter(params.getJobName().isEmpty(), JobsConstants.JOB_NAME_ERROR_MSG);
         ValidateUtils.checkIllegalParameter(params.getJobId().isEmpty(), JobsConstants.JOB_ID_ERROR_MSG);

--- a/src/main/java/zowe/client/sdk/zosjobs/methods/JobSubmit.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/methods/JobSubmit.java
@@ -14,7 +14,6 @@ import org.json.simple.parser.JSONParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zowe.client.sdk.core.ZosConnection;
-import zowe.client.sdk.parse.JsonParseResponse;
 import zowe.client.sdk.parse.JsonParseResponseFactory;
 import zowe.client.sdk.parse.type.ParseType;
 import zowe.client.sdk.rest.*;
@@ -136,8 +135,7 @@ public class JobSubmit {
         final String jsonStr = RestUtils.getResponse(request).getResponsePhrase()
                 .orElseThrow(() -> new IllegalStateException("no job jcl submit response phrase")).toString();
         final JSONObject jsonObject = (JSONObject) new JSONParser().parse(jsonStr);
-        final JsonParseResponse parser = JsonParseResponseFactory.buildParser(jsonObject, ParseType.JOB);
-        return (Job) parser.parseResponse();
+        return (Job) JsonParseResponseFactory.buildParser(ParseType.JOB).setJsonObject(jsonObject).parseResponse();
     }
 
     /**
@@ -183,8 +181,7 @@ public class JobSubmit {
         final String jsonStr = RestUtils.getResponse(request).getResponsePhrase()
                 .orElseThrow(() -> new IllegalStateException("no job submit response phrase")).toString();
         final JSONObject jsonObject = (JSONObject) new JSONParser().parse(jsonStr);
-        final JsonParseResponse parser = JsonParseResponseFactory.buildParser(jsonObject, ParseType.JOB);
-        return (Job) parser.parseResponse();
+        return (Job) JsonParseResponseFactory.buildParser(ParseType.JOB).setJsonObject(jsonObject).parseResponse();
     }
 
     /**

--- a/src/main/java/zowe/client/sdk/zosjobs/methods/JobSubmit.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/methods/JobSubmit.java
@@ -47,7 +47,7 @@ public class JobSubmit {
      * @param connection connection information, see ZOSConnection object
      * @author Frank Giordano
      */
-    public JobSubmit(ZosConnection connection) {
+    public JobSubmit(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
     }
@@ -60,7 +60,7 @@ public class JobSubmit {
      * @param request    any compatible ZoweRequest Interface object
      * @author Frank Giordano
      */
-    public JobSubmit(ZosConnection connection, ZoweRequest request) {
+    public JobSubmit(final ZosConnection connection, final ZoweRequest request) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
         this.request = request;
@@ -76,7 +76,8 @@ public class JobSubmit {
      * @throws Exception error on submitting
      * @author Frank Giordano
      */
-    public Job submitByJcl(String jcl, String internalReaderRecfm, String internalReaderLrecl) throws Exception {
+    public Job submitByJcl(final String jcl, final String internalReaderRecfm, final String internalReaderLrecl)
+            throws Exception {
         return this.submitJclCommon(new SubmitJclParams(jcl, internalReaderRecfm, internalReaderLrecl));
     }
 
@@ -88,7 +89,7 @@ public class JobSubmit {
      * @throws Exception error on submitting
      * @author Frank Giordano
      */
-    public Job submitJclCommon(SubmitJclParams params) throws Exception {
+    public Job submitJclCommon(final SubmitJclParams params) throws Exception {
         ValidateUtils.checkNullParameter(params == null, "params is null");
 
         String key, value;
@@ -146,7 +147,7 @@ public class JobSubmit {
      * @throws Exception error on submitting
      * @author Frank Giordano
      */
-    public Job submit(String jobDataSet) throws Exception {
+    public Job submit(final String jobDataSet) throws Exception {
         return this.submitCommon(new SubmitJobParams(jobDataSet));
     }
 
@@ -158,7 +159,7 @@ public class JobSubmit {
      * @throws Exception error on submitting
      * @author Frank Giordano
      */
-    public Job submitCommon(SubmitJobParams params) throws Exception {
+    public Job submitCommon(final SubmitJobParams params) throws Exception {
         ValidateUtils.checkNullParameter(params == null, "params is null");
 
         final String url = "https://" + connection.getHost() + ":" + connection.getZosmfPort() + JobsConstants.RESOURCE;
@@ -189,10 +190,9 @@ public class JobSubmit {
      *
      * @param keyValues Map containing JCL substitution symbols e.g.: "{"SYMBOL","SYM"},{"SYMBOL2","SYM2"}
      * @return String Map containing all keys and values
-     * @throws Exception error on submitting
      * @author Corinne DeStefano
      */
-    private Map<String, String> getSubstitutionHeaders(Map<String, String> keyValues) throws Exception {
+    private Map<String, String> getSubstitutionHeaders(final Map<String, String> keyValues) {
         final Map<String, String> symbolMap = new HashMap<>();
 
         // Check for matching quotes

--- a/src/main/java/zowe/client/sdk/zosjobs/response/CheckJobStatus.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/response/CheckJobStatus.java
@@ -35,7 +35,7 @@ public class CheckJobStatus {
      * @param job         job used for status checking
      * @author Frank Giordano
      */
-    public CheckJobStatus(boolean statusFound, Job job) {
+    public CheckJobStatus(final boolean statusFound, final Job job) {
         this.statusFound = statusFound;
         this.job = job;
     }
@@ -51,9 +51,9 @@ public class CheckJobStatus {
     }
 
     /**
-     * Retrieve statusFound specified
+     * Retrieve is statusFound specified
      *
-     * @return true or false value
+     * @return boolean true or false
      * @author Frank Giordano
      */
     public boolean isStatusFound() {

--- a/src/main/java/zowe/client/sdk/zosjobs/response/Job.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/response/Job.java
@@ -91,7 +91,7 @@ public class Job {
      */
     private final Optional<String> phaseName;
 
-    private Job(Job.Builder builder) {
+    private Job(final Job.Builder builder) {
         this.jobId = Optional.ofNullable(builder.jobId);
         this.jobName = Optional.ofNullable(builder.jobName);
         this.subSystem = Optional.ofNullable(builder.subSystem);
@@ -293,72 +293,72 @@ public class Job {
             return new Job(this);
         }
 
-        public Builder classs(String classs) {
+        public Builder classs(final String classs) {
             this.classs = classs;
             return this;
         }
 
-        public Builder filesUrl(String filesUrl) {
+        public Builder filesUrl(final String filesUrl) {
             this.filesUrl = filesUrl;
             return this;
         }
 
-        public Builder jobCorrelator(String jobCorrelator) {
+        public Builder jobCorrelator(final String jobCorrelator) {
             this.jobCorrelator = jobCorrelator;
             return this;
         }
 
-        public Builder jobId(String jobId) {
+        public Builder jobId(final String jobId) {
             this.jobId = jobId;
             return this;
         }
 
-        public Builder jobName(String jobName) {
+        public Builder jobName(final String jobName) {
             this.jobName = jobName;
             return this;
         }
 
-        public Builder owner(String owner) {
+        public Builder owner(final String owner) {
             this.owner = owner;
             return this;
         }
 
-        public Builder phase(Long phase) {
+        public Builder phase(final Long phase) {
             this.phase = phase;
             return this;
         }
 
-        public Builder phaseName(String phaseName) {
+        public Builder phaseName(final String phaseName) {
             this.phaseName = phaseName;
             return this;
         }
 
-        public Builder retCode(String retCode) {
+        public Builder retCode(final String retCode) {
             this.retCode = retCode;
             return this;
         }
 
-        public Builder status(String status) {
+        public Builder status(final String status) {
             this.status = status;
             return this;
         }
 
-        public Builder stepData(JobStepData[] stepData) {
+        public Builder stepData(final JobStepData[] stepData) {
             this.stepData = stepData;
             return this;
         }
 
-        public Builder subSystem(String subSystem) {
+        public Builder subSystem(final String subSystem) {
             this.subSystem = subSystem;
             return this;
         }
 
-        public Builder type(String type) {
+        public Builder type(final String type) {
             this.type = type;
             return this;
         }
 
-        public Builder url(String url) {
+        public Builder url(final String url) {
             this.url = url;
             return this;
         }

--- a/src/main/java/zowe/client/sdk/zosjobs/response/JobStepData.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/response/JobStepData.java
@@ -33,7 +33,7 @@ public class JobStepData {
     /**
      * Active
      */
-    private final Optional<Boolean> active;
+    private final boolean active;
 
     /**
      * Job relevant step
@@ -55,10 +55,10 @@ public class JobStepData {
      */
     private final Optional<String> programName;
 
-    private JobStepData(JobStepData.Builder builder) {
+    private JobStepData(final JobStepData.Builder builder) {
         this.smfid = Optional.ofNullable(builder.smfid);
         this.completion = Optional.ofNullable(builder.completion);
-        this.active = Optional.of(builder.active);
+        this.active = builder.active;
         if (builder.stepNumber == null) {
             this.stepNumber = OptionalLong.empty();
         } else {
@@ -69,7 +69,7 @@ public class JobStepData {
         this.programName = Optional.ofNullable(builder.programName);
     }
 
-    public Optional<Boolean> getActive() {
+    public boolean isActive() {
         return active;
     }
 
@@ -114,7 +114,7 @@ public class JobStepData {
 
         private String smfid;
         private String completion;
-        private Boolean active;
+        private boolean active;
         private Long stepNumber;
         private String procStepName;
         private String stepName;
@@ -124,37 +124,37 @@ public class JobStepData {
             return new JobStepData(this);
         }
 
-        public JobStepData.Builder active(Boolean active) {
+        public JobStepData.Builder active(final boolean active) {
             this.active = active;
             return this;
         }
 
-        public JobStepData.Builder completion(String completion) {
+        public JobStepData.Builder completion(final String completion) {
             this.completion = completion;
             return this;
         }
 
-        public JobStepData.Builder procStepName(String procStepName) {
+        public JobStepData.Builder procStepName(final String procStepName) {
             this.procStepName = procStepName;
             return this;
         }
 
-        public JobStepData.Builder programName(String programName) {
+        public JobStepData.Builder programName(final String programName) {
             this.programName = programName;
             return this;
         }
 
-        public JobStepData.Builder smfid(String smfid) {
+        public JobStepData.Builder smfid(final String smfid) {
             this.smfid = smfid;
             return this;
         }
 
-        public JobStepData.Builder stepName(String stepName) {
+        public JobStepData.Builder stepName(final String stepName) {
             this.stepName = stepName;
             return this;
         }
 
-        public JobStepData.Builder stepNumber(Long stepNumber) {
+        public JobStepData.Builder stepNumber(final Long stepNumber) {
             this.stepNumber = stepNumber;
             return this;
         }

--- a/src/main/java/zowe/client/sdk/zoslogs/input/DirectionType.java
+++ b/src/main/java/zowe/client/sdk/zoslogs/input/DirectionType.java
@@ -29,7 +29,7 @@ public enum DirectionType {
 
     private final String value;
 
-    DirectionType(String value) {
+    DirectionType(final String value) {
         this.value = value;
     }
 

--- a/src/main/java/zowe/client/sdk/zoslogs/input/HardCopyType.java
+++ b/src/main/java/zowe/client/sdk/zoslogs/input/HardCopyType.java
@@ -29,7 +29,7 @@ public enum HardCopyType {
 
     private final String value;
 
-    HardCopyType(String value) {
+    HardCopyType(final String value) {
         this.value = value;
     }
 

--- a/src/main/java/zowe/client/sdk/zoslogs/input/ZosLogParams.java
+++ b/src/main/java/zowe/client/sdk/zoslogs/input/ZosLogParams.java
@@ -102,16 +102,16 @@ public class ZosLogParams {
     }
 
     /**
-     * Return process response boolean value.
+     * Is process response specified if so, handle json data differently
      *
-     * @return boolean value
+     * @return boolean true or false
      * @author Frank Giordano
      */
     public boolean isProcessResponses() {
         return processResponses;
     }
 
-    private ZosLogParams(ZosLogParams.Builder builder) {
+    private ZosLogParams(final ZosLogParams.Builder builder) {
         this.startTime = Optional.ofNullable(builder.startTime);
         this.hardCopy = Optional.ofNullable(builder.hardCopy);
         this.direction = Optional.ofNullable(builder.direction);
@@ -141,7 +141,7 @@ public class ZosLogParams {
          * @return ZosLogParams.Builder this object
          * @author Frank Giordano
          */
-        public ZosLogParams.Builder startTime(String startTime) {
+        public ZosLogParams.Builder startTime(final String startTime) {
             this.startTime = startTime;
             return this;
         }
@@ -157,7 +157,7 @@ public class ZosLogParams {
          * @return ZosLogParams.Builder this object
          * @author Frank Giordano
          */
-        public ZosLogParams.Builder hardCopy(HardCopyType hardCopy) {
+        public ZosLogParams.Builder hardCopy(final HardCopyType hardCopy) {
             this.hardCopy = hardCopy;
             return this;
         }
@@ -172,7 +172,7 @@ public class ZosLogParams {
          * @return ZosLogParams.Builder this object
          * @author Frank Giordano
          */
-        public ZosLogParams.Builder direction(DirectionType direction) {
+        public ZosLogParams.Builder direction(final DirectionType direction) {
             this.direction = direction;
             return this;
         }
@@ -188,7 +188,7 @@ public class ZosLogParams {
          * @return ZosLogParams.Builder this object
          * @author Frank Giordano
          */
-        public ZosLogParams.Builder timeRange(String timeRange) {
+        public ZosLogParams.Builder timeRange(final String timeRange) {
             this.timeRange = timeRange;
             return this;
         }
@@ -203,7 +203,7 @@ public class ZosLogParams {
          * @return ZosLogParams.Builder this object
          * @author Frank Giordano
          */
-        public ZosLogParams.Builder processResponses(boolean processResponses) {
+        public ZosLogParams.Builder processResponses(final boolean processResponses) {
             this.processResponses = processResponses;
             return this;
         }

--- a/src/main/java/zowe/client/sdk/zoslogs/method/ZosLog.java
+++ b/src/main/java/zowe/client/sdk/zoslogs/method/ZosLog.java
@@ -124,13 +124,13 @@ public class ZosLog {
 
         for (Object itemJsonObj : jsonArray) {
             final ZosLogItemParseResponse parser = (ZosLogItemParseResponse) JsonParseResponseFactory
-                    .buildParser((JSONObject) itemJsonObj, ParseType.ZOS_LOG_ITEM);
+                    .buildParser(ParseType.ZOS_LOG_ITEM).setJsonObject((JSONObject) itemJsonObj);
             parser.setProcessResponse(isProcessResponse);
             zosLogItems.add(parser.parseResponse());
         }
 
         final ZosLogReplyParseResponse parser = (ZosLogReplyParseResponse) JsonParseResponseFactory
-                .buildParser(jsonObject, ParseType.ZOS_LOG_REPLY);
+                .buildParser(ParseType.ZOS_LOG_REPLY).setJsonObject(jsonObject);
         parser.setZosLogItems(zosLogItems);
         return parser.parseResponse();
     }

--- a/src/main/java/zowe/client/sdk/zoslogs/method/ZosLog.java
+++ b/src/main/java/zowe/client/sdk/zoslogs/method/ZosLog.java
@@ -54,7 +54,7 @@ public class ZosLog {
      * @param connection connection information, see ZosConnection object
      * @author Frank Giordano
      */
-    public ZosLog(ZosConnection connection) {
+    public ZosLog(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
     }
@@ -68,7 +68,7 @@ public class ZosLog {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public ZosLog(ZosConnection connection, ZoweRequest request) throws Exception {
+    public ZosLog(final ZosConnection connection, final ZoweRequest request) throws Exception {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
         if (!(request instanceof JsonGetRequest)) {
@@ -88,7 +88,7 @@ public class ZosLog {
      * @author Frank Giordano
      */
     @SuppressWarnings("unchecked")
-    public ZosLogReply issueCommand(ZosLogParams params) throws Exception {
+    public ZosLogReply issueCommand(final ZosLogParams params) throws Exception {
         ValidateUtils.checkNullParameter(params == null, "params is null");
 
         final String defaultUrl = "https://" + connection.getHost() + ":" + connection.getZosmfPort() + RESOURCE;
@@ -139,10 +139,10 @@ public class ZosLog {
      * Validate given string in expected date/time string format.
      *
      * @param value string representing a date/time
-     * @return boolean value
+     * @return boolean true or false
      * @author Frank Giordano
      */
-    private static boolean isNotValidDate(String value) {
+    private static boolean isNotValidDate(final String value) {
         //  pattern to match example: 2022-11-27T05:06:20Z
         final String patternStr = ".*[0-9]-.*[0-9]-.*[0-9][T].*[0-9][:]*[0-9][:]*[0-9][Z]";
         final Pattern pattern = Pattern.compile(patternStr);

--- a/src/main/java/zowe/client/sdk/zoslogs/response/ZosLogItem.java
+++ b/src/main/java/zowe/client/sdk/zoslogs/response/ZosLogItem.java
@@ -192,7 +192,7 @@ public class ZosLogItem {
      * @param builder ZosLogItem.Builder Object
      * @author Frank Giordano
      */
-    private ZosLogItem(ZosLogItem.Builder builder) {
+    private ZosLogItem(final ZosLogItem.Builder builder) {
         this.cart = Optional.ofNullable(builder.cart);
         this.color = Optional.ofNullable(builder.color);
         this.jobName = Optional.ofNullable(builder.jobName);
@@ -235,7 +235,7 @@ public class ZosLogItem {
          * @return ZosLogItem.Builder object
          * @author Frank Giordano
          */
-        public ZosLogItem.Builder cart(String cart) {
+        public ZosLogItem.Builder cart(final String cart) {
             this.cart = cart;
             return this;
         }
@@ -247,7 +247,7 @@ public class ZosLogItem {
          * @return ZosLogItem.Builder object
          * @author Frank Giordano
          */
-        public ZosLogItem.Builder color(String color) {
+        public ZosLogItem.Builder color(final String color) {
             this.color = color;
             return this;
         }
@@ -259,7 +259,7 @@ public class ZosLogItem {
          * @return ZosLogItem.Builder object
          * @author Frank Giordano
          */
-        public ZosLogItem.Builder jobName(String jobName) {
+        public ZosLogItem.Builder jobName(final String jobName) {
             this.jobName = jobName;
             return this;
         }
@@ -271,7 +271,7 @@ public class ZosLogItem {
          * @return ZosLogItem.Builder object
          * @author Frank Giordano
          */
-        public ZosLogItem.Builder message(String message) {
+        public ZosLogItem.Builder message(final String message) {
             this.message = message;
             return this;
         }
@@ -283,7 +283,7 @@ public class ZosLogItem {
          * @return ZosLogItem.Builder object
          * @author Frank Giordano
          */
-        public ZosLogItem.Builder messageId(String messageId) {
+        public ZosLogItem.Builder messageId(final String messageId) {
             this.messageId = messageId;
             return this;
         }
@@ -295,7 +295,7 @@ public class ZosLogItem {
          * @return ZosLogItem.Builder object
          * @author Frank Giordano
          */
-        public ZosLogItem.Builder replyId(String replyId) {
+        public ZosLogItem.Builder replyId(final String replyId) {
             this.replyId = replyId;
             return this;
         }
@@ -307,7 +307,7 @@ public class ZosLogItem {
          * @return ZosLogItem.Builder object
          * @author Frank Giordano
          */
-        public ZosLogItem.Builder system(String system) {
+        public ZosLogItem.Builder system(final String system) {
             this.system = system;
             return this;
         }
@@ -319,7 +319,7 @@ public class ZosLogItem {
          * @return ZosLogItem.Builder object
          * @author Frank Giordano
          */
-        public ZosLogItem.Builder type(String type) {
+        public ZosLogItem.Builder type(final String type) {
             this.type = type;
             return this;
         }
@@ -331,7 +331,7 @@ public class ZosLogItem {
          * @return ZosLogItem.Builder object
          * @author Frank Giordano
          */
-        public ZosLogItem.Builder subType(String subType) {
+        public ZosLogItem.Builder subType(final String subType) {
             this.subType = subType;
             return this;
         }
@@ -343,7 +343,7 @@ public class ZosLogItem {
          * @return ZosLogItem.Builder object
          * @author Frank Giordano
          */
-        public ZosLogItem.Builder time(String time) {
+        public ZosLogItem.Builder time(final String time) {
             this.time = time;
             return this;
         }
@@ -355,7 +355,7 @@ public class ZosLogItem {
          * @return ZosLogItem.Builder object
          * @author Frank Giordano
          */
-        public ZosLogItem.Builder timeStamp(long timeStamp) {
+        public ZosLogItem.Builder timeStamp(final long timeStamp) {
             this.timeStamp = timeStamp;
             return this;
         }

--- a/src/main/java/zowe/client/sdk/zoslogs/response/ZosLogReply.java
+++ b/src/main/java/zowe/client/sdk/zoslogs/response/ZosLogReply.java
@@ -60,7 +60,8 @@ public class ZosLogReply {
      * @param items         ZosLogItem object items returned from response
      * @author Frank Giordano
      */
-    public ZosLogReply(Long timeZone, Long nextTimeStamp, String source, Long totalItems, List<ZosLogItem> items) {
+    public ZosLogReply(final Long timeZone, final Long nextTimeStamp, final String source, final Long totalItems,
+                       final List<ZosLogItem> items) {
         if (timeZone == null) {
             this.timeZone = OptionalLong.empty();
         } else {

--- a/src/main/java/zowe/client/sdk/zosmfinfo/methods/ZosmfStatus.java
+++ b/src/main/java/zowe/client/sdk/zosmfinfo/methods/ZosmfStatus.java
@@ -40,7 +40,7 @@ public class ZosmfStatus {
      * @param connection connection information, see ZOSConnection object
      * @author Frank Giordano
      */
-    public ZosmfStatus(ZosConnection connection) {
+    public ZosmfStatus(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
     }
@@ -54,7 +54,7 @@ public class ZosmfStatus {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public ZosmfStatus(ZosConnection connection, ZoweRequest request) throws Exception {
+    public ZosmfStatus(final ZosConnection connection, final ZoweRequest request) throws Exception {
         ValidateUtils.checkConnection(connection);
         ValidateUtils.checkNullParameter(request == null, "request is null");
         this.connection = connection;

--- a/src/main/java/zowe/client/sdk/zosmfinfo/methods/ZosmfStatus.java
+++ b/src/main/java/zowe/client/sdk/zosmfinfo/methods/ZosmfStatus.java
@@ -12,7 +12,6 @@ package zowe.client.sdk.zosmfinfo.methods;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import zowe.client.sdk.core.ZosConnection;
-import zowe.client.sdk.parse.JsonParseResponse;
 import zowe.client.sdk.parse.JsonParseResponseFactory;
 import zowe.client.sdk.parse.type.ParseType;
 import zowe.client.sdk.rest.JsonGetRequest;
@@ -84,8 +83,8 @@ public class ZosmfStatus {
         final String jsonStr = RestUtils.getResponse(request).getResponsePhrase()
                 .orElseThrow(() -> new IllegalStateException("no z/osmf status response phrase")).toString();
         final JSONObject jsonObject = (JSONObject) new JSONParser().parse(jsonStr);
-        final JsonParseResponse parser = JsonParseResponseFactory.buildParser(jsonObject, ParseType.ZOSMF_INFO);
-        return (ZosmfInfoResponse) parser.parseResponse();
+        return (ZosmfInfoResponse) JsonParseResponseFactory.buildParser(ParseType.ZOSMF_INFO)
+                .setJsonObject(jsonObject).parseResponse();
     }
 
 }

--- a/src/main/java/zowe/client/sdk/zosmfinfo/methods/ZosmfSystems.java
+++ b/src/main/java/zowe/client/sdk/zosmfinfo/methods/ZosmfSystems.java
@@ -40,7 +40,7 @@ public class ZosmfSystems {
      * @param connection connection information, see ZOSConnection object
      * @author Frank Giordano
      */
-    public ZosmfSystems(ZosConnection connection) {
+    public ZosmfSystems(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
     }
@@ -54,7 +54,7 @@ public class ZosmfSystems {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public ZosmfSystems(ZosConnection connection, ZoweRequest request) throws Exception {
+    public ZosmfSystems(final ZosConnection connection, final ZoweRequest request) throws Exception {
         ValidateUtils.checkConnection(connection);
         ValidateUtils.checkNullParameter(request == null, "request is null");
         this.connection = connection;

--- a/src/main/java/zowe/client/sdk/zosmfinfo/methods/ZosmfSystems.java
+++ b/src/main/java/zowe/client/sdk/zosmfinfo/methods/ZosmfSystems.java
@@ -12,7 +12,6 @@ package zowe.client.sdk.zosmfinfo.methods;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import zowe.client.sdk.core.ZosConnection;
-import zowe.client.sdk.parse.JsonParseResponse;
 import zowe.client.sdk.parse.JsonParseResponseFactory;
 import zowe.client.sdk.parse.type.ParseType;
 import zowe.client.sdk.rest.JsonGetRequest;
@@ -84,8 +83,8 @@ public class ZosmfSystems {
         final String jsonStr = RestUtils.getResponse(request).getResponsePhrase()
                 .orElseThrow(() -> new IllegalStateException("no z/osmf info response phrase")).toString();
         final JSONObject jsonObject = (JSONObject) new JSONParser().parse(jsonStr);
-        final JsonParseResponse parser = JsonParseResponseFactory.buildParser(jsonObject, ParseType.ZOSMF_SYSTEMS);
-        return (ZosmfSystemsResponse) parser.parseResponse();
+        return (ZosmfSystemsResponse) JsonParseResponseFactory.buildParser(ParseType.ZOSMF_SYSTEMS)
+                .setJsonObject(jsonObject).parseResponse();
     }
 
 }

--- a/src/main/java/zowe/client/sdk/zosmfinfo/response/DefinedSystem.java
+++ b/src/main/java/zowe/client/sdk/zosmfinfo/response/DefinedSystem.java
@@ -88,7 +88,7 @@ public class DefinedSystem {
      * @param builder DefinedSystem.Builder Object
      * @author Frank Giordano
      */
-    private DefinedSystem(DefinedSystem.Builder builder) {
+    private DefinedSystem(final DefinedSystem.Builder builder) {
         this.systemNickName = Optional.ofNullable(builder.systemNickName);
         this.groupNames = Optional.ofNullable(builder.groupNames);
         this.cpcSerial = Optional.ofNullable(builder.cpcSerial);
@@ -260,62 +260,62 @@ public class DefinedSystem {
             return new DefinedSystem(this);
         }
 
-        public DefinedSystem.Builder cpcName(String cpcName) {
+        public DefinedSystem.Builder cpcName(final String cpcName) {
             this.cpcName = cpcName;
             return this;
         }
 
-        public DefinedSystem.Builder cpcSerial(String cpcSerial) {
+        public DefinedSystem.Builder cpcSerial(final String cpcSerial) {
             this.cpcSerial = cpcSerial;
             return this;
         }
 
-        public DefinedSystem.Builder ftpDestinationName(String ftpDestinationName) {
+        public DefinedSystem.Builder ftpDestinationName(final String ftpDestinationName) {
             this.ftpDestinationName = ftpDestinationName;
             return this;
         }
 
-        public DefinedSystem.Builder groupNames(String groupNames) {
+        public DefinedSystem.Builder groupNames(final String groupNames) {
             this.groupNames = groupNames;
             return this;
         }
 
-        public DefinedSystem.Builder httpProxyName(String httpProxyName) {
+        public DefinedSystem.Builder httpProxyName(final String httpProxyName) {
             this.httpProxyName = httpProxyName;
             return this;
         }
 
-        public DefinedSystem.Builder jesMemberName(String jesMemberName) {
+        public DefinedSystem.Builder jesMemberName(final String jesMemberName) {
             this.jesMemberName = jesMemberName;
             return this;
         }
 
-        public DefinedSystem.Builder jesType(String jesType) {
+        public DefinedSystem.Builder jesType(final String jesType) {
             this.jesType = jesType;
             return this;
         }
 
-        public DefinedSystem.Builder sysplexName(String sysplexName) {
+        public DefinedSystem.Builder sysplexName(final String sysplexName) {
             this.sysplexName = sysplexName;
             return this;
         }
 
-        public DefinedSystem.Builder systemName(String systemName) {
+        public DefinedSystem.Builder systemName(final String systemName) {
             this.systemName = systemName;
             return this;
         }
 
-        public DefinedSystem.Builder systemNickName(String systemNickName) {
+        public DefinedSystem.Builder systemNickName(final String systemNickName) {
             this.systemNickName = systemNickName;
             return this;
         }
 
-        public DefinedSystem.Builder url(String url) {
+        public DefinedSystem.Builder url(final String url) {
             this.url = url;
             return this;
         }
 
-        public DefinedSystem.Builder zosVR(String zosVR) {
+        public DefinedSystem.Builder zosVR(final String zosVR) {
             this.zosVR = zosVR;
             return this;
         }

--- a/src/main/java/zowe/client/sdk/zosmfinfo/response/ZosmfInfoResponse.java
+++ b/src/main/java/zowe/client/sdk/zosmfinfo/response/ZosmfInfoResponse.java
@@ -65,7 +65,7 @@ public class ZosmfInfoResponse {
      * @param builder ZosmfInfoResponse.Builder Object
      * @author Frank Giordano
      */
-    private ZosmfInfoResponse(ZosmfInfoResponse.Builder builder) {
+    private ZosmfInfoResponse(final ZosmfInfoResponse.Builder builder) {
         this.zosVersion = Optional.ofNullable(builder.zosVersion);
         this.zosmfPort = Optional.ofNullable(builder.zosmfPort);
         this.zosmfVersion = Optional.ofNullable(builder.zosmfVersion);
@@ -181,7 +181,7 @@ public class ZosmfInfoResponse {
         private String apiVersion;
         private ZosmfPluginInfo[] zosmfPluginsInfo;
 
-        public ZosmfInfoResponse.Builder apiVersion(String apiVersion) {
+        public ZosmfInfoResponse.Builder apiVersion(final String apiVersion) {
             this.apiVersion = apiVersion;
             return this;
         }
@@ -190,37 +190,37 @@ public class ZosmfInfoResponse {
             return new ZosmfInfoResponse(this);
         }
 
-        public ZosmfInfoResponse.Builder zosVersion(String zosVersion) {
+        public ZosmfInfoResponse.Builder zosVersion(final String zosVersion) {
             this.zosVersion = zosVersion;
             return this;
         }
 
-        public ZosmfInfoResponse.Builder zosmfFullVersion(String zosmfFullVersion) {
+        public ZosmfInfoResponse.Builder zosmfFullVersion(final String zosmfFullVersion) {
             this.zosmfFullVersion = zosmfFullVersion;
             return this;
         }
 
-        public ZosmfInfoResponse.Builder zosmfHostName(String zosmfHostName) {
+        public ZosmfInfoResponse.Builder zosmfHostName(final String zosmfHostName) {
             this.zosmfHostName = zosmfHostName;
             return this;
         }
 
-        public ZosmfInfoResponse.Builder zosmfPluginsInfo(ZosmfPluginInfo[] zosmfPluginsInfo) {
+        public ZosmfInfoResponse.Builder zosmfPluginsInfo(final ZosmfPluginInfo[] zosmfPluginsInfo) {
             this.zosmfPluginsInfo = zosmfPluginsInfo;
             return this;
         }
 
-        public ZosmfInfoResponse.Builder zosmfPort(String zosmfPort) {
+        public ZosmfInfoResponse.Builder zosmfPort(final String zosmfPort) {
             this.zosmfPort = zosmfPort;
             return this;
         }
 
-        public ZosmfInfoResponse.Builder zosmfSafRealm(String zosmfSafRealm) {
+        public ZosmfInfoResponse.Builder zosmfSafRealm(final String zosmfSafRealm) {
             this.zosmfSafRealm = zosmfSafRealm;
             return this;
         }
 
-        public ZosmfInfoResponse.Builder zosmfVersion(String zosmfVersion) {
+        public ZosmfInfoResponse.Builder zosmfVersion(final String zosmfVersion) {
             this.zosmfVersion = zosmfVersion;
             return this;
         }

--- a/src/main/java/zowe/client/sdk/zosmfinfo/response/ZosmfPluginInfo.java
+++ b/src/main/java/zowe/client/sdk/zosmfinfo/response/ZosmfPluginInfo.java
@@ -40,7 +40,7 @@ public class ZosmfPluginInfo {
      * @param builder ZosmfPluginInfo.Builder Object
      * @author Frank Giordano
      */
-    private ZosmfPluginInfo(ZosmfPluginInfo.Builder builder) {
+    private ZosmfPluginInfo(final ZosmfPluginInfo.Builder builder) {
         this.pluginVersion = Optional.ofNullable(builder.pluginVersion);
         this.pluginDefaultName = Optional.ofNullable(builder.pluginDefaultName);
         this.pluginStatus = Optional.ofNullable(builder.pluginStatus);
@@ -95,17 +95,17 @@ public class ZosmfPluginInfo {
             return new ZosmfPluginInfo(this);
         }
 
-        public ZosmfPluginInfo.Builder pluginDefaultName(String pluginDefaultName) {
+        public ZosmfPluginInfo.Builder pluginDefaultName(final String pluginDefaultName) {
             this.pluginDefaultName = pluginDefaultName;
             return this;
         }
 
-        public ZosmfPluginInfo.Builder pluginStatus(String pluginStatus) {
+        public ZosmfPluginInfo.Builder pluginStatus(final String pluginStatus) {
             this.pluginStatus = pluginStatus;
             return this;
         }
 
-        public ZosmfPluginInfo.Builder pluginVersion(String pluginVersion) {
+        public ZosmfPluginInfo.Builder pluginVersion(final String pluginVersion) {
             this.pluginVersion = pluginVersion;
             return this;
         }

--- a/src/main/java/zowe/client/sdk/zosmfinfo/response/ZosmfSystemsResponse.java
+++ b/src/main/java/zowe/client/sdk/zosmfinfo/response/ZosmfSystemsResponse.java
@@ -10,6 +10,7 @@
 package zowe.client.sdk.zosmfinfo.response;
 
 import java.util.Optional;
+import java.util.OptionalLong;
 
 /**
  * API response for list systems defined to z/OSMF.
@@ -22,7 +23,7 @@ public class ZosmfSystemsResponse {
     /**
      * Total items returned.
      */
-    private final Optional<Long> numRows;
+    private final OptionalLong numRows;
 
     /**
      * Properties of each defined system.
@@ -36,7 +37,11 @@ public class ZosmfSystemsResponse {
      * @author Frank Giordano
      */
     private ZosmfSystemsResponse(ZosmfSystemsResponse.Builder builder) {
-        this.numRows = Optional.ofNullable(builder.numRows);
+        if (builder.numRows == null) {
+            this.numRows = OptionalLong.empty();
+        } else {
+            this.numRows = OptionalLong.of(builder.numRows);
+        }
         this.definedSystems = Optional.ofNullable(builder.definedSystems);
     }
 
@@ -56,7 +61,7 @@ public class ZosmfSystemsResponse {
      * @return numRows value
      * @author Frank Giordano
      */
-    public Optional<Long> getNumRows() {
+    public OptionalLong getNumRows() {
         return numRows;
     }
 

--- a/src/main/java/zowe/client/sdk/zosmfinfo/response/ZosmfSystemsResponse.java
+++ b/src/main/java/zowe/client/sdk/zosmfinfo/response/ZosmfSystemsResponse.java
@@ -36,7 +36,7 @@ public class ZosmfSystemsResponse {
      * @param builder ZosmfListDefinedSystemsResponse.Builder Object
      * @author Frank Giordano
      */
-    private ZosmfSystemsResponse(ZosmfSystemsResponse.Builder builder) {
+    private ZosmfSystemsResponse(final ZosmfSystemsResponse.Builder builder) {
         if (builder.numRows == null) {
             this.numRows = OptionalLong.empty();
         } else {
@@ -82,12 +82,12 @@ public class ZosmfSystemsResponse {
             return new ZosmfSystemsResponse(this);
         }
 
-        public ZosmfSystemsResponse.Builder definedSystems(DefinedSystem[] definedSystems) {
+        public ZosmfSystemsResponse.Builder definedSystems(final DefinedSystem[] definedSystems) {
             this.definedSystems = definedSystems;
             return this;
         }
 
-        public ZosmfSystemsResponse.Builder numRows(Long numRows) {
+        public ZosmfSystemsResponse.Builder numRows(final Long numRows) {
             this.numRows = numRows;
             return this;
         }

--- a/src/main/java/zowe/client/sdk/zostso/input/SendTsoParams.java
+++ b/src/main/java/zowe/client/sdk/zostso/input/SendTsoParams.java
@@ -36,7 +36,7 @@ public class SendTsoParams {
      * @param data       to be sent to the active address space
      * @author Frank Giordano
      */
-    public SendTsoParams(String servletKey, String data) {
+    public SendTsoParams(final String servletKey, final String data) {
         ValidateUtils.checkNullParameter(servletKey == null, "servletKey is null");
         ValidateUtils.checkIllegalParameter(servletKey.isBlank(), "servletKey not specified");
         ValidateUtils.checkNullParameter(data == null, "data is null");

--- a/src/main/java/zowe/client/sdk/zostso/input/StartTsoParams.java
+++ b/src/main/java/zowe/client/sdk/zostso/input/StartTsoParams.java
@@ -69,8 +69,9 @@ public class StartTsoParams {
      * @param regionSize     region size for tso address space
      * @author Frank Giordano
      */
-    public StartTsoParams(String logonProcedure, String characterSet, String codePage, String rows, String columns,
-                          String accountNumber, String regionSize) {
+    public StartTsoParams(final String logonProcedure, final String characterSet, final String codePage,
+                          final String rows, final String columns, final String accountNumber,
+                          final String regionSize) {
         this.logonProcedure = Optional.ofNullable(logonProcedure);
         this.characterSet = Optional.ofNullable(characterSet);
         this.codePage = Optional.ofNullable(codePage);
@@ -96,7 +97,7 @@ public class StartTsoParams {
      * @param account user's z/OS permission account number
      * @author Frank Giordano
      */
-    public void setAccount(String account) {
+    public void setAccount(final String account) {
         this.account = Optional.ofNullable(account);
     }
 
@@ -116,7 +117,7 @@ public class StartTsoParams {
      * @param characterSet character set for address space
      * @author Frank Giordano
      */
-    public void setCharacterSet(String characterSet) {
+    public void setCharacterSet(final String characterSet) {
         this.characterSet = Optional.of(characterSet);
     }
 
@@ -136,7 +137,7 @@ public class StartTsoParams {
      * @param codePage code page for tso address space
      * @author Frank Giordano
      */
-    public void setCodePage(String codePage) {
+    public void setCodePage(final String codePage) {
         this.codePage = Optional.ofNullable(codePage);
     }
 
@@ -156,7 +157,7 @@ public class StartTsoParams {
      * @param columns number of columns
      * @author Frank Giordano
      */
-    public void setColumns(String columns) {
+    public void setColumns(final String columns) {
         this.columns = Optional.ofNullable(columns);
     }
 
@@ -176,7 +177,7 @@ public class StartTsoParams {
      * @param logonProcedure name of the logonProcedure for address space
      * @author Frank Giordano
      */
-    public void setLogonProcedure(String logonProcedure) {
+    public void setLogonProcedure(final String logonProcedure) {
         this.logonProcedure = Optional.of(logonProcedure);
     }
 
@@ -196,7 +197,7 @@ public class StartTsoParams {
      * @param regionSize region size for tso address space
      * @author Frank Giordano
      */
-    public void setRegionSize(String regionSize) {
+    public void setRegionSize(final String regionSize) {
         this.regionSize = Optional.of(regionSize);
     }
 

--- a/src/main/java/zowe/client/sdk/zostso/input/StopTsoParams.java
+++ b/src/main/java/zowe/client/sdk/zostso/input/StopTsoParams.java
@@ -32,7 +32,7 @@ public class StopTsoParams {
      * @param servletKey key of an active tso address space
      * @author Frank Giordano
      */
-    public StopTsoParams(String servletKey) {
+    public StopTsoParams(final String servletKey) {
         ValidateUtils.checkNullParameter(servletKey == null, "servletKey is null");
         ValidateUtils.checkIllegalParameter(servletKey.isBlank(), "servletKey not specified");
         this.servletKey = Optional.of(servletKey);

--- a/src/main/java/zowe/client/sdk/zostso/lifecycle/SendTso.java
+++ b/src/main/java/zowe/client/sdk/zostso/lifecycle/SendTso.java
@@ -46,7 +46,7 @@ public class SendTso {
      * @param connection connection information, see ZOSConnection object
      * @author Frank Giordano
      */
-    public SendTso(ZosConnection connection) {
+    public SendTso(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
     }
@@ -60,7 +60,7 @@ public class SendTso {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public SendTso(ZosConnection connection, ZoweRequest request) throws Exception {
+    public SendTso(final ZosConnection connection, final ZoweRequest request) throws Exception {
         ValidateUtils.checkConnection(connection);
         ValidateUtils.checkNullParameter(request == null, "request is null");
         this.connection = connection;
@@ -77,7 +77,7 @@ public class SendTso {
      * @return SendResponse, see SendResponse
      * @author Frank Giordano
      */
-    private static SendResponse createResponse(CollectedResponses responses) {
+    private static SendResponse createResponse(final CollectedResponses responses) {
         return new SendResponse(true, responses.getTsos(), responses.getMessages()
                 .orElseThrow(() -> new IllegalStateException("no responses tso messages exist")));
     }
@@ -134,7 +134,7 @@ public class SendTso {
      * @throws Exception error executing command
      * @author Frank Giordano
      */
-    private ZosmfTsoResponse getDataFromTso(String servletKey) throws Exception {
+    private ZosmfTsoResponse getDataFromTso(final String servletKey) throws Exception {
         final String url = "https://" + connection.getHost() + ":" + connection.getZosmfPort() +
                 TsoConstants.RESOURCE + "/" + TsoConstants.RES_START_TSO + "/" + servletKey;
 
@@ -154,7 +154,7 @@ public class SendTso {
      * @return json representation of TSO RESPONSE
      * @author Frank Giordano
      */
-    private String getTsoResponseSendMessage(TsoResponseMessage tsoResponseMessage) {
+    private String getTsoResponseSendMessage(final TsoResponseMessage tsoResponseMessage) {
         return "{\"TSO RESPONSE\":{\"VERSION\":\"" + tsoResponseMessage.getVersion().orElse("")
                 + "\",\"DATA\":\"" + tsoResponseMessage.getData().orElse("") + "\"}}";
     }
@@ -169,7 +169,7 @@ public class SendTso {
      * @throws Exception error executing command
      * @author Frank Giordano
      */
-    public SendResponse sendDataToTsoCollect(String servletKey, String command) throws Exception {
+    public SendResponse sendDataToTsoCollect(final String servletKey, final String command) throws Exception {
         final ZosmfTsoResponse putResponse = sendDataToTsoCommon(new SendTsoParams(servletKey, command));
         final CollectedResponses responses = getAllResponses(putResponse);
         return createResponse(responses);
@@ -183,7 +183,7 @@ public class SendTso {
      * @throws Exception error executing command
      * @author Frank Giordano
      */
-    public ZosmfTsoResponse sendDataToTsoCommon(SendTsoParams commandParams) throws Exception {
+    public ZosmfTsoResponse sendDataToTsoCommon(final SendTsoParams commandParams) throws Exception {
         ValidateUtils.checkNullParameter(commandParams == null, "commandParams is null");
 
         final String url = "https://" + connection.getHost() + ":" + connection.getZosmfPort() + TsoConstants.RESOURCE + "/" +

--- a/src/main/java/zowe/client/sdk/zostso/lifecycle/StartTso.java
+++ b/src/main/java/zowe/client/sdk/zostso/lifecycle/StartTso.java
@@ -41,7 +41,7 @@ public class StartTso {
      * @param connection connection information, see ZOSConnection object
      * @author Frank Giordano
      */
-    public StartTso(ZosConnection connection) {
+    public StartTso(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
     }
@@ -55,7 +55,7 @@ public class StartTso {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public StartTso(ZosConnection connection, ZoweRequest request) throws Exception {
+    public StartTso(final ZosConnection connection, final ZoweRequest request) throws Exception {
         ValidateUtils.checkConnection(connection);
         ValidateUtils.checkNullParameter(request == null, "request is null");
         this.connection = connection;
@@ -72,7 +72,7 @@ public class StartTso {
      * @return generated url
      * @author Frank Giordano
      */
-    private String getResourcesQuery(StartTsoParams params) {
+    private String getResourcesQuery(final StartTsoParams params) {
         String query = "https://" + connection.getHost() + ":" + connection.getZosmfPort();
         query += TsoConstants.RESOURCE + "/" + TsoConstants.RES_START_TSO + "?";
         query += TsoConstants.PARAM_ACCT + "=" + params.account
@@ -94,7 +94,7 @@ public class StartTso {
      * @return StartTsoParams object
      * @author Frank Giordano
      */
-    private StartTsoParams setDefaultAddressSpaceParams(StartTsoParams params, String accountNumber) {
+    private StartTsoParams setDefaultAddressSpaceParams(StartTsoParams params, final String accountNumber) {
         if (params == null) {
             params = new StartTsoParams();
         }
@@ -116,7 +116,7 @@ public class StartTso {
      * @throws Exception error executing command
      * @author Frank Giordano
      */
-    public StartStopResponses start(String accountNumber, StartTsoParams params) throws Exception {
+    public StartStopResponses start(final String accountNumber, final StartTsoParams params) throws Exception {
         ValidateUtils.checkNullParameter(accountNumber == null, "accountNumber is null");
         ValidateUtils.checkIllegalParameter(accountNumber.isBlank(), "accountNumber not specified");
 
@@ -146,7 +146,7 @@ public class StartTso {
      * @throws Exception error executing command
      * @author Frank Giordano
      */
-    public ZosmfTsoResponse startCommon(StartTsoParams commandParams) throws Exception {
+    public ZosmfTsoResponse startCommon(final StartTsoParams commandParams) throws Exception {
         ValidateUtils.checkNullParameter(commandParams == null, "commandParams is null");
 
         final String url = getResourcesQuery(commandParams);

--- a/src/main/java/zowe/client/sdk/zostso/lifecycle/StopTso.java
+++ b/src/main/java/zowe/client/sdk/zostso/lifecycle/StopTso.java
@@ -12,7 +12,6 @@ package zowe.client.sdk.zostso.lifecycle;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import zowe.client.sdk.core.ZosConnection;
-import zowe.client.sdk.parse.JsonParseResponse;
 import zowe.client.sdk.parse.JsonParseResponseFactory;
 import zowe.client.sdk.parse.type.ParseType;
 import zowe.client.sdk.rest.JsonDeleteRequest;
@@ -112,8 +111,8 @@ public class StopTso {
         final String jsonStr = response.getResponsePhrase()
                 .orElseThrow(() -> new IllegalStateException("no tso stop response phrase")).toString();
         final JSONObject jsonObject = (JSONObject) new JSONParser().parse(jsonStr);
-        final JsonParseResponse jsonParseResponse = JsonParseResponseFactory.buildParser(jsonObject, ParseType.TSO_STOP);
-        return (ZosmfTsoResponse) jsonParseResponse.parseResponse();
+        return (ZosmfTsoResponse) JsonParseResponseFactory.buildParser(ParseType.TSO_STOP)
+                .setJsonObject(jsonObject).parseResponse();
     }
 
 }

--- a/src/main/java/zowe/client/sdk/zostso/lifecycle/StopTso.java
+++ b/src/main/java/zowe/client/sdk/zostso/lifecycle/StopTso.java
@@ -44,7 +44,7 @@ public class StopTso {
      * @param connection connection information, see ZosConnection object
      * @author Frank Giordano
      */
-    public StopTso(ZosConnection connection) {
+    public StopTso(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
     }
@@ -58,7 +58,7 @@ public class StopTso {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public StopTso(ZosConnection connection, ZoweRequest request) throws Exception {
+    public StopTso(final ZosConnection connection, final ZoweRequest request) throws Exception {
         ValidateUtils.checkConnection(connection);
         ValidateUtils.checkNullParameter(request == null, "request is null");
         this.connection = connection;
@@ -76,7 +76,7 @@ public class StopTso {
      * @throws Exception error on TSO sto command
      * @author Frank Giordano
      */
-    public StartStopResponse stop(String servletKey) throws Exception {
+    public StartStopResponse stop(final String servletKey) throws Exception {
         ValidateUtils.checkNullParameter(servletKey == null, "servletKey is null");
         ValidateUtils.checkIllegalParameter(servletKey.isBlank(), "servletKey not specified");
 
@@ -95,7 +95,7 @@ public class StopTso {
      * @throws Exception error on TSO sto command
      * @author Frank Giordano
      */
-    public ZosmfTsoResponse stopCommon(StopTsoParams commandParams) throws Exception {
+    public ZosmfTsoResponse stopCommon(final StopTsoParams commandParams) throws Exception {
         ValidateUtils.checkNullParameter(commandParams == null, "commandParams is null");
 
         final String url = "https://" + connection.getHost() + ":" + connection.getZosmfPort() +

--- a/src/main/java/zowe/client/sdk/zostso/message/TsoMessage.java
+++ b/src/main/java/zowe/client/sdk/zostso/message/TsoMessage.java
@@ -44,7 +44,7 @@ public class TsoMessage {
      * @param data    description of the data type
      * @author Frank Giordano
      */
-    public TsoMessage(String version, String data) {
+    public TsoMessage(final String version, final String data) {
         this.version = Optional.ofNullable(version);
         this.data = Optional.ofNullable(data);
     }
@@ -65,7 +65,7 @@ public class TsoMessage {
      * @param version JSON version for message format
      * @author Frank Giordano
      */
-    public void setVersion(String version) {
+    public void setVersion(final String version) {
         this.version = Optional.ofNullable(version);
     }
 
@@ -85,7 +85,7 @@ public class TsoMessage {
      * @param data description os the data type
      * @author Frank Giordano
      */
-    public void setData(String data) {
+    public void setData(final String data) {
         this.data = Optional.ofNullable(data);
     }
 

--- a/src/main/java/zowe/client/sdk/zostso/message/TsoMessages.java
+++ b/src/main/java/zowe/client/sdk/zostso/message/TsoMessages.java
@@ -50,7 +50,7 @@ public class TsoMessages {
      * @param tsoMessage tso message value
      * @author Frank Giordano
      */
-    public void setTsoMessage(TsoMessage tsoMessage) {
+    public void setTsoMessage(final TsoMessage tsoMessage) {
         this.tsoMessage = Optional.ofNullable(tsoMessage);
     }
 
@@ -70,7 +70,7 @@ public class TsoMessages {
      * @param tsoPrompt tso prompt value
      * @author Frank Giordano
      */
-    public void setTsoPrompt(TsoPromptMessage tsoPrompt) {
+    public void setTsoPrompt(final TsoPromptMessage tsoPrompt) {
         this.tsoPrompt = Optional.ofNullable(tsoPrompt);
     }
 
@@ -90,7 +90,7 @@ public class TsoMessages {
      * @param tsoResponse tso response value
      * @author Frank Giordano
      */
-    public void setTsoResponse(TsoResponseMessage tsoResponse) {
+    public void setTsoResponse(final TsoResponseMessage tsoResponse) {
         this.tsoResponse = Optional.ofNullable(tsoResponse);
     }
 

--- a/src/main/java/zowe/client/sdk/zostso/message/TsoPromptMessage.java
+++ b/src/main/java/zowe/client/sdk/zostso/message/TsoPromptMessage.java
@@ -44,7 +44,7 @@ public class TsoPromptMessage {
      * @param hidden  hidden value
      * @author Frank Giordano
      */
-    public TsoPromptMessage(String version, String hidden) {
+    public TsoPromptMessage(final String version, final String hidden) {
         this.version = Optional.ofNullable(version);
         this.hidden = Optional.ofNullable(hidden);
     }
@@ -65,7 +65,7 @@ public class TsoPromptMessage {
      * @param version JSON version for message format
      * @author Frank Giordano
      */
-    public void setVersion(String version) {
+    public void setVersion(final String version) {
         this.version = Optional.ofNullable(version);
     }
 
@@ -85,7 +85,7 @@ public class TsoPromptMessage {
      * @param hidden hidden value
      * @author Frank Giordano
      */
-    public void setHidden(String hidden) {
+    public void setHidden(final String hidden) {
         this.hidden = Optional.ofNullable(hidden);
     }
 

--- a/src/main/java/zowe/client/sdk/zostso/message/TsoResponseMessage.java
+++ b/src/main/java/zowe/client/sdk/zostso/message/TsoResponseMessage.java
@@ -44,7 +44,7 @@ public class TsoResponseMessage {
      * @param data    description of the data type
      * @author Frank Giordano
      */
-    public TsoResponseMessage(String version, String data) {
+    public TsoResponseMessage(final String version, final String data) {
         this.version = Optional.ofNullable(version);
         this.data = Optional.ofNullable(data);
     }
@@ -65,7 +65,7 @@ public class TsoResponseMessage {
      * @param version JSON version for message format
      * @author Frank Giordano
      */
-    public void setVersion(String version) {
+    public void setVersion(final String version) {
         this.version = Optional.ofNullable(version);
     }
 
@@ -85,7 +85,7 @@ public class TsoResponseMessage {
      * @param data description os the data type
      * @author Frank Giordano
      */
-    public void setData(String data) {
+    public void setData(final String data) {
         this.data = Optional.ofNullable(data);
     }
 

--- a/src/main/java/zowe/client/sdk/zostso/message/ZosmfMessages.java
+++ b/src/main/java/zowe/client/sdk/zostso/message/ZosmfMessages.java
@@ -42,7 +42,7 @@ public class ZosmfMessages {
      * @param stackTrace  error message stack trace value
      * @author Frank Giordano
      */
-    public ZosmfMessages(String messageText, String messageId, String stackTrace) {
+    public ZosmfMessages(final String messageText, final String messageId, final String stackTrace) {
         this.messageText = Optional.ofNullable(messageText);
         this.messageId = Optional.ofNullable(messageId);
         this.stackTrace = Optional.ofNullable(stackTrace);
@@ -64,7 +64,7 @@ public class ZosmfMessages {
      * @param messageText value
      * @author Frank Giordano
      */
-    public void setMessageText(String messageText) {
+    public void setMessageText(final String messageText) {
         this.messageText = Optional.ofNullable(messageText);
     }
 
@@ -84,7 +84,7 @@ public class ZosmfMessages {
      * @param messageId value
      * @author Frank Giordano
      */
-    public void setMessageId(String messageId) {
+    public void setMessageId(final String messageId) {
         this.messageId = Optional.ofNullable(messageId);
     }
 
@@ -104,7 +104,7 @@ public class ZosmfMessages {
      * @param stackTrace value
      * @author Frank Giordano
      */
-    public void setStackTrace(String stackTrace) {
+    public void setStackTrace(final String stackTrace) {
         this.stackTrace = Optional.ofNullable(stackTrace);
     }
 

--- a/src/main/java/zowe/client/sdk/zostso/message/ZosmfTsoResponse.java
+++ b/src/main/java/zowe/client/sdk/zostso/message/ZosmfTsoResponse.java
@@ -40,12 +40,12 @@ public class ZosmfTsoResponse {
     /**
      * Reconnected indicator
      */
-    private final Optional<Boolean> reused;
+    private final boolean reused;
 
     /**
      * Timeout indicator
      */
-    private final Optional<Boolean> timeout;
+    private final boolean timeout;
 
     /**
      * z/OSMF messages
@@ -67,12 +67,12 @@ public class ZosmfTsoResponse {
      */
     private final Optional<String> appData;
 
-    private ZosmfTsoResponse(ZosmfTsoResponse.Builder builder) {
+    private ZosmfTsoResponse(final ZosmfTsoResponse.Builder builder) {
         this.servletKey = Optional.ofNullable(builder.servletKey);
         this.queueId = Optional.ofNullable(builder.queueId);
         this.ver = Optional.ofNullable(builder.ver);
-        this.reused = Optional.ofNullable(builder.reused);
-        this.timeout = Optional.ofNullable(builder.timeout);
+        this.reused = builder.reused;
+        this.timeout = builder.timeout;
         this.msgData = Objects.requireNonNullElse(builder.msgData, Collections.emptyList());
         this.sessionId = Optional.ofNullable(builder.sessionId);
         this.tsoData = Objects.requireNonNullElse(builder.tsoData, Collections.emptyList());
@@ -110,22 +110,22 @@ public class ZosmfTsoResponse {
     }
 
     /**
-     * Retrieve reused specified
+     * Retrieve is reused specified
      *
-     * @return reused value
+     * @return boolean true or false
      * @author Frank Giordano
      */
-    public Optional<Boolean> getReused() {
+    public boolean isReused() {
         return reused;
     }
 
     /**
-     * Retrieve timeout specified
+     * Retrieve is timeout specified
      *
-     * @return timeout value
+     * @return boolean true or false
      * @author Frank Giordano
      */
-    public Optional<Boolean> getTimeout() {
+    public boolean isTimeout() {
         return timeout;
     }
 
@@ -175,7 +175,7 @@ public class ZosmfTsoResponse {
      * @param tsoData message list
      * @author Frank Giordano
      */
-    public void setTsoData(List<TsoMessages> tsoData) {
+    public void setTsoData(final List<TsoMessages> tsoData) {
         this.tsoData = Objects.requireNonNullElse(tsoData, Collections.emptyList());
     }
 
@@ -199,54 +199,54 @@ public class ZosmfTsoResponse {
         private String servletKey;
         private String queueId;
         private String ver;
-        private Boolean reused;
-        private Boolean timeout;
+        private boolean reused;
+        private boolean timeout;
         private List<ZosmfMessages> msgData;
         private String sessionId;
         private List<TsoMessages> tsoData;
         private String appData;
 
-        public ZosmfTsoResponse.Builder servletKey(String servletKey) {
+        public ZosmfTsoResponse.Builder servletKey(final String servletKey) {
             this.servletKey = servletKey;
             return this;
         }
 
-        public ZosmfTsoResponse.Builder queueId(String queueId) {
+        public ZosmfTsoResponse.Builder queueId(final String queueId) {
             this.queueId = queueId;
             return this;
         }
 
-        public ZosmfTsoResponse.Builder ver(String ver) {
+        public ZosmfTsoResponse.Builder ver(final String ver) {
             this.ver = ver;
             return this;
         }
 
-        public ZosmfTsoResponse.Builder reused(Boolean reused) {
+        public ZosmfTsoResponse.Builder reused(final boolean reused) {
             this.reused = reused;
             return this;
         }
 
-        public ZosmfTsoResponse.Builder timeout(Boolean timeout) {
+        public ZosmfTsoResponse.Builder timeout(final boolean timeout) {
             this.timeout = timeout;
             return this;
         }
 
-        public ZosmfTsoResponse.Builder msgData(List<ZosmfMessages> msgData) {
+        public ZosmfTsoResponse.Builder msgData(final List<ZosmfMessages> msgData) {
             this.msgData = msgData;
             return this;
         }
 
-        public ZosmfTsoResponse.Builder sessionId(String sessionId) {
+        public ZosmfTsoResponse.Builder sessionId(final String sessionId) {
             this.sessionId = sessionId;
             return this;
         }
 
-        public ZosmfTsoResponse.Builder tsoData(List<TsoMessages> tsoData) {
+        public ZosmfTsoResponse.Builder tsoData(final List<TsoMessages> tsoData) {
             this.tsoData = tsoData;
             return this;
         }
 
-        public ZosmfTsoResponse.Builder tsoData(String appData) {
+        public ZosmfTsoResponse.Builder tsoData(final String appData) {
             this.appData = appData;
             return this;
         }

--- a/src/main/java/zowe/client/sdk/zostso/method/IssueTso.java
+++ b/src/main/java/zowe/client/sdk/zostso/method/IssueTso.java
@@ -40,7 +40,7 @@ public class IssueTso {
      * @param connection connection information, see ZosConnection object
      * @author Frank Giordano
      */
-    public IssueTso(ZosConnection connection) {
+    public IssueTso(final ZosConnection connection) {
         ValidateUtils.checkConnection(connection);
         this.connection = connection;
     }
@@ -55,7 +55,7 @@ public class IssueTso {
      * @throws Exception error executing command
      * @author Frank Giordano
      */
-    public IssueResponse issueCommand(String accountNumber, String command) throws Exception {
+    public IssueResponse issueCommand(final String accountNumber, final String command) throws Exception {
         return issueCommand(accountNumber, command, null);
     }
 
@@ -70,8 +70,8 @@ public class IssueTso {
      * @throws Exception error executing command
      * @author Frank Giordano
      */
-    public IssueResponse issueCommand(String accountNumber, String command, StartTsoParams startParams)
-            throws Exception {
+    public IssueResponse issueCommand(final String accountNumber, final String command,
+                                      final StartTsoParams startParams) throws Exception {
         ValidateUtils.checkNullParameter(accountNumber == null, "accountNumber is null");
         ValidateUtils.checkNullParameter(command == null, "command is null");
         ValidateUtils.checkIllegalParameter(accountNumber.isBlank(), "accountNumber not specified");
@@ -102,7 +102,7 @@ public class IssueTso {
         // second stage send command to tso servlet session created in first stage and collect all tso responses
         final SendTso sendTso = new SendTso(connection);
         final SendResponse sendResponse = sendTso.sendDataToTsoCollect(servletKey, command);
-        issueResponse.setSuccess(sendResponse.getSuccess());
+        issueResponse.setSuccess(sendResponse.isSuccess());
         zosmfTsoResponses.addAll(sendResponse.getZosmfResponses());
 
         issueResponse.setZosmfResponses(zosmfTsoResponses);

--- a/src/main/java/zowe/client/sdk/zostso/response/CollectedResponses.java
+++ b/src/main/java/zowe/client/sdk/zostso/response/CollectedResponses.java
@@ -41,7 +41,7 @@ public class CollectedResponses {
      * @param messages tso messages
      * @author Frank Giordano
      */
-    public CollectedResponses(List<ZosmfTsoResponse> tsoLst, String messages) {
+    public CollectedResponses(final List<ZosmfTsoResponse> tsoLst, final String messages) {
         this.tsos = Objects.requireNonNullElse(tsoLst, Collections.emptyList());
         this.messages = Optional.ofNullable(messages);
     }

--- a/src/main/java/zowe/client/sdk/zostso/response/IssueResponse.java
+++ b/src/main/java/zowe/client/sdk/zostso/response/IssueResponse.java
@@ -71,17 +71,17 @@ public class IssueResponse {
      * @param commandResponses command string responses
      * @author Frank Giordano
      */
-    public void setCommandResponses(String commandResponses) {
+    public void setCommandResponses(final String commandResponses) {
         this.commandResponses = Optional.ofNullable(commandResponses);
     }
 
     /**
-     * Retrieve startReady specified
+     * Retrieve is startReady specified
      *
-     * @return startReady value
+     * @return boolean true or false
      * @author Frank Giordano
      */
-    public boolean getStartReady() {
+    public boolean isStartReady() {
         return startReady;
     }
 
@@ -91,7 +91,7 @@ public class IssueResponse {
      * @param startReady true or false is start ready prompt seen or not
      * @author Frank Giordano
      */
-    public void setStartReady(boolean startReady) {
+    public void setStartReady(final boolean startReady) {
         this.startReady = startReady;
     }
 
@@ -111,7 +111,7 @@ public class IssueResponse {
      * @param startResponse tso response
      * @author Frank Giordano
      */
-    public void setStartResponse(StartStopResponses startResponse) {
+    public void setStartResponse(final StartStopResponses startResponse) {
         this.startResponse = Optional.ofNullable(startResponse);
     }
 
@@ -131,17 +131,17 @@ public class IssueResponse {
      * @param stopResponse tso response
      * @author Frank Giordano
      */
-    public void setStopResponse(StartStopResponse stopResponse) {
+    public void setStopResponse(final StartStopResponse stopResponse) {
         this.stopResponse = Optional.ofNullable(stopResponse);
     }
 
     /**
-     * Retrieve success specified
+     * Retrieve is success
      *
-     * @return boolean value
+     * @return boolean true or false
      * @author Frank Giordano
      */
-    public boolean getSuccess() {
+    public boolean isSuccess() {
         return success;
     }
 
@@ -151,7 +151,7 @@ public class IssueResponse {
      * @param success true or false is response seen
      * @author Frank Giordano
      */
-    public void setSuccess(boolean success) {
+    public void setSuccess(final boolean success) {
         this.success = success;
     }
 
@@ -171,7 +171,7 @@ public class IssueResponse {
      * @param zosmfResponses z/OSMF tso responses
      * @author Frank Giordano
      */
-    public void setZosmfResponses(List<ZosmfTsoResponse> zosmfResponses) {
+    public void setZosmfResponses(final List<ZosmfTsoResponse> zosmfResponses) {
         this.zosmfResponses = Objects.requireNonNullElse(zosmfResponses, Collections.emptyList());
     }
 

--- a/src/main/java/zowe/client/sdk/zostso/response/SendResponse.java
+++ b/src/main/java/zowe/client/sdk/zostso/response/SendResponse.java
@@ -48,7 +48,8 @@ public class SendResponse {
      * @param commandResponse   tso command response
      * @author Frank Giordano
      */
-    public SendResponse(boolean success, List<ZosmfTsoResponse> zosmfTsoResponses, String commandResponse) {
+    public SendResponse(final boolean success, final List<ZosmfTsoResponse> zosmfTsoResponses,
+                        final String commandResponse) {
         this.success = success;
         this.zosmfTsoResponses = Objects.requireNonNullElse(zosmfTsoResponses, Collections.emptyList());
         this.commandResponse = Optional.ofNullable(commandResponse);
@@ -65,12 +66,12 @@ public class SendResponse {
     }
 
     /**
-     * Retrieve success specified
+     * Retrieve is success
      *
-     * @return success value
+     * @return boolean true or false
      * @author Frank Giordano
      */
-    public boolean getSuccess() {
+    public boolean isSuccess() {
         return success;
     }
 

--- a/src/main/java/zowe/client/sdk/zostso/response/StartStopResponse.java
+++ b/src/main/java/zowe/client/sdk/zostso/response/StartStopResponse.java
@@ -36,7 +36,7 @@ public class StartStopResponse {
     /**
      * True if the command was issued and the responses were collected.
      */
-    public Optional<Boolean> success;
+    public boolean success;
 
     /**
      * StartStopResponse constructor
@@ -46,8 +46,8 @@ public class StartStopResponse {
      * @param servletKey       key value for tso address space
      * @author Frank Giordano
      */
-    public StartStopResponse(boolean success, ZosmfTsoResponse zosmfTsoResponse, String servletKey) {
-        this.success = Optional.of(success);
+    public StartStopResponse(final boolean success, final ZosmfTsoResponse zosmfTsoResponse, final String servletKey) {
+        this.success = success;
         this.zosmfTsoResponse = Optional.ofNullable(zosmfTsoResponse);
         this.servletKey = Optional.ofNullable(servletKey);
     }
@@ -68,7 +68,7 @@ public class StartStopResponse {
      * @param failureResponse failure response string
      * @author Frank Giordano
      */
-    public void setFailureResponse(String failureResponse) {
+    public void setFailureResponse(final String failureResponse) {
         this.failureResponse = Optional.ofNullable(failureResponse);
     }
 
@@ -83,12 +83,12 @@ public class StartStopResponse {
     }
 
     /**
-     * Retrieve success specified
+     * Retrieve is success
      *
-     * @return boolean value
+     * @return boolean true or false
      * @author Frank Giordano
      */
-    public Optional<Boolean> getSuccess() {
+    public boolean isSuccess() {
         return success;
     }
 
@@ -98,8 +98,8 @@ public class StartStopResponse {
      * @param success true or false is response seen
      * @author Frank Giordano
      */
-    public void setSuccess(boolean success) {
-        this.success = Optional.of(success);
+    public void setSuccess(final boolean success) {
+        this.success = success;
     }
 
     /**

--- a/src/main/java/zowe/client/sdk/zostso/response/StartStopResponses.java
+++ b/src/main/java/zowe/client/sdk/zostso/response/StartStopResponses.java
@@ -58,7 +58,8 @@ public class StartStopResponses {
      * @throws Exception error processing request
      * @author Frank Giordano
      */
-    public StartStopResponses(ZosmfTsoResponse zosmfTsoResponse, CollectedResponses collectedResponses) throws Exception {
+    public StartStopResponses(final ZosmfTsoResponse zosmfTsoResponse, final CollectedResponses collectedResponses)
+            throws Exception {
         this.zosmfTsoResponse = zosmfTsoResponse;
         if (!zosmfTsoResponse.getMsgData().isEmpty()) {
             // more data means more tso responses to come and as such tso command request has not ended in success yet
@@ -97,7 +98,7 @@ public class StartStopResponses {
      * @param collectedResponses list of ZosmfTsoResponse objects
      * @author Frank Giordano
      */
-    public void setCollectedResponses(List<ZosmfTsoResponse> collectedResponses) {
+    public void setCollectedResponses(final List<ZosmfTsoResponse> collectedResponses) {
         this.collectedResponses = collectedResponses;
     }
 
@@ -137,7 +138,7 @@ public class StartStopResponses {
      * @param servletKey key of tso address space
      * @author Frank Giordano
      */
-    public void setServletKey(String servletKey) {
+    public void setServletKey(final String servletKey) {
         this.servletKey = servletKey;
     }
 
@@ -152,9 +153,9 @@ public class StartStopResponses {
     }
 
     /**
-     * Retrieve success specified
+     * Retrieve is success
      *
-     * @return success value
+     * @return boolean true or false
      * @author Frank Giordano
      */
     public boolean isSuccess() {

--- a/src/main/java/zowe/client/sdk/zostso/service/TsoResponseService.java
+++ b/src/main/java/zowe/client/sdk/zostso/service/TsoResponseService.java
@@ -2,7 +2,6 @@ package zowe.client.sdk.zostso.service;
 
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
-import zowe.client.sdk.parse.JsonParseResponse;
 import zowe.client.sdk.parse.JsonParseResponseFactory;
 import zowe.client.sdk.parse.type.ParseType;
 import zowe.client.sdk.rest.Response;
@@ -56,8 +55,8 @@ public class TsoResponseService {
             final String jsonStr = tsoCmdResponse.getResponsePhrase()
                     .orElseThrow(() -> new IllegalStateException("no tsoCmdResponse phrase")).toString();
             final JSONObject jsonObject = (JSONObject) new JSONParser().parse(jsonStr);
-            final JsonParseResponse parser = JsonParseResponseFactory.buildParser(jsonObject, ParseType.TSO_CONSOLE);
-            result = (ZosmfTsoResponse) parser.parseResponse();
+            result = (ZosmfTsoResponse) JsonParseResponseFactory.buildParser(ParseType.TSO_CONSOLE)
+                    .setJsonObject(jsonObject).parseResponse();
         }
 
         return result;

--- a/src/main/java/zowe/client/sdk/zostso/service/TsoResponseService.java
+++ b/src/main/java/zowe/client/sdk/zostso/service/TsoResponseService.java
@@ -25,12 +25,12 @@ public class TsoResponseService {
      */
     private ZosmfTsoResponse zosmfPhraseResponse;
 
-    public TsoResponseService(Response response) {
+    public TsoResponseService(final Response response) {
         ValidateUtils.checkNullParameter(response == null, "response is null");
         this.tsoCmdResponse = response;
     }
 
-    public TsoResponseService(ZosmfTsoResponse zosmfResponse) {
+    public TsoResponseService(final ZosmfTsoResponse zosmfResponse) {
         ValidateUtils.checkNullParameter(zosmfResponse == null, "zosmfResponse is null");
         this.zosmfPhraseResponse = zosmfResponse;
     }

--- a/src/main/java/zowe/client/sdk/zosuss/method/IssueUss.java
+++ b/src/main/java/zowe/client/sdk/zosuss/method/IssueUss.java
@@ -34,7 +34,7 @@ public class IssueUss {
      *
      * @param connection SSHConnection object
      */
-    public IssueUss(SshConnection connection) {
+    public IssueUss(final SshConnection connection) {
         ValidateUtils.checkSshConnection(connection);
         this.connection = connection;
     }
@@ -48,7 +48,7 @@ public class IssueUss {
      * @throws Exception processing error
      * @author Frank Giordano
      */
-    public String issueCommand(String command, int timeout) throws Exception {
+    public String issueCommand(final String command, final int timeout) throws Exception {
         Session session = null;
         ChannelExec channel = null;
 

--- a/src/test/java/zowe/client/sdk/parse/DatasetParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/DatasetParseResponseTest.java
@@ -1,0 +1,75 @@
+package zowe.client.sdk.parse;
+
+import org.json.simple.JSONObject;
+import org.junit.Test;
+import zowe.client.sdk.parse.type.ParseType;
+import zowe.client.sdk.zosfiles.dsn.response.Dataset;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class DatasetParseResponseTest {
+
+    @Test
+    public void tstDatasetParseJsonStopResponseNullFail() {
+        String msg = "";
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.DATASET).setJsonObject(null);
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals("data is null", msg);
+    }
+
+    @Test
+    public void tstDatasetParseJsonStopResponseSingletonSuccess() throws Exception {
+        final JsonParseResponse parser = JsonParseResponseFactory.buildParser(ParseType.DATASET);
+        final JsonParseResponse parser2 = JsonParseResponseFactory.buildParser(ParseType.DATASET);
+        assertSame(parser, parser2);
+    }
+
+    @Test
+    public void tstDatasetParseJsonStopResponseSingletonWithDataSuccess() throws Exception {
+        final JsonParseResponse parser =
+                JsonParseResponseFactory.buildParser(ParseType.DATASET).setJsonObject(new JSONObject());
+        final JsonParseResponse parser2 =
+                JsonParseResponseFactory.buildParser(ParseType.DATASET).setJsonObject(new JSONObject());
+        assertSame(parser, parser2);
+    }
+
+    @Test
+    public void tstDatasetParseJsonStopResponseResetDataFail() {
+        String msg = "";
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.DATASET).setJsonObject(new JSONObject());
+            JsonParseResponseFactory.buildParser(ParseType.DATASET).parseResponse();
+            JsonParseResponseFactory.buildParser(ParseType.DATASET).parseResponse();
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals(ParseConstants.REQUIRED_ACTION_MSG, msg);
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.DATASET).setJsonObject(new JSONObject()).parseResponse();
+            JsonParseResponseFactory.buildParser(ParseType.DATASET).parseResponse();
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals(ParseConstants.REQUIRED_ACTION_MSG, msg);
+    }
+
+    @Test
+    public void tstDatasetParseJsonStopResponseSuccess() throws Exception {
+        final Map<String, Object> jsonMap = new HashMap<>();
+        jsonMap.put("dsname", "ver");
+        jsonMap.put("dev", "dev");
+        final JSONObject json = new JSONObject(jsonMap);
+
+        final Dataset response = (Dataset) JsonParseResponseFactory.buildParser(ParseType.DATASET)
+                .setJsonObject(json).parseResponse();
+        assertEquals("ver", response.getDsname().orElse("n\\a"));
+        assertEquals("dev", response.getDev().orElse("n\\a"));
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/parse/DatasetParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/DatasetParseResponseTest.java
@@ -1,3 +1,12 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
 package zowe.client.sdk.parse;
 
 import org.json.simple.JSONObject;
@@ -8,8 +17,15 @@ import zowe.client.sdk.zosfiles.dsn.response.Dataset;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
+/**
+ * Class containing unit tests for DatasetParseResponse.
+ *
+ * @author Frank Giordano
+ * @version 2.0
+ */
 public class DatasetParseResponseTest {
 
     @Test

--- a/src/test/java/zowe/client/sdk/parse/JobFileParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/JobFileParseResponseTest.java
@@ -1,0 +1,91 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.parse;
+
+import org.json.simple.JSONObject;
+import org.junit.Test;
+import zowe.client.sdk.parse.type.ParseType;
+import zowe.client.sdk.zosjobs.input.JobFile;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+/**
+ * Class containing unit tests for JobFileParseResponse.
+ *
+ * @author Frank Giordano
+ * @version 2.0
+ */
+public class JobFileParseResponseTest {
+
+    @Test
+    public void tstJobFileParseJsonStopResponseNullFail() {
+        String msg = "";
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.JOB_FILE).setJsonObject(null);
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals("data is null", msg);
+    }
+
+    @Test
+    public void tstJobFileParseJsonStopResponseSingletonSuccess() throws Exception {
+        final JsonParseResponse parser = JsonParseResponseFactory.buildParser(ParseType.JOB_FILE);
+        final JsonParseResponse parser2 = JsonParseResponseFactory.buildParser(ParseType.JOB_FILE);
+        assertSame(parser, parser2);
+    }
+
+    @Test
+    public void tstJobFileParseJsonStopResponseSingletonWithDataSuccess() throws Exception {
+        final JsonParseResponse parser =
+                JsonParseResponseFactory.buildParser(ParseType.JOB_FILE).setJsonObject(new JSONObject());
+        final JsonParseResponse parser2 =
+                JsonParseResponseFactory.buildParser(ParseType.JOB_FILE).setJsonObject(new JSONObject());
+        assertSame(parser, parser2);
+    }
+
+    @Test
+    public void tstJobFileParseJsonStopResponseResetDataFail() {
+        String msg = "";
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.JOB_FILE).setJsonObject(new JSONObject());
+            JsonParseResponseFactory.buildParser(ParseType.JOB_FILE).parseResponse();
+            JsonParseResponseFactory.buildParser(ParseType.JOB_FILE).parseResponse();
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals(ParseConstants.REQUIRED_ACTION_MSG, msg);
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.JOB_FILE).setJsonObject(new JSONObject()).parseResponse();
+            JsonParseResponseFactory.buildParser(ParseType.JOB_FILE).parseResponse();
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals(ParseConstants.REQUIRED_ACTION_MSG, msg);
+    }
+
+    @Test
+    public void tstJobFileParseJsonStopResponseSuccess() throws Exception {
+        final Map<String, Object> jsonMap = new HashMap<>();
+        jsonMap.put("jobname", "ver");
+        jsonMap.put("jobid", "dev");
+        final JSONObject json = new JSONObject(jsonMap);
+
+        final JobFile response = (JobFile) JsonParseResponseFactory.buildParser(ParseType.JOB_FILE)
+                .setJsonObject(json).parseResponse();
+        assertEquals("ver", response.getJobName().orElse("n\\a"));
+        assertEquals("dev", response.getJobId().orElse("n\\a"));
+        assertTrue(0 == response.getId().orElse(-1L));
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/parse/JobParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/JobParseResponseTest.java
@@ -1,0 +1,91 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.parse;
+
+import org.json.simple.JSONObject;
+import org.junit.Test;
+import zowe.client.sdk.parse.type.ParseType;
+import zowe.client.sdk.zosjobs.response.Job;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+/**
+ * Class containing unit tests for JobParseResponse.
+ *
+ * @author Frank Giordano
+ * @version 2.0
+ */
+public class JobParseResponseTest {
+
+    @Test
+    public void tstJobParseJsonStopResponseNullFail() {
+        String msg = "";
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.JOB).setJsonObject(null);
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals("data is null", msg);
+    }
+
+    @Test
+    public void tstJobParseJsonStopResponseSingletonSuccess() throws Exception {
+        final JsonParseResponse parser = JsonParseResponseFactory.buildParser(ParseType.JOB);
+        final JsonParseResponse parser2 = JsonParseResponseFactory.buildParser(ParseType.JOB);
+        assertSame(parser, parser2);
+    }
+
+    @Test
+    public void tstJobParseJsonStopResponseSingletonWithDataSuccess() throws Exception {
+        final JsonParseResponse parser =
+                JsonParseResponseFactory.buildParser(ParseType.JOB).setJsonObject(new JSONObject());
+        final JsonParseResponse parser2 =
+                JsonParseResponseFactory.buildParser(ParseType.JOB).setJsonObject(new JSONObject());
+        assertSame(parser, parser2);
+    }
+
+    @Test
+    public void tstJobParseJsonStopResponseResetDataFail() {
+        String msg = "";
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.JOB).setJsonObject(new JSONObject());
+            JsonParseResponseFactory.buildParser(ParseType.JOB).parseResponse();
+            JsonParseResponseFactory.buildParser(ParseType.JOB).parseResponse();
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals(ParseConstants.REQUIRED_ACTION_MSG, msg);
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.JOB).setJsonObject(new JSONObject()).parseResponse();
+            JsonParseResponseFactory.buildParser(ParseType.JOB).parseResponse();
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals(ParseConstants.REQUIRED_ACTION_MSG, msg);
+    }
+
+    @Test
+    public void tstJobParseJsonStopResponseSuccess() throws Exception {
+        final Map<String, Object> jsonMap = new HashMap<>();
+        jsonMap.put("jobname", "ver");
+        jsonMap.put("jobid", "dev");
+        final JSONObject json = new JSONObject(jsonMap);
+
+        final Job response = (Job) JsonParseResponseFactory.buildParser(ParseType.JOB)
+                .setJsonObject(json).parseResponse();
+        assertEquals("ver", response.getJobName().orElse("n\\a"));
+        assertEquals("dev", response.getJobId().orElse("n\\a"));
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/parse/MemberParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/MemberParseResponseTest.java
@@ -1,0 +1,91 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.parse;
+
+import org.json.simple.JSONObject;
+import org.junit.Test;
+import zowe.client.sdk.parse.type.ParseType;
+import zowe.client.sdk.zosfiles.dsn.response.Member;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+/**
+ * Class containing unit tests for emberParseResponse.
+ *
+ * @author Frank Giordano
+ * @version 2.0
+ */
+public class MemberParseResponseTest {
+
+    @Test
+    public void tstMemberParseJsonStopResponseNullFail() {
+        String msg = "";
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.MEMBER).setJsonObject(null);
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals("data is null", msg);
+    }
+
+    @Test
+    public void tstMemberParseJsonStopResponseSingletonSuccess() throws Exception {
+        final JsonParseResponse parser = JsonParseResponseFactory.buildParser(ParseType.MEMBER);
+        final JsonParseResponse parser2 = JsonParseResponseFactory.buildParser(ParseType.MEMBER);
+        assertSame(parser, parser2);
+    }
+
+    @Test
+    public void tstMemberParseJsonStopResponseSingletonWithDataSuccess() throws Exception {
+        final JsonParseResponse parser =
+                JsonParseResponseFactory.buildParser(ParseType.MEMBER).setJsonObject(new JSONObject());
+        final JsonParseResponse parser2 =
+                JsonParseResponseFactory.buildParser(ParseType.MEMBER).setJsonObject(new JSONObject());
+        assertSame(parser, parser2);
+    }
+
+    @Test
+    public void tstMemberParseJsonStopResponseResetDataFail() {
+        String msg = "";
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.MEMBER).setJsonObject(new JSONObject());
+            JsonParseResponseFactory.buildParser(ParseType.MEMBER).parseResponse();
+            JsonParseResponseFactory.buildParser(ParseType.MEMBER).parseResponse();
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals(ParseConstants.REQUIRED_ACTION_MSG, msg);
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.MEMBER).setJsonObject(new JSONObject()).parseResponse();
+            JsonParseResponseFactory.buildParser(ParseType.MEMBER).parseResponse();
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals(ParseConstants.REQUIRED_ACTION_MSG, msg);
+    }
+
+    @Test
+    public void tstMemberParseJsonStopResponseSuccess() throws Exception {
+        final Map<String, Object> jsonMap = new HashMap<>();
+        jsonMap.put("member", "ver");
+        jsonMap.put("vers", 0L);
+        final JSONObject json = new JSONObject(jsonMap);
+
+        final Member response = (Member) JsonParseResponseFactory.buildParser(ParseType.MEMBER)
+                .setJsonObject(json).parseResponse();
+        assertEquals("ver", response.getMember().orElse("n\\a"));
+        assertEquals(Long.parseLong("0"), response.getVers().orElse(-1L));
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/parse/MvsConsoleParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/MvsConsoleParseResponseTest.java
@@ -1,0 +1,89 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.parse;
+
+import org.json.simple.JSONObject;
+import org.junit.Test;
+import zowe.client.sdk.parse.type.ParseType;
+import zowe.client.sdk.zosconsole.response.ZosmfIssueResponse;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+/**
+ * Class containing unit tests for MvsConsoleParseResponse.
+ *
+ * @author Frank Giordano
+ * @version 2.0
+ */
+public class MvsConsoleParseResponseTest {
+
+    @Test
+    public void tstMvsConsoleParseJsonStopResponseNullFail() {
+        String msg = "";
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.MVS_CONSOLE).setJsonObject(null);
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals("data is null", msg);
+    }
+
+    @Test
+    public void tstMvsConsoleParseJsonStopResponseSingletonSuccess() throws Exception {
+        final JsonParseResponse parser = JsonParseResponseFactory.buildParser(ParseType.MVS_CONSOLE);
+        final JsonParseResponse parser2 = JsonParseResponseFactory.buildParser(ParseType.MVS_CONSOLE);
+        assertSame(parser, parser2);
+    }
+
+    @Test
+    public void tstMvsConsoleParseJsonStopResponseSingletonWithDataSuccess() throws Exception {
+        final JsonParseResponse parser =
+                JsonParseResponseFactory.buildParser(ParseType.MVS_CONSOLE).setJsonObject(new JSONObject());
+        final JsonParseResponse parser2 =
+                JsonParseResponseFactory.buildParser(ParseType.MVS_CONSOLE).setJsonObject(new JSONObject());
+        assertSame(parser, parser2);
+    }
+
+    @Test
+    public void tstMvsConsoleParseJsonStopResponseResetDataFail() {
+        String msg = "";
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.MVS_CONSOLE).setJsonObject(new JSONObject());
+            JsonParseResponseFactory.buildParser(ParseType.MVS_CONSOLE).parseResponse();
+            JsonParseResponseFactory.buildParser(ParseType.MVS_CONSOLE).parseResponse();
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals(ParseConstants.REQUIRED_ACTION_MSG, msg);
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.MVS_CONSOLE).setJsonObject(new JSONObject()).parseResponse();
+            JsonParseResponseFactory.buildParser(ParseType.MVS_CONSOLE).parseResponse();
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals(ParseConstants.REQUIRED_ACTION_MSG, msg);
+    }
+
+    @Test
+    public void tstMvsConsoleParseJsonStopResponseSuccess() throws Exception {
+        final Map<String, Object> jsonMap = new HashMap<>();
+        jsonMap.put("cmd-response", "ver");
+        final JSONObject json = new JSONObject(jsonMap);
+
+        final ZosmfIssueResponse response = (ZosmfIssueResponse) JsonParseResponseFactory
+                .buildParser(ParseType.MVS_CONSOLE).setJsonObject(json).parseResponse();
+        assertEquals("ver", response.getCmdResponse().orElse("n\\a"));
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/parse/PropsParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/PropsParseResponseTest.java
@@ -1,0 +1,89 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.parse;
+
+import org.json.simple.JSONObject;
+import org.junit.Test;
+import zowe.client.sdk.parse.type.ParseType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+/**
+ * Class containing unit tests for PropsParseResponse.
+ *
+ * @author Frank Giordano
+ * @version 2.0
+ */
+public class PropsParseResponseTest {
+
+    @Test
+    public void tstPropsParseJsonStopResponseNullFail() {
+        String msg = "";
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.PROPS).setJsonObject(null);
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals("data is null", msg);
+    }
+
+    @Test
+    public void tstPropsParseJsonStopResponseSingletonSuccess() throws Exception {
+        final JsonParseResponse parser = JsonParseResponseFactory.buildParser(ParseType.PROPS);
+        final JsonParseResponse parser2 = JsonParseResponseFactory.buildParser(ParseType.PROPS);
+        assertSame(parser, parser2);
+    }
+
+    @Test
+    public void tstPropsParseJsonStopResponseSingletonWithDataSuccess() throws Exception {
+        final JsonParseResponse parser =
+                JsonParseResponseFactory.buildParser(ParseType.PROPS).setJsonObject(new JSONObject());
+        final JsonParseResponse parser2 =
+                JsonParseResponseFactory.buildParser(ParseType.PROPS).setJsonObject(new JSONObject());
+        assertSame(parser, parser2);
+    }
+
+    @Test
+    public void tstPropsParseJsonStopResponseResetDataFail() {
+        String msg = "";
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.PROPS).setJsonObject(new JSONObject());
+            JsonParseResponseFactory.buildParser(ParseType.PROPS).parseResponse();
+            JsonParseResponseFactory.buildParser(ParseType.PROPS).parseResponse();
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals(ParseConstants.REQUIRED_ACTION_MSG, msg);
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.PROPS).setJsonObject(new JSONObject()).parseResponse();
+            JsonParseResponseFactory.buildParser(ParseType.PROPS).parseResponse();
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals(ParseConstants.REQUIRED_ACTION_MSG, msg);
+    }
+
+    @Test
+    public void tstPropsParseJsonStopResponseSuccess() throws Exception {
+        final Map<String, Object> jsonMap = new HashMap<>();
+        jsonMap.put("cmd-response", "ver");
+        final JSONObject json = new JSONObject(jsonMap);
+
+        final Map<String, String> response = (Map<String, String>) JsonParseResponseFactory
+                .buildParser(ParseType.PROPS).setJsonObject(json).parseResponse();
+        assertEquals("ver", response.get("cmd-response"));
+    }
+
+
+}

--- a/src/test/java/zowe/client/sdk/parse/SystemInfoParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/SystemInfoParseResponseTest.java
@@ -1,0 +1,92 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.parse;
+
+import org.json.simple.JSONObject;
+import org.junit.Test;
+import zowe.client.sdk.parse.type.ParseType;
+import zowe.client.sdk.zosmfinfo.response.ZosmfInfoResponse;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+/**
+ * Class containing unit tests for SystemInfoParseResponse.
+ *
+ * @author Frank Giordano
+ * @version 2.0
+ */
+public class SystemInfoParseResponseTest {
+
+    @Test
+    public void tstZosmfInfoParseJsonStopResponseNullFail() {
+        String msg = "";
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.ZOSMF_INFO).setJsonObject(null);
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals("data is null", msg);
+    }
+
+    @Test
+    public void tstZosmfInfoParseJsonStopResponseSingletonSuccess() throws Exception {
+        final JsonParseResponse parser = JsonParseResponseFactory.buildParser(ParseType.ZOSMF_INFO);
+        final JsonParseResponse parser2 = JsonParseResponseFactory.buildParser(ParseType.ZOSMF_INFO);
+        assertSame(parser, parser2);
+    }
+
+    @Test
+    public void tstZosmfInfoParseJsonStopResponseSingletonWithDataSuccess() throws Exception {
+        final JsonParseResponse parser =
+                JsonParseResponseFactory.buildParser(ParseType.ZOSMF_INFO).setJsonObject(new JSONObject());
+        final JsonParseResponse parser2 =
+                JsonParseResponseFactory.buildParser(ParseType.ZOSMF_INFO).setJsonObject(new JSONObject());
+        assertSame(parser, parser2);
+    }
+
+    @Test
+    public void tstZosmfInfoParseJsonStopResponseResetDataFail() {
+        String msg = "";
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.ZOSMF_INFO).setJsonObject(new JSONObject());
+            JsonParseResponseFactory.buildParser(ParseType.ZOSMF_INFO).parseResponse();
+            JsonParseResponseFactory.buildParser(ParseType.ZOSMF_INFO).parseResponse();
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals(ParseConstants.REQUIRED_ACTION_MSG, msg);
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.ZOSMF_INFO).setJsonObject(new JSONObject()).parseResponse();
+            JsonParseResponseFactory.buildParser(ParseType.ZOSMF_INFO).parseResponse();
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals(ParseConstants.REQUIRED_ACTION_MSG, msg);
+    }
+
+    @Test
+    public void tstZosmfInfoParseJsonStopResponseSuccess() throws Exception {
+        final Map<String, Object> jsonMap = new HashMap<>();
+        jsonMap.put("api_version", "ver");
+        jsonMap.put("zosmf_port", "dev");
+        final JSONObject json = new JSONObject(jsonMap);
+
+        final ZosmfInfoResponse response = (ZosmfInfoResponse) JsonParseResponseFactory.buildParser(ParseType.ZOSMF_INFO)
+                .setJsonObject(json).parseResponse();
+        assertEquals("ver", response.getApiVersion().orElse("n\\a"));
+        assertEquals("dev", response.getZosmfPort().orElse("n\\a"));
+        assertEquals("n\\a", response.getZosVersion().orElse("n\\a"));
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/parse/SystemsParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/SystemsParseResponseTest.java
@@ -1,0 +1,86 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.parse;
+
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.junit.Test;
+import zowe.client.sdk.parse.type.ParseType;
+import zowe.client.sdk.zosmfinfo.response.ZosmfSystemsResponse;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+/**
+ * Class containing unit tests for SystemsParseResponse.
+ *
+ * @author Frank Giordano
+ * @version 2.0
+ */
+public class SystemsParseResponseTest {
+
+    @Test
+    public void tstZosmfSystemsParseJsonStopResponseNullFail() {
+        String msg = "";
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.ZOSMF_SYSTEMS).setJsonObject(null);
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals("data is null", msg);
+    }
+
+    @Test
+    public void tstZosmfSystemsParseJsonStopResponseSingletonSuccess() throws Exception {
+        final JsonParseResponse parser = JsonParseResponseFactory.buildParser(ParseType.ZOSMF_SYSTEMS);
+        final JsonParseResponse parser2 = JsonParseResponseFactory.buildParser(ParseType.ZOSMF_SYSTEMS);
+        assertSame(parser, parser2);
+    }
+
+    @Test
+    public void tstZosmfSystemsParseJsonStopResponseSingletonWithDataSuccess() throws Exception {
+        final JsonParseResponse parser =
+                JsonParseResponseFactory.buildParser(ParseType.ZOSMF_SYSTEMS).setJsonObject(new JSONObject());
+        final JsonParseResponse parser2 =
+                JsonParseResponseFactory.buildParser(ParseType.ZOSMF_SYSTEMS).setJsonObject(new JSONObject());
+        assertSame(parser, parser2);
+    }
+
+    @Test
+    public void tstZosmfSystemsParseJsonStopResponseResetDataFail() {
+        String msg = "";
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.ZOSMF_SYSTEMS).setJsonObject(new JSONObject());
+            JsonParseResponseFactory.buildParser(ParseType.ZOSMF_SYSTEMS).parseResponse();
+            JsonParseResponseFactory.buildParser(ParseType.ZOSMF_SYSTEMS).parseResponse();
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals(ParseConstants.REQUIRED_ACTION_MSG, msg);
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.ZOSMF_SYSTEMS).setJsonObject(new JSONObject()).parseResponse();
+            JsonParseResponseFactory.buildParser(ParseType.ZOSMF_SYSTEMS).parseResponse();
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals(ParseConstants.REQUIRED_ACTION_MSG, msg);
+    }
+
+    @Test
+    public void tstZosmfSystemsParseJsonStopResponseSuccess() throws Exception {
+        final String data = "{\"items\":[{\"systemNickName\":\"test\",\"zosVR\":\"2.5\"}],\"numRows\":1}";
+        final JSONObject json = new JSONObject((JSONObject) new JSONParser().parse(data));
+        final ZosmfSystemsResponse response = (ZosmfSystemsResponse) JsonParseResponseFactory
+                .buildParser(ParseType.ZOSMF_SYSTEMS).setJsonObject(json).parseResponse();
+        assertEquals(Long.parseLong("1"), response.getNumRows().orElse(-1L));
+        assertEquals("test", response.getDefinedSystems().get()[0].getSystemNickName().get());
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/parse/TsoParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/TsoParseResponseTest.java
@@ -1,0 +1,91 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.parse;
+
+import org.json.simple.JSONObject;
+import org.junit.Test;
+import zowe.client.sdk.parse.type.ParseType;
+import zowe.client.sdk.zostso.message.ZosmfTsoResponse;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+/**
+ * Class containing unit tests for TsoParseResponse.
+ *
+ * @author Frank Giordano
+ * @version 2.0
+ */
+public class TsoParseResponseTest {
+
+    @Test
+    public void tstTsoParseJsonStopResponseNullFail() {
+        String msg = "";
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.TSO_CONSOLE).setJsonObject(null);
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals("data is null", msg);
+    }
+
+    @Test
+    public void tstTsoParseJsonStopResponseSingletonSuccess() throws Exception {
+        final JsonParseResponse parser = JsonParseResponseFactory.buildParser(ParseType.TSO_CONSOLE);
+        final JsonParseResponse parser2 = JsonParseResponseFactory.buildParser(ParseType.TSO_CONSOLE);
+        assertSame(parser, parser2);
+    }
+
+    @Test
+    public void tstTsoParseJsonStopResponseSingletonWithDataSuccess() throws Exception {
+        final JsonParseResponse parser =
+                JsonParseResponseFactory.buildParser(ParseType.TSO_CONSOLE).setJsonObject(new JSONObject());
+        final JsonParseResponse parser2 =
+                JsonParseResponseFactory.buildParser(ParseType.TSO_CONSOLE).setJsonObject(new JSONObject());
+        assertSame(parser, parser2);
+    }
+
+    @Test
+    public void tstTsoParseJsonStopResponseResetDataFail() {
+        String msg = "";
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.TSO_CONSOLE).setJsonObject(new JSONObject());
+            JsonParseResponseFactory.buildParser(ParseType.TSO_CONSOLE).parseResponse();
+            JsonParseResponseFactory.buildParser(ParseType.TSO_CONSOLE).parseResponse();
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals(ParseConstants.REQUIRED_ACTION_MSG, msg);
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.TSO_CONSOLE).setJsonObject(new JSONObject()).parseResponse();
+            JsonParseResponseFactory.buildParser(ParseType.TSO_CONSOLE).parseResponse();
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals(ParseConstants.REQUIRED_ACTION_MSG, msg);
+    }
+
+    @Test
+    public void tstTsoParseJsonStopResponseSuccess() throws Exception {
+        final Map<String, Object> jsonMap = new HashMap<>();
+        jsonMap.put("ver", "ver");
+        jsonMap.put("servletKey", "key");
+        final JSONObject json = new JSONObject(jsonMap);
+
+        final ZosmfTsoResponse response = (ZosmfTsoResponse) JsonParseResponseFactory.buildParser(ParseType.TSO_CONSOLE)
+                .setJsonObject(json).parseResponse();
+        assertEquals("ver", response.getVer().orElse("n\\a"));
+        assertEquals("key", response.getServletKey().orElse("n\\a"));
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/parse/TsoStopParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/TsoStopParseResponseTest.java
@@ -87,8 +87,8 @@ public class TsoStopParseResponseTest {
                 .setJsonObject(json).parseResponse();
         assertEquals("ver", response.getVer().orElse("n\\a"));
         assertEquals("servletKey", response.getServletKey().orElse("n\\a"));
-        assertTrue(response.getReused().orElse(false));
-        assertTrue(response.getTimeout().orElse(false));
+        assertTrue(response.isReused());
+        assertTrue(response.isTimeout());
     }
 
 }

--- a/src/test/java/zowe/client/sdk/parse/TsoStopParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/TsoStopParseResponseTest.java
@@ -18,7 +18,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.*;
-import static org.junit.Assert.assertSame;
 
 /**
  * Class containing unit tests for TsoStopParseResponse.

--- a/src/test/java/zowe/client/sdk/parse/TsoStopParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/TsoStopParseResponseTest.java
@@ -17,8 +17,8 @@ import zowe.client.sdk.zostso.message.ZosmfTsoResponse;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertSame;
 
 /**
  * Class containing unit tests for TsoStopParseResponse.
@@ -29,18 +29,54 @@ import static org.junit.Assert.assertTrue;
 public class TsoStopParseResponseTest {
 
     @Test
-    public void tstParseJsonStopResponseNullFail() {
+    public void tstTsoStopParseJsonStopResponseNullFail() {
         String msg = "";
         try {
-            JsonParseResponseFactory.buildParser(null, ParseType.TSO_STOP);
+            JsonParseResponseFactory.buildParser(ParseType.TSO_STOP).setJsonObject(null);
         } catch (Exception e) {
             msg = e.getMessage();
         }
-        assertEquals("json data is null", msg);
+        assertEquals("data is null", msg);
     }
 
     @Test
-    public void tstParseJsonStopResponseSuccess() throws Exception {
+    public void tstTsoStopParseJsonStopResponseSingletonSuccess() throws Exception {
+        final JsonParseResponse parser = JsonParseResponseFactory.buildParser(ParseType.TSO_STOP);
+        final JsonParseResponse parser2 = JsonParseResponseFactory.buildParser(ParseType.TSO_STOP);
+        assertSame(parser, parser2);
+    }
+
+    @Test
+    public void tstTsoStopParseJsonStopResponseSingletonWithDataSuccess() throws Exception {
+        final JsonParseResponse parser =
+                JsonParseResponseFactory.buildParser(ParseType.TSO_STOP).setJsonObject(new JSONObject());
+        final JsonParseResponse parser2 =
+                JsonParseResponseFactory.buildParser(ParseType.TSO_STOP).setJsonObject(new JSONObject());
+        assertSame(parser, parser2);
+    }
+
+    @Test
+    public void tstTsoStopParseJsonStopResponseResetDataFail() {
+        String msg = "";
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.TSO_STOP).setJsonObject(new JSONObject());
+            JsonParseResponseFactory.buildParser(ParseType.TSO_STOP).parseResponse();
+            JsonParseResponseFactory.buildParser(ParseType.TSO_STOP).parseResponse();
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals(ParseConstants.REQUIRED_ACTION_MSG, msg);
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.TSO_STOP).setJsonObject(new JSONObject()).parseResponse();
+            JsonParseResponseFactory.buildParser(ParseType.TSO_STOP).parseResponse();
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals(ParseConstants.REQUIRED_ACTION_MSG, msg);
+    }
+
+    @Test
+    public void tstTsoStopParseJsonStopResponseSuccess() throws Exception {
         final Map<String, Object> jsonMap = new HashMap<>();
         jsonMap.put("ver", "ver");
         jsonMap.put("servletKey", "servletKey");
@@ -48,12 +84,12 @@ public class TsoStopParseResponseTest {
         jsonMap.put("timeout", true);
         final JSONObject json = new JSONObject(jsonMap);
 
-        final ZosmfTsoResponse response =
-                (ZosmfTsoResponse) JsonParseResponseFactory.buildParser(json, ParseType.TSO_STOP).parseResponse();
-        assertEquals("ver", response.getVer().get());
-        assertEquals("servletKey", response.getServletKey().get());
-        assertTrue(response.getReused().get());
-        assertTrue(response.getTimeout().get());
+        final ZosmfTsoResponse response = (ZosmfTsoResponse) JsonParseResponseFactory.buildParser(ParseType.TSO_STOP)
+                .setJsonObject(json).parseResponse();
+        assertEquals("ver", response.getVer().orElse("n\\a"));
+        assertEquals("servletKey", response.getServletKey().orElse("n\\a"));
+        assertTrue(response.getReused().orElse(false));
+        assertTrue(response.getTimeout().orElse(false));
     }
 
 }

--- a/src/test/java/zowe/client/sdk/parse/UnixFileParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/UnixFileParseResponseTest.java
@@ -1,0 +1,91 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.parse;
+
+import org.json.simple.JSONObject;
+import org.junit.Test;
+import zowe.client.sdk.parse.type.ParseType;
+import zowe.client.sdk.zosfiles.uss.response.UnixFile;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+/**
+ * Class containing unit tests for UnixFileParseResponse.
+ *
+ * @author Frank Giordano
+ * @version 2.0
+ */
+public class UnixFileParseResponseTest {
+
+    @Test
+    public void tstUnixFileParseJsonStopResponseNullFail() {
+        String msg = "";
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.UNIX_FILE).setJsonObject(null);
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals("data is null", msg);
+    }
+
+    @Test
+    public void tstUnixFileParseJsonStopResponseSingletonSuccess() throws Exception {
+        final JsonParseResponse parser = JsonParseResponseFactory.buildParser(ParseType.UNIX_FILE);
+        final JsonParseResponse parser2 = JsonParseResponseFactory.buildParser(ParseType.UNIX_FILE);
+        assertSame(parser, parser2);
+    }
+
+    @Test
+    public void tstUnixFileParseJsonStopResponseSingletonWithDataSuccess() throws Exception {
+        final JsonParseResponse parser =
+                JsonParseResponseFactory.buildParser(ParseType.UNIX_FILE).setJsonObject(new JSONObject());
+        final JsonParseResponse parser2 =
+                JsonParseResponseFactory.buildParser(ParseType.UNIX_FILE).setJsonObject(new JSONObject());
+        assertSame(parser, parser2);
+    }
+
+    @Test
+    public void tstUnixFileParseJsonStopResponseResetDataFail() {
+        String msg = "";
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.UNIX_FILE).setJsonObject(new JSONObject());
+            JsonParseResponseFactory.buildParser(ParseType.UNIX_FILE).parseResponse();
+            JsonParseResponseFactory.buildParser(ParseType.UNIX_FILE).parseResponse();
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals(ParseConstants.REQUIRED_ACTION_MSG, msg);
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.UNIX_FILE).setJsonObject(new JSONObject()).parseResponse();
+            JsonParseResponseFactory.buildParser(ParseType.UNIX_FILE).parseResponse();
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals(ParseConstants.REQUIRED_ACTION_MSG, msg);
+    }
+
+    @Test
+    public void tstUnixFileParseJsonStopResponseSuccess() throws Exception {
+        final Map<String, Object> jsonMap = new HashMap<>();
+        jsonMap.put("name", "ver");
+        jsonMap.put("mode", "mode");
+        final JSONObject json = new JSONObject(jsonMap);
+
+        final UnixFile response = (UnixFile) JsonParseResponseFactory.buildParser(ParseType.UNIX_FILE)
+                .setJsonObject(json).parseResponse();
+        assertEquals("ver", response.getName().orElse("n\\a"));
+        assertEquals("mode", response.getMode().orElse("n\\a"));
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/parse/UnixZfsParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/UnixZfsParseResponseTest.java
@@ -1,0 +1,110 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.parse;
+
+import org.json.simple.JSONObject;
+import org.junit.Test;
+import zowe.client.sdk.parse.type.ParseType;
+import zowe.client.sdk.zosfiles.uss.response.UnixZfs;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+/**
+ * Class containing unit tests for UnixZfsParseResponse.
+ *
+ * @author Frank Giordano
+ * @version 2.0
+ */
+public class UnixZfsParseResponseTest {
+
+    @Test
+    public void tstUnixZfsParseJsonStopResponseDataNullFail() {
+        String msg = "";
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.UNIX_ZFS).setJsonObject(null);
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals("data is null", msg);
+    }
+
+    @Test
+    public void tstUnixZfsParseJsonStopResponseModeNullFail() {
+        String msg = "";
+        try {
+            final UnixZfsParseResponse parser = (UnixZfsParseResponse)
+                    JsonParseResponseFactory.buildParser(ParseType.UNIX_ZFS).setJsonObject(new JSONObject());
+            parser.setModeStr(null);
+            parser.parseResponse();
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals("modeStr is null", msg);
+    }
+
+    @Test
+    public void tstUnixZfsParseJsonStopResponseSingletonSuccess() throws Exception {
+        final JsonParseResponse parser = JsonParseResponseFactory.buildParser(ParseType.UNIX_ZFS);
+        final JsonParseResponse parser2 = JsonParseResponseFactory.buildParser(ParseType.UNIX_ZFS);
+        assertSame(parser, parser2);
+    }
+
+    @Test
+    public void tstUnixZfsParseJsonStopResponseSingletonWithDataSuccess() throws Exception {
+        final JsonParseResponse parser =
+                JsonParseResponseFactory.buildParser(ParseType.UNIX_ZFS).setJsonObject(new JSONObject());
+        final JsonParseResponse parser2 =
+                JsonParseResponseFactory.buildParser(ParseType.UNIX_ZFS).setJsonObject(new JSONObject());
+        assertSame(parser, parser2);
+    }
+
+    @Test
+    public void tstUnixZfsParseJsonStopResponseResetDataModeFail() {
+        String msg = "";
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.UNIX_ZFS).setJsonObject(new JSONObject());
+            JsonParseResponseFactory.buildParser(ParseType.UNIX_ZFS).parseResponse();
+            JsonParseResponseFactory.buildParser(ParseType.UNIX_ZFS).parseResponse();
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals(ParseConstants.REQUIRED_ACTION_MODE_STR_MSG, msg);
+        try {
+            final UnixZfsParseResponse parser = (UnixZfsParseResponse)
+                    JsonParseResponseFactory.buildParser(ParseType.UNIX_ZFS).setJsonObject(new JSONObject());
+            parser.setModeStr("sd");
+            parser.parseResponse();
+            parser.parseResponse();
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals(ParseConstants.REQUIRED_ACTION_MSG, msg);
+    }
+
+    @Test
+    public void tstUnixZfsParseJsonStopResponseSuccess() throws Exception {
+        final Map<String, Object> jsonMap = new HashMap<>();
+        jsonMap.put("name", "ver");
+        jsonMap.put("mode", "mode");
+        final JSONObject json = new JSONObject(jsonMap);
+
+        final UnixZfsParseResponse parser = (UnixZfsParseResponse)
+                JsonParseResponseFactory.buildParser(ParseType.UNIX_ZFS).setJsonObject(json);
+        parser.setModeStr("mode");
+        final UnixZfs response = parser.parseResponse();
+        assertEquals("ver", response.getName().orElse("n\\a"));
+        assertEquals("mode", response.getMode().orElse("n\\a"));
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/parse/ZosLogItemParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/ZosLogItemParseResponseTest.java
@@ -1,0 +1,91 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.parse;
+
+import org.json.simple.JSONObject;
+import org.junit.Test;
+import zowe.client.sdk.parse.type.ParseType;
+import zowe.client.sdk.zoslogs.response.ZosLogItem;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+/**
+ * Class containing unit tests for ZosLogItemParseResponse.
+ *
+ * @author Frank Giordano
+ * @version 2.0
+ */
+public class ZosLogItemParseResponseTest {
+
+    @Test
+    public void tstZosLogItemParseJsonStopResponseNullFail() {
+        String msg = "";
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.ZOS_LOG_ITEM).setJsonObject(null);
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals("data is null", msg);
+    }
+
+    @Test
+    public void tstZosLogItemParseJsonStopResponseSingletonSuccess() throws Exception {
+        final JsonParseResponse parser = JsonParseResponseFactory.buildParser(ParseType.ZOS_LOG_ITEM);
+        final JsonParseResponse parser2 = JsonParseResponseFactory.buildParser(ParseType.ZOS_LOG_ITEM);
+        assertSame(parser, parser2);
+    }
+
+    @Test
+    public void tstZosLogItemParseJsonStopResponseSingletonWithDataSuccess() throws Exception {
+        final JsonParseResponse parser =
+                JsonParseResponseFactory.buildParser(ParseType.ZOS_LOG_ITEM).setJsonObject(new JSONObject());
+        final JsonParseResponse parser2 =
+                JsonParseResponseFactory.buildParser(ParseType.ZOS_LOG_ITEM).setJsonObject(new JSONObject());
+        assertSame(parser, parser2);
+    }
+
+    @Test
+    public void tstZosLogItemParseJsonStopResponseResetDataFail() {
+        String msg = "";
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.ZOS_LOG_ITEM).setJsonObject(new JSONObject());
+            JsonParseResponseFactory.buildParser(ParseType.ZOS_LOG_ITEM).parseResponse();
+            JsonParseResponseFactory.buildParser(ParseType.ZOS_LOG_ITEM).parseResponse();
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals(ParseConstants.REQUIRED_ACTION_MSG, msg);
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.ZOS_LOG_ITEM).setJsonObject(new JSONObject()).parseResponse();
+            JsonParseResponseFactory.buildParser(ParseType.ZOS_LOG_ITEM).parseResponse();
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals(ParseConstants.REQUIRED_ACTION_MSG, msg);
+    }
+
+    @Test
+    public void tstZosLogItemParseJsonStopResponseSuccess() throws Exception {
+        final Map<String, Object> jsonMap = new HashMap<>();
+        jsonMap.put("jobName", "ver");
+        jsonMap.put("message", "message");
+        final JSONObject json = new JSONObject(jsonMap);
+
+        final ZosLogItem response = (ZosLogItem) JsonParseResponseFactory.buildParser(ParseType.ZOS_LOG_ITEM)
+                .setJsonObject(json).parseResponse();
+        assertEquals("ver", response.getJobName().orElse("n\\a"));
+        assertEquals("message", response.getMessage().orElse("n\\a"));
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/parse/ZosLogReplyParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/ZosLogReplyParseResponseTest.java
@@ -1,0 +1,98 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.parse;
+
+import org.json.simple.JSONObject;
+import org.junit.Test;
+import zowe.client.sdk.parse.type.ParseType;
+import zowe.client.sdk.zoslogs.response.ZosLogReply;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+/**
+ * Class containing unit tests for ZosLogReplyParseResponse.
+ *
+ * @author Frank Giordano
+ * @version 2.0
+ */
+public class ZosLogReplyParseResponseTest {
+
+    @Test
+    public void tstZosLogReplyParseJsonStopResponseNullFail() {
+        String msg = "";
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.ZOS_LOG_REPLY).setJsonObject(null);
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals("data is null", msg);
+    }
+
+    @Test
+    public void tstZosLogReplyParseJsonStopResponseSingletonSuccess() throws Exception {
+        final JsonParseResponse parser = JsonParseResponseFactory.buildParser(ParseType.ZOS_LOG_REPLY);
+        final JsonParseResponse parser2 = JsonParseResponseFactory.buildParser(ParseType.ZOS_LOG_REPLY);
+        assertSame(parser, parser2);
+    }
+
+    @Test
+    public void tstZosLogReplyParseJsonStopResponseSingletonWithDataSuccess() throws Exception {
+        final JsonParseResponse parser =
+                JsonParseResponseFactory.buildParser(ParseType.ZOS_LOG_REPLY).setJsonObject(new JSONObject());
+        final JsonParseResponse parser2 =
+                JsonParseResponseFactory.buildParser(ParseType.ZOS_LOG_REPLY).setJsonObject(new JSONObject());
+        assertSame(parser, parser2);
+    }
+
+    @Test
+    public void tstUnixZfsParseJsonStopResponseResetDataModeFail() {
+        String msg = "";
+        try {
+            JsonParseResponseFactory.buildParser(ParseType.ZOS_LOG_REPLY).setJsonObject(new JSONObject());
+            JsonParseResponseFactory.buildParser(ParseType.ZOS_LOG_REPLY).parseResponse();
+            JsonParseResponseFactory.buildParser(ParseType.ZOS_LOG_REPLY).parseResponse();
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals(ParseConstants.REQUIRED_ACTION_ZOS_LOG_ITEMS_MSG, msg);
+        try {
+            final ZosLogReplyParseResponse parser = (ZosLogReplyParseResponse)
+                    JsonParseResponseFactory.buildParser(ParseType.ZOS_LOG_REPLY).setJsonObject(new JSONObject());
+            parser.setZosLogItems(new ArrayList<>());
+            parser.parseResponse();
+            parser.parseResponse();
+        } catch (Exception e) {
+            msg = e.getMessage();
+        }
+        assertEquals(ParseConstants.REQUIRED_ACTION_MSG, msg);
+    }
+
+    @Test
+    public void tstZosLogReplyParseJsonStopResponseSuccess() throws Exception {
+        final Map<String, Object> jsonMap = new HashMap<>();
+        jsonMap.put("totalitems", 1L);
+        jsonMap.put("source", "dev");
+        final JSONObject json = new JSONObject(jsonMap);
+
+        final ZosLogReplyParseResponse parser = (ZosLogReplyParseResponse)
+                JsonParseResponseFactory.buildParser(ParseType.ZOS_LOG_REPLY).setJsonObject(json);
+        parser.setZosLogItems(new ArrayList<>());
+
+        final ZosLogReply response = parser.parseResponse();
+        assertEquals(Long.parseLong("1"), response.getTotalItems().orElse(-1L));
+        assertEquals("dev", response.getSource().orElse("n\\a"));
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/utility/RestUtilsTest.java
+++ b/src/test/java/zowe/client/sdk/utility/RestUtilsTest.java
@@ -142,7 +142,7 @@ public class RestUtilsTest {
         Mockito.when(mockRequest.executeRequest()).thenReturn(
                 new Response(new JSONObject(), 200, "success"));
         Response response = RestUtils.getResponse(mockRequest);
-        assertEquals("200", response.getStatusCode().get().toString());
+        assertEquals(200, response.getStatusCode().getAsInt());
         assertEquals("{}", response.getResponsePhrase().get().toString());
         assertEquals("success", response.getStatusText().get().toString());
     }

--- a/src/test/java/zowe/client/sdk/utility/RestUtilsTest.java
+++ b/src/test/java/zowe/client/sdk/utility/RestUtilsTest.java
@@ -12,6 +12,7 @@ package zowe.client.sdk.utility;
 import org.json.simple.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.mockito.Mockito;
 import zowe.client.sdk.rest.Response;
 import zowe.client.sdk.rest.ZoweRequest;
@@ -142,9 +143,9 @@ public class RestUtilsTest {
         Mockito.when(mockRequest.executeRequest()).thenReturn(
                 new Response(new JSONObject(), 200, "success"));
         Response response = RestUtils.getResponse(mockRequest);
-        assertEquals(200, response.getStatusCode().getAsInt());
-        assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals("success", response.getStatusText().get().toString());
+        Assertions.assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        Assertions.assertEquals(200, response.getStatusCode().orElse(-1));
+        Assertions.assertEquals("success", response.getStatusText().orElse("n\\a"));
     }
 
 }

--- a/src/test/java/zowe/client/sdk/zosfiles/UssChangeModeTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssChangeModeTest.java
@@ -46,9 +46,9 @@ public class UssChangeModeTest {
         final UssChangeMode ussChangeMode = new UssChangeMode(connection, mockJsonPutRequest);
         final Response response = ussChangeMode.change("/xxx/xx/xx",
                 new ChangeModeParams.Builder().mode("rwxrwxrwx").build());
-        assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals(200, response.getStatusCode().getAsInt());
-        assertEquals("success", response.getStatusText().get());
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
     }
 
     @Test
@@ -56,9 +56,9 @@ public class UssChangeModeTest {
         final UssChangeMode ussChangeMode = new UssChangeMode(connection, mockJsonPutRequest);
         final Response response = ussChangeMode.change("/xxx/xx/xx",
                 new ChangeModeParams.Builder().mode("rwxrwxrwx").recursive(true).build());
-        assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals(200, response.getStatusCode().getAsInt());
-        assertEquals("success", response.getStatusText().get());
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosfiles/UssChangeModeTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssChangeModeTest.java
@@ -47,7 +47,7 @@ public class UssChangeModeTest {
         final Response response = ussChangeMode.change("/xxx/xx/xx",
                 new ChangeModeParams.Builder().mode("rwxrwxrwx").build());
         assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals("200", response.getStatusCode().get().toString());
+        assertEquals(200, response.getStatusCode().getAsInt());
         assertEquals("success", response.getStatusText().get());
     }
 
@@ -57,7 +57,7 @@ public class UssChangeModeTest {
         final Response response = ussChangeMode.change("/xxx/xx/xx",
                 new ChangeModeParams.Builder().mode("rwxrwxrwx").recursive(true).build());
         assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals("200", response.getStatusCode().get().toString());
+        assertEquals(200, response.getStatusCode().getAsInt());
         assertEquals("success", response.getStatusText().get());
     }
 

--- a/src/test/java/zowe/client/sdk/zosfiles/UssChangeOwnerTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssChangeOwnerTest.java
@@ -46,7 +46,7 @@ public class UssChangeOwnerTest {
         final UssChangeOwner ussChangeOwner = new UssChangeOwner(connection, mockJsonPutRequest);
         final Response response = ussChangeOwner.change("/xxx/xx/xx", "user");
         assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals("200", response.getStatusCode().get().toString());
+        assertEquals(200, response.getStatusCode().getAsInt());
         assertEquals("success", response.getStatusText().get());
     }
 
@@ -56,7 +56,7 @@ public class UssChangeOwnerTest {
         final Response response = ussChangeOwner.change("/xxx/xx/xx",
                 new ChangeOwnerParams.Builder().owner("user").recursive(true).build());
         assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals("200", response.getStatusCode().get().toString());
+        assertEquals(200, response.getStatusCode().getAsInt());
         assertEquals("success", response.getStatusText().get());
     }
 

--- a/src/test/java/zowe/client/sdk/zosfiles/UssChangeOwnerTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssChangeOwnerTest.java
@@ -45,9 +45,9 @@ public class UssChangeOwnerTest {
     public void tstUssChangeOwnerSuccess() throws Exception {
         final UssChangeOwner ussChangeOwner = new UssChangeOwner(connection, mockJsonPutRequest);
         final Response response = ussChangeOwner.change("/xxx/xx/xx", "user");
-        assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals(200, response.getStatusCode().getAsInt());
-        assertEquals("success", response.getStatusText().get());
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
     }
 
     @Test
@@ -55,9 +55,9 @@ public class UssChangeOwnerTest {
         final UssChangeOwner ussChangeOwner = new UssChangeOwner(connection, mockJsonPutRequest);
         final Response response = ussChangeOwner.change("/xxx/xx/xx",
                 new ChangeOwnerParams.Builder().owner("user").recursive(true).build());
-        assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals(200, response.getStatusCode().getAsInt());
-        assertEquals("success", response.getStatusText().get());
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosfiles/UssChangeTagTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssChangeTagTest.java
@@ -47,7 +47,7 @@ public class UssChangeTagTest {
         final UssChangeTag ussChangeTag = new UssChangeTag(connection, mockJsonPutRequest);
         final Response response = ussChangeTag.changeToBinary("/xxx/xx/xx");
         assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals("200", response.getStatusCode().get().toString());
+        assertEquals(200, response.getStatusCode().getAsInt());
         assertEquals("success", response.getStatusText().get());
     }
 
@@ -56,7 +56,7 @@ public class UssChangeTagTest {
         final UssChangeTag ussChangeTag = new UssChangeTag(connection, mockJsonPutRequest);
         final Response response = ussChangeTag.changeToText("/xxx/xx/xx", "IBM-1047");
         assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals("200", response.getStatusCode().get().toString());
+        assertEquals(200, response.getStatusCode().getAsInt());
         assertEquals("success", response.getStatusText().get());
     }
 
@@ -65,7 +65,7 @@ public class UssChangeTagTest {
         final UssChangeTag ussChangeTag = new UssChangeTag(connection, mockJsonPutRequest);
         final Response response = ussChangeTag.remove("/xxx/xx/xx");
         assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals("200", response.getStatusCode().get().toString());
+        assertEquals(200, response.getStatusCode().getAsInt());
         assertEquals("success", response.getStatusText().get());
     }
 
@@ -74,7 +74,7 @@ public class UssChangeTagTest {
         final UssChangeTag ussChangeTag = new UssChangeTag(connection, mockJsonPutRequest);
         final Response response = ussChangeTag.retrieve("/xxx/xx/xx");
         assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals("200", response.getStatusCode().get().toString());
+        assertEquals(200, response.getStatusCode().getAsInt());
         assertEquals("success", response.getStatusText().get());
     }
 
@@ -84,7 +84,7 @@ public class UssChangeTagTest {
         final Response response = ussChangeTag.changeCommon("/xxx/xx/xx",
                 new ChangeTagParams.Builder().action(ChangeTagAction.LIST).build());
         assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals("200", response.getStatusCode().get().toString());
+        assertEquals(200, response.getStatusCode().getAsInt());
         assertEquals("success", response.getStatusText().get());
     }
 
@@ -94,7 +94,7 @@ public class UssChangeTagTest {
         final Response response = ussChangeTag.changeCommon("/xx x/x x/x x",
                 new ChangeTagParams.Builder().action(ChangeTagAction.LIST).build());
         assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals("200", response.getStatusCode().get().toString());
+        assertEquals(200, response.getStatusCode().getAsInt());
         assertEquals("success", response.getStatusText().get());
     }
 

--- a/src/test/java/zowe/client/sdk/zosfiles/UssChangeTagTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssChangeTagTest.java
@@ -46,36 +46,36 @@ public class UssChangeTagTest {
     public void tstUssChangeTagChangeToBinarySuccess() throws Exception {
         final UssChangeTag ussChangeTag = new UssChangeTag(connection, mockJsonPutRequest);
         final Response response = ussChangeTag.changeToBinary("/xxx/xx/xx");
-        assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals(200, response.getStatusCode().getAsInt());
-        assertEquals("success", response.getStatusText().get());
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
     }
 
     @Test
     public void tstUssChangeTagChangeToTextSuccess() throws Exception {
         final UssChangeTag ussChangeTag = new UssChangeTag(connection, mockJsonPutRequest);
         final Response response = ussChangeTag.changeToText("/xxx/xx/xx", "IBM-1047");
-        assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals(200, response.getStatusCode().getAsInt());
-        assertEquals("success", response.getStatusText().get());
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
     }
 
     @Test
     public void tstUssChangeTagRemoveSuccess() throws Exception {
         final UssChangeTag ussChangeTag = new UssChangeTag(connection, mockJsonPutRequest);
         final Response response = ussChangeTag.remove("/xxx/xx/xx");
-        assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals(200, response.getStatusCode().getAsInt());
-        assertEquals("success", response.getStatusText().get());
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
     }
 
     @Test
     public void tstUssChangeTagRetrieveSuccess() throws Exception {
         final UssChangeTag ussChangeTag = new UssChangeTag(connection, mockJsonPutRequest);
         final Response response = ussChangeTag.retrieve("/xxx/xx/xx");
-        assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals(200, response.getStatusCode().getAsInt());
-        assertEquals("success", response.getStatusText().get());
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
     }
 
     @Test
@@ -83,9 +83,9 @@ public class UssChangeTagTest {
         final UssChangeTag ussChangeTag = new UssChangeTag(connection, mockJsonPutRequest);
         final Response response = ussChangeTag.changeCommon("/xxx/xx/xx",
                 new ChangeTagParams.Builder().action(ChangeTagAction.LIST).build());
-        assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals(200, response.getStatusCode().getAsInt());
-        assertEquals("success", response.getStatusText().get());
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
     }
 
     @Test
@@ -93,9 +93,9 @@ public class UssChangeTagTest {
         final UssChangeTag ussChangeTag = new UssChangeTag(connection, mockJsonPutRequest);
         final Response response = ussChangeTag.changeCommon("/xx x/x x/x x",
                 new ChangeTagParams.Builder().action(ChangeTagAction.LIST).build());
-        assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals(200, response.getStatusCode().getAsInt());
-        assertEquals("success", response.getStatusText().get());
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosfiles/UssCopyTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssCopyTest.java
@@ -46,7 +46,7 @@ public class UssCopyTest {
         final UssCopy ussCopy = new UssCopy(connection, mockJsonPutRequest);
         final Response response = ussCopy.copy("/xxx/xx/xx", "/xxx/xx/xx");
         assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals("200", response.getStatusCode().get().toString());
+        assertEquals(200, response.getStatusCode().getAsInt());
         assertEquals("success", response.getStatusText().get());
     }
 
@@ -56,7 +56,7 @@ public class UssCopyTest {
         final Response response = ussCopy.copy("/xxx/xx/xx",
                 new CopyParams.Builder().from("/xxx/xx/xx").recursive(true).build());
         assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals("200", response.getStatusCode().get().toString());
+        assertEquals(200, response.getStatusCode().getAsInt());
         assertEquals("success", response.getStatusText().get());
     }
 
@@ -66,7 +66,7 @@ public class UssCopyTest {
         final Response response = ussCopy.copy("/xxx/xx/xx",
                 new CopyParams.Builder().from("/xxx/xx/xx").overwrite(true).build());
         assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals("200", response.getStatusCode().get().toString());
+        assertEquals(200, response.getStatusCode().getAsInt());
         assertEquals("success", response.getStatusText().get());
     }
 

--- a/src/test/java/zowe/client/sdk/zosfiles/UssCopyTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssCopyTest.java
@@ -12,6 +12,7 @@ package zowe.client.sdk.zosfiles;
 import org.json.simple.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.JsonPutRequest;
@@ -45,9 +46,9 @@ public class UssCopyTest {
     public void tstUssCopySuccess() throws Exception {
         final UssCopy ussCopy = new UssCopy(connection, mockJsonPutRequest);
         final Response response = ussCopy.copy("/xxx/xx/xx", "/xxx/xx/xx");
-        assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals(200, response.getStatusCode().getAsInt());
-        assertEquals("success", response.getStatusText().get());
+        Assertions.assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        Assertions.assertEquals(200, response.getStatusCode().orElse(-1));
+        Assertions.assertEquals("success", response.getStatusText().orElse("n\\a"));
     }
 
     @Test
@@ -55,9 +56,9 @@ public class UssCopyTest {
         final UssCopy ussCopy = new UssCopy(connection, mockJsonPutRequest);
         final Response response = ussCopy.copy("/xxx/xx/xx",
                 new CopyParams.Builder().from("/xxx/xx/xx").recursive(true).build());
-        assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals(200, response.getStatusCode().getAsInt());
-        assertEquals("success", response.getStatusText().get());
+        Assertions.assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        Assertions.assertEquals(200, response.getStatusCode().orElse(-1));
+        Assertions.assertEquals("success", response.getStatusText().orElse("n\\a"));
     }
 
     @Test
@@ -65,9 +66,9 @@ public class UssCopyTest {
         final UssCopy ussCopy = new UssCopy(connection, mockJsonPutRequest);
         final Response response = ussCopy.copy("/xxx/xx/xx",
                 new CopyParams.Builder().from("/xxx/xx/xx").overwrite(true).build());
-        assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals(200, response.getStatusCode().getAsInt());
-        assertEquals("success", response.getStatusText().get());
+        Assertions.assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        Assertions.assertEquals(200, response.getStatusCode().orElse(-1));
+        Assertions.assertEquals("success", response.getStatusText().orElse("n\\a"));
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosfiles/UssCreateTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssCreateTest.java
@@ -48,7 +48,7 @@ public class UssCreateTest {
         final UssCreate ussCreate = new UssCreate(connection, mockJsonPostRequest);
         final Response response = ussCreate.create("/xx/xx/x", new CreateParams(CreateType.FILE, "rwxrwxrwx"));
         Assertions.assertEquals("{}", response.getResponsePhrase().get().toString());
-        Assertions.assertEquals("200", response.getStatusCode().get().toString());
+        Assertions.assertEquals(200, response.getStatusCode().getAsInt());
         Assertions.assertEquals("success", response.getStatusText().get());
     }
 

--- a/src/test/java/zowe/client/sdk/zosfiles/UssCreateTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssCreateTest.java
@@ -47,9 +47,9 @@ public class UssCreateTest {
                 new Response(new JSONObject(), 200, "success"));
         final UssCreate ussCreate = new UssCreate(connection, mockJsonPostRequest);
         final Response response = ussCreate.create("/xx/xx/x", new CreateParams(CreateType.FILE, "rwxrwxrwx"));
-        Assertions.assertEquals("{}", response.getResponsePhrase().get().toString());
-        Assertions.assertEquals(200, response.getStatusCode().getAsInt());
-        Assertions.assertEquals("success", response.getStatusText().get());
+        Assertions.assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        Assertions.assertEquals(200, response.getStatusCode().orElse(-1));
+        Assertions.assertEquals("success", response.getStatusText().orElse("n\\a"));
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosfiles/UssDeleteTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssDeleteTest.java
@@ -45,7 +45,7 @@ public class UssDeleteTest {
         final UssDelete ussDelete = new UssDelete(connection, mockJsonDeleteRequest);
         final Response response = ussDelete.delete("/xxx/xx/xx");
         assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals("200", response.getStatusCode().get().toString());
+        assertEquals(200, response.getStatusCode().getAsInt());
         assertEquals("success", response.getStatusText().get());
     }
 
@@ -54,7 +54,7 @@ public class UssDeleteTest {
         final UssDelete ussDelete = new UssDelete(connection, mockJsonDeleteRequest);
         final Response response = ussDelete.delete("/xxx/xx/xx", true);
         assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals("200", response.getStatusCode().get().toString());
+        assertEquals(200, response.getStatusCode().getAsInt());
         assertEquals("success", response.getStatusText().get());
     }
 

--- a/src/test/java/zowe/client/sdk/zosfiles/UssDeleteTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssDeleteTest.java
@@ -12,6 +12,7 @@ package zowe.client.sdk.zosfiles;
 import org.json.simple.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.JsonDeleteRequest;
@@ -44,18 +45,18 @@ public class UssDeleteTest {
     public void tstUssDeleteSuccess() throws Exception {
         final UssDelete ussDelete = new UssDelete(connection, mockJsonDeleteRequest);
         final Response response = ussDelete.delete("/xxx/xx/xx");
-        assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals(200, response.getStatusCode().getAsInt());
-        assertEquals("success", response.getStatusText().get());
+        Assertions.assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        Assertions.assertEquals(200, response.getStatusCode().orElse(-1));
+        Assertions.assertEquals("success", response.getStatusText().orElse("n\\a"));
     }
 
     @Test
     public void tstUssDeleteRecursiveSuccess() throws Exception {
         final UssDelete ussDelete = new UssDelete(connection, mockJsonDeleteRequest);
         final Response response = ussDelete.delete("/xxx/xx/xx", true);
-        assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals(200, response.getStatusCode().getAsInt());
-        assertEquals("success", response.getStatusText().get());
+        Assertions.assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        Assertions.assertEquals(200, response.getStatusCode().orElse(-1));
+        Assertions.assertEquals("success", response.getStatusText().orElse("n\\a"));
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosfiles/UssListTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssListTest.java
@@ -147,23 +147,23 @@ public class UssListTest {
         // should only contain two items
         assertEquals(2, items.size());
         // verify first item's data
-        assertEquals("test", items.get(0).getName().get());
-        assertEquals("drwxr-xr-x", items.get(0).getMode().get());
-        assertEquals(0, items.get(0).getSize().getAsLong());
-        assertEquals(10000518, items.get(0).getUid().getAsLong());
-        assertEquals("user", items.get(0).getUser().get());
-        assertEquals(8, items.get(0).getGid().getAsLong());
-        assertEquals("FRAMEWKG", items.get(0).getGroup().get());
-        assertEquals("2022-11-03T10:48:32", items.get(0).getMtime().get());
+        assertEquals("test", items.get(0).getName().orElse("n\\a"));
+        assertEquals("drwxr-xr-x", items.get(0).getMode().orElse("n\\a"));
+        assertEquals(0, items.get(0).getSize().orElse(-1));
+        assertEquals(10000518, items.get(0).getUid().orElse(-1));
+        assertEquals("user", items.get(0).getUser().orElse("n\\a"));
+        assertEquals(8, items.get(0).getGid().orElse(-1));
+        assertEquals("FRAMEWKG", items.get(0).getGroup().orElse("n\\a"));
+        assertEquals("2022-11-03T10:48:32", items.get(0).getMtime().orElse("n\\a"));
         // verify second item's data
-        assertEquals("test2", items.get(1).getName().get());
-        assertEquals("-rwxr-xr-x", items.get(1).getMode().get());
-        assertEquals(13545, items.get(1).getSize().getAsLong());
-        assertEquals(10000518, items.get(1).getUid().getAsLong());
-        assertEquals("user2", items.get(1).getUser().get());
-        assertEquals(8, items.get(1).getGid().getAsLong());
-        assertEquals("FRAMEWKG", items.get(1).getGroup().get());
-        assertEquals("2022-11-12T15:20:11", items.get(1).getMtime().get());
+        assertEquals("test2", items.get(1).getName().orElse("n\\a"));
+        assertEquals("-rwxr-xr-x", items.get(1).getMode().orElse("n\\a"));
+        assertEquals(13545, items.get(1).getSize().orElse(-1));
+        assertEquals(10000518, items.get(1).getUid().orElse(-1));
+        assertEquals("user2", items.get(1).getUser().orElse("n\\a"));
+        assertEquals(8, items.get(1).getGid().orElse(-1));
+        assertEquals("FRAMEWKG", items.get(1).getGroup().orElse("n\\a"));
+        assertEquals("2022-11-12T15:20:11", items.get(1).getMtime().orElse("n\\a"));
     }
 
     @Test
@@ -179,16 +179,16 @@ public class UssListTest {
         // verify first item's data
         assertTrue(items.get(0).getName().isEmpty());
         assertTrue(items.get(0).getMode().isEmpty());
-        assertEquals(0, items.get(0).getSize().getAsLong());
+        assertEquals(0, items.get(0).getSize().orElse(-1));
         assertTrue(items.get(0).getUid().isEmpty());
         assertTrue(items.get(0).getUser().isEmpty());
         assertTrue(items.get(0).getGid().isEmpty());
         assertTrue(items.get(0).getGroup().isEmpty());
         assertTrue(items.get(0).getMtime().isEmpty());
         // verify second item's data
-        assertEquals("test2", items.get(1).getName().get());
+        assertEquals("test2", items.get(1).getName().orElse("n\\a"));
         assertTrue(items.get(0).getMode().isEmpty());
-        assertEquals(0, items.get(0).getSize().getAsLong());
+        assertEquals(0, items.get(0).getSize().orElse(-1));
         assertTrue(items.get(0).getUid().isEmpty());
         assertTrue(items.get(0).getUser().isEmpty());
         assertTrue(items.get(0).getGid().isEmpty());
@@ -227,19 +227,19 @@ public class UssListTest {
         // should only contain one item
         assertEquals(1, items.size());
         // verify first item's data
-        assertEquals("OMVSGRP.USER.TNGFW.CA31", items.get(0).getName().get());
-        assertEquals("/CA31/u/users/framewrk", items.get(0).getMountpoint().get());
-        assertEquals("ZFS", items.get(0).getFstname().get());
-        assertEquals("noautomove,unmount,acl,synchonly", items.get(0).getMode().get());
-        assertEquals(2718, items.get(0).getDev().getAsLong());
-        assertEquals(1, items.get(0).getFstype().getAsLong());
-        assertEquals(1024, items.get(0).getBsize().getAsLong());
-        assertEquals(269231, items.get(0).getBavail().getAsLong());
-        assertEquals(1382400, items.get(0).getBlocks().getAsLong());
-        assertEquals("CA31", items.get(0).getSysname().get());
-        assertEquals(907651, items.get(0).getReadibc().getAsLong());
-        assertEquals(42, items.get(0).getWriteibc().getAsLong());
-        assertEquals(453057, items.get(0).getDiribc().getAsLong());
+        assertEquals("OMVSGRP.USER.TNGFW.CA31", items.get(0).getName().orElse("n\\a"));
+        assertEquals("/CA31/u/users/framewrk", items.get(0).getMountpoint().orElse("n\\a"));
+        assertEquals("ZFS", items.get(0).getFstname().orElse("n\\a"));
+        assertEquals("noautomove,unmount,acl,synchonly", items.get(0).getMode().orElse("n\\a"));
+        assertEquals(2718, items.get(0).getDev().orElse(-1));
+        assertEquals(1, items.get(0).getFstype().orElse(-1));
+        assertEquals(1024, items.get(0).getBsize().orElse(-1));
+        assertEquals(269231, items.get(0).getBavail().orElse(-1));
+        assertEquals(1382400, items.get(0).getBlocks().orElse(-1));
+        assertEquals("CA31", items.get(0).getSysname().orElse("n\\a"));
+        assertEquals(907651, items.get(0).getReadibc().orElse(-1));
+        assertEquals(42, items.get(0).getWriteibc().orElse(-1));
+        assertEquals(453057, items.get(0).getDiribc().orElse(-1));
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosfiles/UssMountTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssMountTest.java
@@ -47,7 +47,7 @@ public class UssMountTest {
         final UssMount ussMount = new UssMount(connection, mockJsonPutRequest);
         final Response response = ussMount.mount("name", "mountpoint", "fstype");
         Assertions.assertEquals("{}", response.getResponsePhrase().get().toString());
-        Assertions.assertEquals("200", response.getStatusCode().get().toString());
+        Assertions.assertEquals(200, response.getStatusCode().getAsInt());
         Assertions.assertEquals("success", response.getStatusText().get());
     }
 

--- a/src/test/java/zowe/client/sdk/zosfiles/UssMountTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssMountTest.java
@@ -46,9 +46,9 @@ public class UssMountTest {
                 new Response(new JSONObject(), 200, "success"));
         final UssMount ussMount = new UssMount(connection, mockJsonPutRequest);
         final Response response = ussMount.mount("name", "mountpoint", "fstype");
-        Assertions.assertEquals("{}", response.getResponsePhrase().get().toString());
-        Assertions.assertEquals(200, response.getStatusCode().getAsInt());
-        Assertions.assertEquals("success", response.getStatusText().get());
+        Assertions.assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        Assertions.assertEquals(200, response.getStatusCode().orElse(-1));
+        Assertions.assertEquals("success", response.getStatusText().orElse("n\\a"));
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosfiles/UssMoveTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssMoveTest.java
@@ -44,18 +44,18 @@ public class UssMoveTest {
     public void tstUssMoveSuccess() throws Exception {
         final UssMove ussMove = new UssMove(connection, mockJsonPutRequest);
         final Response response = ussMove.move("/xxx/xx/xx", "/xxx/xx/xx");
-        assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals(200, response.getStatusCode().getAsInt());
-        assertEquals("success", response.getStatusText().get());
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
     }
 
     @Test
     public void tstUssMoveOverwriteSuccess() throws Exception {
         final UssMove ussMove = new UssMove(connection, mockJsonPutRequest);
         final Response response = ussMove.move("/xxx/xx/xx", "/xxx/xx/xx", true);
-        assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals(200, response.getStatusCode().getAsInt());
-        assertEquals("success", response.getStatusText().get());
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosfiles/UssMoveTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssMoveTest.java
@@ -45,7 +45,7 @@ public class UssMoveTest {
         final UssMove ussMove = new UssMove(connection, mockJsonPutRequest);
         final Response response = ussMove.move("/xxx/xx/xx", "/xxx/xx/xx");
         assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals("200", response.getStatusCode().get().toString());
+        assertEquals(200, response.getStatusCode().getAsInt());
         assertEquals("success", response.getStatusText().get());
     }
 
@@ -54,7 +54,7 @@ public class UssMoveTest {
         final UssMove ussMove = new UssMove(connection, mockJsonPutRequest);
         final Response response = ussMove.move("/xxx/xx/xx", "/xxx/xx/xx", true);
         assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals("200", response.getStatusCode().get().toString());
+        assertEquals(200, response.getStatusCode().getAsInt());
         assertEquals("success", response.getStatusText().get());
     }
 

--- a/src/test/java/zowe/client/sdk/zosfiles/UssWriteTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssWriteTest.java
@@ -47,7 +47,7 @@ public class UssWriteTest {
         final UssWrite ussWrite = new UssWrite(connection, mockTextPutRequest);
         final Response response = ussWrite.writeText("/xx/xx/x", "text");
         assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals("200", response.getStatusCode().get().toString());
+        assertEquals(200, response.getStatusCode().getAsInt());
         assertEquals("success", response.getStatusText().get());
     }
 
@@ -59,7 +59,7 @@ public class UssWriteTest {
         final UssWrite ussWrite = new UssWrite(connection, mockStreamPutRequest);
         final Response response = ussWrite.writeBinary("/xx/xx/x", new byte[0]);
         assertTrue(response.getResponsePhrase().get() instanceof byte[]);
-        assertEquals("200", response.getStatusCode().get().toString());
+        assertEquals(200, response.getStatusCode().getAsInt());
         assertEquals("success", response.getStatusText().get());
     }
 

--- a/src/test/java/zowe/client/sdk/zosfiles/UssWriteTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssWriteTest.java
@@ -12,6 +12,7 @@ package zowe.client.sdk.zosfiles;
 import org.json.simple.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.Response;
@@ -46,9 +47,9 @@ public class UssWriteTest {
                 new Response(new JSONObject(), 200, "success"));
         final UssWrite ussWrite = new UssWrite(connection, mockTextPutRequest);
         final Response response = ussWrite.writeText("/xx/xx/x", "text");
-        assertEquals("{}", response.getResponsePhrase().get().toString());
-        assertEquals(200, response.getStatusCode().getAsInt());
-        assertEquals("success", response.getStatusText().get());
+        Assertions.assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        Assertions.assertEquals(200, response.getStatusCode().orElse(-1));
+        Assertions.assertEquals("success", response.getStatusText().orElse("n\\a"));
     }
 
     @Test
@@ -58,9 +59,9 @@ public class UssWriteTest {
                 new Response(new byte[0], 200, "success"));
         final UssWrite ussWrite = new UssWrite(connection, mockStreamPutRequest);
         final Response response = ussWrite.writeBinary("/xx/xx/x", new byte[0]);
-        assertTrue(response.getResponsePhrase().get() instanceof byte[]);
-        assertEquals(200, response.getStatusCode().getAsInt());
-        assertEquals("success", response.getStatusText().get());
+        assertTrue(response.getResponsePhrase().orElse(null) instanceof byte[]);
+        Assertions.assertEquals(200, response.getStatusCode().orElse(-1));
+        Assertions.assertEquals("success", response.getStatusText().orElse("n\\a"));
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zostso/TsoResponseServiceTest.java
+++ b/src/test/java/zowe/client/sdk/zostso/TsoResponseServiceTest.java
@@ -108,8 +108,8 @@ public class TsoResponseServiceTest {
         final ZosmfTsoResponse zosmfTsoResponse = new TsoResponseService(response).getZosmfTsoResponse();
         assertFalse(zosmfTsoResponse.getTsoData().isEmpty());
         assertTrue(zosmfTsoResponse.getMsgData().isEmpty());
-        assertTrue(zosmfTsoResponse.getTimeout().get());
-        assertTrue(zosmfTsoResponse.getReused().get());
+        assertTrue(zosmfTsoResponse.isTimeout());
+        assertTrue(zosmfTsoResponse.isReused());
         assertEquals("0100", zosmfTsoResponse.getVer().get());
         assertEquals("0100", zosmfTsoResponse.getQueueId().get());
         assertEquals("ZOSMFAD-71-aabcaaaf", zosmfTsoResponse.getServletKey().get());
@@ -134,8 +134,8 @@ public class TsoResponseServiceTest {
         final ZosmfTsoResponse zosmfTsoResponse = new TsoResponseService(response).getZosmfTsoResponse();
         assertFalse(zosmfTsoResponse.getTsoData().isEmpty());
         assertTrue(zosmfTsoResponse.getMsgData().isEmpty());
-        assertTrue(zosmfTsoResponse.getTimeout().get());
-        assertTrue(zosmfTsoResponse.getReused().get());
+        assertTrue(zosmfTsoResponse.isTimeout());
+        assertTrue(zosmfTsoResponse.isReused());
         assertEquals("0100", zosmfTsoResponse.getVer().get());
         assertEquals("0100", zosmfTsoResponse.getQueueId().get());
         assertEquals("ZOSMFAD-71-aabcaaaf", zosmfTsoResponse.getServletKey().get());
@@ -154,8 +154,8 @@ public class TsoResponseServiceTest {
         final ZosmfTsoResponse zosmfTsoResponse = new TsoResponseService(response).getZosmfTsoResponse();
         assertFalse(zosmfTsoResponse.getTsoData().isEmpty());
         assertTrue(zosmfTsoResponse.getMsgData().isEmpty());
-        assertTrue(zosmfTsoResponse.getTimeout().get());
-        assertTrue(zosmfTsoResponse.getReused().get());
+        assertTrue(zosmfTsoResponse.isTimeout());
+        assertTrue(zosmfTsoResponse.isReused());
         assertEquals("0100", zosmfTsoResponse.getVer().get());
         assertEquals("0100", zosmfTsoResponse.getQueueId().get());
         assertEquals("ZOSMFAD-71-aabcaaaf", zosmfTsoResponse.getServletKey().get());


### PR DESCRIPTION
Reworked parse classes as singleton. To avoid multiple class insanitation and improve performance.  
Other changes:
Made most method parameters final.
Removed Optional Boolean and replace with boolean usage.
Removed Optional Long and replace with OptionalLong usage.
Removed Optional Integer and replace with OptionalInt usage.
Removed boolean getters "get" with "is" method starting name. 
Removed unused method throw Exception statements. 
Updated some javadoc throughout. 

Changes results in project wide consistent styling and best practice usages.