### PR TITLE
Exception handling improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.zowe.client.java.sdk</groupId>
     <artifactId>zowe-client-java-sdk</artifactId>
-    <version>2.1.1</version>
+    <version>2.1.2</version>
     <build>
         <plugins>
             <plugin>

--- a/src/main/java/zowe/client/sdk/rest/DeleteJsonZosmfRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/DeleteJsonZosmfRequest.java
@@ -12,6 +12,7 @@ package zowe.client.sdk.rest;
 import kong.unirest.HttpResponse;
 import kong.unirest.JsonNode;
 import kong.unirest.Unirest;
+import kong.unirest.UnirestException;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.utility.EncodeUtils;
@@ -45,7 +46,12 @@ public class DeleteJsonZosmfRequest extends ZosmfRequest {
     @Override
     public Response executeRequest() throws ZosmfRequestException {
         ValidateUtils.checkNullParameter(url == null, "url is null");
-        HttpResponse<JsonNode> reply = Unirest.delete(url).headers(headers).asJson();
+        HttpResponse<JsonNode> reply;
+        try {
+            reply = Unirest.delete(url).headers(headers).asJson();
+        } catch (UnirestException e) {
+            throw new ZosmfRequestException(e.getMessage(), e);
+        }
         return buildResponse(reply);
     }
 

--- a/src/main/java/zowe/client/sdk/rest/GetJsonZosmfRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/GetJsonZosmfRequest.java
@@ -12,6 +12,7 @@ package zowe.client.sdk.rest;
 import kong.unirest.HttpResponse;
 import kong.unirest.JsonNode;
 import kong.unirest.Unirest;
+import kong.unirest.UnirestException;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.utility.EncodeUtils;
@@ -45,7 +46,12 @@ public class GetJsonZosmfRequest extends ZosmfRequest {
     @Override
     public Response executeRequest() throws ZosmfRequestException {
         ValidateUtils.checkNullParameter(url == null, "url is null");
-        HttpResponse<JsonNode> reply = Unirest.get(url).headers(headers).asJson();
+        HttpResponse<JsonNode> reply;
+        try {
+            reply = Unirest.get(url).headers(headers).asJson();
+        } catch (UnirestException e) {
+            throw new ZosmfRequestException(e.getMessage(), e);
+        }
         return buildResponse(reply);
     }
 

--- a/src/main/java/zowe/client/sdk/rest/GetStreamZosmfRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/GetStreamZosmfRequest.java
@@ -11,6 +11,7 @@ package zowe.client.sdk.rest;
 
 import kong.unirest.HttpResponse;
 import kong.unirest.Unirest;
+import kong.unirest.UnirestException;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.utility.EncodeUtils;
@@ -44,7 +45,12 @@ public class GetStreamZosmfRequest extends ZosmfRequest {
     @Override
     public Response executeRequest() throws ZosmfRequestException {
         ValidateUtils.checkNullParameter(url == null, "url is null");
-        HttpResponse<byte[]> reply = Unirest.get(url).headers(headers).asBytes();
+        HttpResponse<byte[]> reply;
+        try {
+            reply = Unirest.get(url).headers(headers).asBytes();
+        } catch (UnirestException e) {
+            throw new ZosmfRequestException(e.getMessage(), e);
+        }
         return buildResponse(reply);
     }
 

--- a/src/main/java/zowe/client/sdk/rest/GetTextZosmfRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/GetTextZosmfRequest.java
@@ -11,6 +11,7 @@ package zowe.client.sdk.rest;
 
 import kong.unirest.HttpResponse;
 import kong.unirest.Unirest;
+import kong.unirest.UnirestException;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.utility.EncodeUtils;
@@ -44,7 +45,12 @@ public class GetTextZosmfRequest extends ZosmfRequest {
     @Override
     public Response executeRequest() throws ZosmfRequestException {
         ValidateUtils.checkNullParameter(url == null, "url is null");
-        HttpResponse<String> reply = Unirest.get(url).headers(headers).asString();
+        HttpResponse<String> reply;
+        try {
+            reply = Unirest.get(url).headers(headers).asString();
+        } catch (UnirestException e) {
+            throw new ZosmfRequestException(e.getMessage(), e);
+        }
         return buildResponse(reply);
     }
 

--- a/src/main/java/zowe/client/sdk/rest/PostJsonZosmfRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/PostJsonZosmfRequest.java
@@ -12,6 +12,7 @@ package zowe.client.sdk.rest;
 import kong.unirest.HttpResponse;
 import kong.unirest.JsonNode;
 import kong.unirest.Unirest;
+import kong.unirest.UnirestException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zowe.client.sdk.core.ZosConnection;
@@ -55,7 +56,12 @@ public class PostJsonZosmfRequest extends ZosmfRequest {
     public Response executeRequest() throws ZosmfRequestException {
         ValidateUtils.checkNullParameter(url == null, "url is null");
         ValidateUtils.checkNullParameter(body == null, "body is null");
-        HttpResponse<JsonNode> reply = Unirest.post(url).headers(headers).body(body).asJson();
+        HttpResponse<JsonNode> reply;
+        try {
+            reply = Unirest.post(url).headers(headers).body(body).asJson();
+        } catch (UnirestException e) {
+            throw new ZosmfRequestException(e.getMessage(), e);
+        }
         return buildResponse(reply);
     }
 

--- a/src/main/java/zowe/client/sdk/rest/PutJsonZosmfRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/PutJsonZosmfRequest.java
@@ -12,6 +12,7 @@ package zowe.client.sdk.rest;
 import kong.unirest.HttpResponse;
 import kong.unirest.JsonNode;
 import kong.unirest.Unirest;
+import kong.unirest.UnirestException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zowe.client.sdk.core.ZosConnection;
@@ -56,7 +57,12 @@ public class PutJsonZosmfRequest extends ZosmfRequest {
     public Response executeRequest() throws ZosmfRequestException {
         ValidateUtils.checkNullParameter(url == null, "url is null");
         ValidateUtils.checkNullParameter(body == null, "body is null");
-        HttpResponse<JsonNode> reply = Unirest.put(url).headers(headers).body(body).asJson();
+        HttpResponse<JsonNode> reply;
+        try {
+            reply = Unirest.put(url).headers(headers).body(body).asJson();
+        } catch (UnirestException e) {
+            throw new ZosmfRequestException(e.getMessage(), e);
+        }
         return buildResponse(reply);
     }
 

--- a/src/main/java/zowe/client/sdk/rest/PutStreamZosmfRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/PutStreamZosmfRequest.java
@@ -12,6 +12,7 @@ package zowe.client.sdk.rest;
 import kong.unirest.HttpResponse;
 import kong.unirest.JsonNode;
 import kong.unirest.Unirest;
+import kong.unirest.UnirestException;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.utility.EncodeUtils;
@@ -51,7 +52,12 @@ public class PutStreamZosmfRequest extends ZosmfRequest {
     public Response executeRequest() throws ZosmfRequestException {
         ValidateUtils.checkNullParameter(url == null, "url is null");
         ValidateUtils.checkNullParameter(body == null, "body is null");
-        HttpResponse<JsonNode> reply = Unirest.put(url).headers(headers).body(body).asJson();
+        HttpResponse<JsonNode> reply;
+        try {
+            reply = Unirest.put(url).headers(headers).body(body).asJson();
+        } catch (UnirestException e) {
+            throw new ZosmfRequestException(e.getMessage(), e);
+        }
         return buildResponse(reply);
     }
 

--- a/src/main/java/zowe/client/sdk/rest/PutTextZosmfRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/PutTextZosmfRequest.java
@@ -11,6 +11,7 @@ package zowe.client.sdk.rest;
 
 import kong.unirest.HttpResponse;
 import kong.unirest.Unirest;
+import kong.unirest.UnirestException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zowe.client.sdk.core.ZosConnection;
@@ -54,7 +55,12 @@ public class PutTextZosmfRequest extends ZosmfRequest {
     public Response executeRequest() throws ZosmfRequestException {
         ValidateUtils.checkNullParameter(url == null, "url is null");
         ValidateUtils.checkNullParameter(body == null, "body is null");
-        HttpResponse<String> reply = Unirest.put(url).headers(headers).body(body).asString();
+        HttpResponse<String> reply;
+        try {
+            reply = Unirest.put(url).headers(headers).body(body).asString();
+        } catch (UnirestException e) {
+            throw new ZosmfRequestException(e.getMessage(), e);
+        }
         return buildResponse(reply);
     }
 

--- a/src/main/java/zowe/client/sdk/rest/exception/ZosmfRequestException.java
+++ b/src/main/java/zowe/client/sdk/rest/exception/ZosmfRequestException.java
@@ -11,8 +11,6 @@ package zowe.client.sdk.rest.exception;
 
 import zowe.client.sdk.rest.Response;
 
-import java.util.Optional;
-
 /**
  * Custom exception to represent z/OSMF request error state
  *
@@ -27,10 +25,11 @@ public class ZosmfRequestException extends Exception {
      * ZosmfRequestException constructor for message value
      *
      * @param message error message
+     * @param err     original throwable exception
      * @author Frank Giordano
      */
-    public ZosmfRequestException(final String message) {
-        super(message);
+    public ZosmfRequestException(final String message, Throwable err) {
+        super(message, err);
     }
 
     /**

--- a/src/main/java/zowe/client/sdk/utility/JsonParserUtil.java
+++ b/src/main/java/zowe/client/sdk/utility/JsonParserUtil.java
@@ -49,7 +49,7 @@ public final class JsonParserUtil {
             return (JSONObject) new JSONParser().parse(item);
         } catch (ParseException e) {
             LOG.debug(PARSE_ERROR_MSG, e);
-            throw new ZosmfRequestException(e.getMessage());
+            throw new ZosmfRequestException(e.getMessage(), e);
         }
     }
 
@@ -66,7 +66,7 @@ public final class JsonParserUtil {
             return (JSONArray) new JSONParser().parse(item);
         } catch (ParseException e) {
             LOG.debug(PARSE_ERROR_MSG, e);
-            throw new ZosmfRequestException(e.getMessage());
+            throw new ZosmfRequestException(e.getMessage(), e);
         }
     }
 

--- a/src/main/java/zowe/client/sdk/zosuss/exception/IssueUssException.java
+++ b/src/main/java/zowe/client/sdk/zosuss/exception/IssueUssException.java
@@ -21,10 +21,11 @@ public class IssueUssException extends Exception {
      * IssueCommandException constructor for message value
      *
      * @param message error message
+     * @param err     original throwable exception
      * @author Frank Giordano
      */
-    public IssueUssException(final String message) {
-        super(message);
+    public IssueUssException(final String message, Throwable err) {
+        super(message, err);
     }
 
 }

--- a/src/main/java/zowe/client/sdk/zosuss/method/IssueUss.java
+++ b/src/main/java/zowe/client/sdk/zosuss/method/IssueUss.java
@@ -80,10 +80,10 @@ public class IssueUss {
             return responseStream.toString();
         } catch (IOException e) {
             LOG.debug("IOException error " + e);
-            throw new IssueUssException(e.getMessage());
+            throw new IssueUssException(e.getMessage(), e);
         } catch (JSchException e) {
             LOG.debug("JSchException error " + e);
-            throw new IssueUssException(e.getMessage());
+            throw new IssueUssException(e.getMessage(), e);
         } finally {
             if (session != null) {
                 session.disconnect();


### PR DESCRIPTION
The following PR changes:

- Avoid losing the root cause of the exception from previous changes. 
- Update custom exceptions with a java.lang.Throwable parameter to the constructor. This way, we can pass the root exception to the method call.
- Catch UnirestException and throw custom exception

This PR will be reflected in version release 2.1.2.