### PR TITLE
Test authentication toggling 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.zowe.client.java.sdk</groupId>
     <artifactId>zowe-client-java-sdk</artifactId>
-    <version>3.0.2</version>
+    <version>3.0.3</version>
     <build>
         <plugins>
             <plugin>

--- a/src/main/java/zowe/client/sdk/core/ZosConnection.java
+++ b/src/main/java/zowe/client/sdk/core/ZosConnection.java
@@ -153,7 +153,9 @@ public class ZosConnection {
         }
         ZosConnection other = (ZosConnection) obj;
         return Objects.equals(host, other.host) && Objects.equals(zosmfPort, other.zosmfPort)
-                && Objects.equals(user, other.user) && Objects.equals(password, other.password);
+                && Objects.equals(user, other.user) && Objects.equals(password, other.password)
+                && Objects.equals(cookie.orElse(new Cookie("")).getValue(),
+                other.cookie.orElse(new Cookie("")).getValue());
     }
 
     /**
@@ -163,7 +165,7 @@ public class ZosConnection {
      */
     @Override
     public int hashCode() {
-        return Objects.hash(host, zosmfPort, user, password);
+        return Objects.hash(host, zosmfPort, user, password, cookie);
     }
 
 }

--- a/src/main/java/zowe/client/sdk/rest/ZosmfRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/ZosmfRequest.java
@@ -280,4 +280,13 @@ public abstract class ZosmfRequest {
         }
     }
 
+    /**
+     * Get current http header values for request
+     *
+     * @author Frank Giordano
+     */
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
 }

--- a/src/main/java/zowe/client/sdk/zosjobs/methods/JobGet.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/methods/JobGet.java
@@ -292,8 +292,7 @@ public class JobGet {
         }
         request.setUrl(url);
         connection.getCookie().ifPresentOrElse(c -> request.setCookie(c), () -> request.setCookie(null));
-
-
+        
         final String spoolErrMsg = "no job spool content response phrase";
         return (String) request.executeRequest().getResponsePhrase()
                 .orElseThrow(() -> new IllegalStateException(spoolErrMsg));

--- a/src/test/java/zowe/client/sdk/core/ZosConnectionTest.java
+++ b/src/test/java/zowe/client/sdk/core/ZosConnectionTest.java
@@ -9,6 +9,7 @@
  */
 package zowe.client.sdk.core;
 
+import kong.unirest.core.Cookie;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -31,8 +32,34 @@ public class ZosConnectionTest {
     }
 
     @Test
+    public void tstReferenceNotEqualsWithAuthSuccess() {
+        final ZosConnection zc1 = new ZosConnection("test", "zosmfPort", "user", "password");
+        zc1.setCookie(new Cookie("hello", "world"));
+        final ZosConnection zc2 = new ZosConnection("test", "zosmfPort", "user", "password");
+        zc2.setCookie(new Cookie("hello", "world"));
+        assertNotSame(zc1, zc2);
+    }
+
+    @Test
+    public void tstReferenceNotEqualsWithNullAuthSuccess() {
+        final ZosConnection zc1 = new ZosConnection("test", "zosmfPort", "user", "password");
+        zc1.setCookie(null);
+        final ZosConnection zc2 = new ZosConnection("test", "zosmfPort", "user", "password");
+        zc2.setCookie(null);
+        assertNotSame(zc1, zc2);
+    }
+
+    @Test
     public void tstReferenceEqualsSuccess() {
         final ZosConnection zc1 = new ZosConnection("test", "zosmfPort", "user", "password");
+        final ZosConnection zc2 = zc1;
+        assertEquals(zc1, zc2);
+    }
+
+    @Test
+    public void tstReferenceEqualsWithAuthSuccess() {
+        final ZosConnection zc1 = new ZosConnection("test", "zosmfPort", "user", "password");
+        zc1.setCookie(new Cookie("hello", "world"));
         final ZosConnection zc2 = zc1;
         assertEquals(zc1, zc2);
     }
@@ -45,9 +72,45 @@ public class ZosConnectionTest {
     }
 
     @Test
+    public void tstEqualsWithAuthSuccess() {
+        final ZosConnection zc1 = new ZosConnection("test", "zosmfPort", "user", "password");
+        zc1.setCookie(new Cookie("hello", "world"));
+        final ZosConnection zc2 = new ZosConnection("test", "zosmfPort", "user", "password");
+        zc2.setCookie(new Cookie("hello", "world"));
+        assertEquals(zc1, zc2);
+    }
+
+    @Test
+    public void tstEqualsWithNullAuthSuccess() {
+        final ZosConnection zc1 = new ZosConnection("test", "zosmfPort", "user", "password");
+        zc1.setCookie(null);
+        final ZosConnection zc2 = new ZosConnection("test", "zosmfPort", "user", "password");
+        zc2.setCookie(null);
+        assertEquals(zc1, zc2);
+    }
+
+    @Test
     public void tstNotEqualsSuccess() {
         final ZosConnection zc1 = new ZosConnection("test", "zosmfPort", "user", "password");
         final ZosConnection zc2 = new ZosConnection("test2", "zosmfPort", "user", "password");
+        assertNotEquals(zc1, zc2);
+    }
+
+    @Test
+    public void tstNotEqualsWithAuthSuccess() {
+        final ZosConnection zc1 = new ZosConnection("test", "zosmfPort", "user", "password");
+        zc1.setCookie(new Cookie("hello", "world1"));
+        final ZosConnection zc2 = new ZosConnection("test", "zosmfPort", "user", "password");
+        zc2.setCookie(new Cookie("hello", "world"));
+        assertNotEquals(zc1, zc2);
+    }
+
+    @Test
+    public void tstNotEqualsWithNullAuthSuccess() {
+        final ZosConnection zc1 = new ZosConnection("test1", "zosmfPort", "user", "password");
+        zc1.setCookie(null);
+        final ZosConnection zc2 = new ZosConnection("test", "zosmfPort", "user", "password");
+        zc2.setCookie(null);
         assertNotEquals(zc1, zc2);
     }
 

--- a/src/test/java/zowe/client/sdk/zosfiles/UssChangeModeTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssChangeModeTest.java
@@ -21,8 +21,6 @@ import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosfiles.uss.input.ChangeModeParams;
 import zowe.client.sdk.zosfiles.uss.methods.UssChangeMode;
 
-import java.util.Map;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;

--- a/src/test/java/zowe/client/sdk/zosfiles/UssChangeModeTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssChangeModeTest.java
@@ -9,6 +9,7 @@
  */
 package zowe.client.sdk.zosfiles;
 
+import kong.unirest.core.Cookie;
 import org.json.simple.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
@@ -20,7 +21,11 @@ import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosfiles.uss.input.ChangeModeParams;
 import zowe.client.sdk.zosfiles.uss.methods.UssChangeMode;
 
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 /**
  * Class containing unit tests for UssChMod.
@@ -33,6 +38,7 @@ public class UssChangeModeTest {
 
     private final ZosConnection connection = new ZosConnection("1", "1", "1", "1");
     private PutJsonZosmfRequest mockJsonPutRequest;
+    private PutJsonZosmfRequest mockJsonPutRequestAuth;
     private UssChangeMode ussChangeMode;
 
     @Before
@@ -40,6 +46,16 @@ public class UssChangeModeTest {
         mockJsonPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
         Mockito.when(mockJsonPutRequest.executeRequest()).thenReturn(
                 new Response(new JSONObject(), 200, "success"));
+
+        mockJsonPutRequestAuth = Mockito.mock(PutJsonZosmfRequest.class, withSettings().useConstructor(connection));
+        Mockito.when(mockJsonPutRequestAuth.executeRequest()).thenReturn(
+                new Response(new JSONObject(), 200, "success"));
+        doCallRealMethod().when(mockJsonPutRequestAuth).setHeaders(any(Map.class));
+        doCallRealMethod().when(mockJsonPutRequestAuth).setStandardHeaders();
+        doCallRealMethod().when(mockJsonPutRequestAuth).setUrl(any());
+        doCallRealMethod().when(mockJsonPutRequestAuth).setCookie(any());
+        doCallRealMethod().when(mockJsonPutRequestAuth).getHeaders();
+
         ussChangeMode = new UssChangeMode(connection);
     }
 
@@ -48,6 +64,29 @@ public class UssChangeModeTest {
         final UssChangeMode ussChangeMode = new UssChangeMode(connection, mockJsonPutRequest);
         final Response response = ussChangeMode.change("/xxx/xx/xx",
                 new ChangeModeParams.Builder().mode("rwxrwxrwx").build());
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
+    }
+
+    @Test
+    public void tstUssChangeModeToggleAuthSuccess() throws ZosmfRequestException {
+        final UssChangeMode ussChangeMode = new UssChangeMode(connection, mockJsonPutRequestAuth);
+
+        connection.setCookie(new Cookie("hello=hello"));
+        Response response = ussChangeMode.change("/xxx/xx/xx",
+                new ChangeModeParams.Builder().mode("rwxrwxrwx").build());
+        assertEquals("{X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
+                mockJsonPutRequestAuth.getHeaders().toString());
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
+
+        connection.setCookie(null);
+        response = ussChangeMode.change("/xxx/xx/xx",
+                new ChangeModeParams.Builder().mode("rwxrwxrwx").build());
+        assertEquals("{Authorization=Basic MTox, X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
+                mockJsonPutRequestAuth.getHeaders().toString());
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));

--- a/src/test/java/zowe/client/sdk/zosfiles/UssChangeModeTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssChangeModeTest.java
@@ -50,7 +50,7 @@ public class UssChangeModeTest {
         mockJsonPutRequestAuth = Mockito.mock(PutJsonZosmfRequest.class, withSettings().useConstructor(connection));
         Mockito.when(mockJsonPutRequestAuth.executeRequest()).thenReturn(
                 new Response(new JSONObject(), 200, "success"));
-        doCallRealMethod().when(mockJsonPutRequestAuth).setHeaders(any(Map.class));
+        doCallRealMethod().when(mockJsonPutRequestAuth).setHeaders(anyMap());
         doCallRealMethod().when(mockJsonPutRequestAuth).setStandardHeaders();
         doCallRealMethod().when(mockJsonPutRequestAuth).setUrl(any());
         doCallRealMethod().when(mockJsonPutRequestAuth).setCookie(any());

--- a/src/test/java/zowe/client/sdk/zosfiles/UssChangeOwnerTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssChangeOwnerTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.withSettings;
 
@@ -53,7 +54,7 @@ public class UssChangeOwnerTest {
         mockJsonPutRequestAuth = Mockito.mock(PutJsonZosmfRequest.class, withSettings().useConstructor(connection));
         Mockito.when(mockJsonPutRequestAuth.executeRequest()).thenReturn(
                 new Response(new JSONObject(), 200, "success"));
-        doCallRealMethod().when(mockJsonPutRequestAuth).setHeaders(any(Map.class));
+        doCallRealMethod().when(mockJsonPutRequestAuth).setHeaders(anyMap());
         doCallRealMethod().when(mockJsonPutRequestAuth).setStandardHeaders();
         doCallRealMethod().when(mockJsonPutRequestAuth).setUrl(any());
         doCallRealMethod().when(mockJsonPutRequestAuth).setCookie(any());

--- a/src/test/java/zowe/client/sdk/zosfiles/UssChangeOwnerTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssChangeOwnerTest.java
@@ -18,12 +18,8 @@ import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.PutJsonZosmfRequest;
 import zowe.client.sdk.rest.Response;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
-import zowe.client.sdk.zosfiles.uss.input.ChangeModeParams;
 import zowe.client.sdk.zosfiles.uss.input.ChangeOwnerParams;
-import zowe.client.sdk.zosfiles.uss.methods.UssChangeMode;
 import zowe.client.sdk.zosfiles.uss.methods.UssChangeOwner;
-
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;

--- a/src/test/java/zowe/client/sdk/zosfiles/UssChangeOwnerTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssChangeOwnerTest.java
@@ -72,7 +72,7 @@ public class UssChangeOwnerTest {
     }
 
     @Test
-    public void tstUssChangeModeToggleAuthSuccess() throws ZosmfRequestException {
+    public void tstUssChangeOwnerToggleAuthSuccess() throws ZosmfRequestException {
         final UssChangeOwner ussChangeOwner = new UssChangeOwner(connection, mockJsonPutRequestAuth);
 
         connection.setCookie(new Cookie("hello=hello"));

--- a/src/test/java/zowe/client/sdk/zosfiles/UssChangeTagTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssChangeTagTest.java
@@ -28,6 +28,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.withSettings;
 
@@ -54,7 +55,7 @@ public class UssChangeTagTest {
         mockJsonPutRequestAuth = Mockito.mock(PutJsonZosmfRequest.class, withSettings().useConstructor(connection));
         Mockito.when(mockJsonPutRequestAuth.executeRequest()).thenReturn(
                 new Response(new org.json.simple.JSONObject(), 200, "success"));
-        doCallRealMethod().when(mockJsonPutRequestAuth).setHeaders(any(Map.class));
+        doCallRealMethod().when(mockJsonPutRequestAuth).setHeaders(anyMap());
         doCallRealMethod().when(mockJsonPutRequestAuth).setStandardHeaders();
         doCallRealMethod().when(mockJsonPutRequestAuth).setUrl(any());
         doCallRealMethod().when(mockJsonPutRequestAuth).setCookie(any());

--- a/src/test/java/zowe/client/sdk/zosfiles/UssChangeTagTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssChangeTagTest.java
@@ -9,6 +9,7 @@
  */
 package zowe.client.sdk.zosfiles;
 
+import kong.unirest.core.Cookie;
 import kong.unirest.core.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
@@ -17,11 +18,18 @@ import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.PutJsonZosmfRequest;
 import zowe.client.sdk.rest.Response;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
+import zowe.client.sdk.zosfiles.uss.input.ChangeModeParams;
 import zowe.client.sdk.zosfiles.uss.input.ChangeTagParams;
+import zowe.client.sdk.zosfiles.uss.methods.UssChangeMode;
 import zowe.client.sdk.zosfiles.uss.methods.UssChangeTag;
 import zowe.client.sdk.zosfiles.uss.types.ChangeTagAction;
 
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.withSettings;
 
 /**
  * Class containing unit tests for UssChangeTag.
@@ -34,6 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class UssChangeTagTest {
     private final ZosConnection connection = new ZosConnection("1", "1", "1", "1");
     private PutJsonZosmfRequest mockJsonPutRequest;
+    private PutJsonZosmfRequest mockJsonPutRequestAuth;
     private UssChangeTag ussChangeTag;
 
     @Before
@@ -41,6 +50,16 @@ public class UssChangeTagTest {
         mockJsonPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
         Mockito.when(mockJsonPutRequest.executeRequest()).thenReturn(
                 new Response(new JSONObject(), 200, "success"));
+
+        mockJsonPutRequestAuth = Mockito.mock(PutJsonZosmfRequest.class, withSettings().useConstructor(connection));
+        Mockito.when(mockJsonPutRequestAuth.executeRequest()).thenReturn(
+                new Response(new org.json.simple.JSONObject(), 200, "success"));
+        doCallRealMethod().when(mockJsonPutRequestAuth).setHeaders(any(Map.class));
+        doCallRealMethod().when(mockJsonPutRequestAuth).setStandardHeaders();
+        doCallRealMethod().when(mockJsonPutRequestAuth).setUrl(any());
+        doCallRealMethod().when(mockJsonPutRequestAuth).setCookie(any());
+        doCallRealMethod().when(mockJsonPutRequestAuth).getHeaders();
+
         ussChangeTag = new UssChangeTag(connection);
     }
 
@@ -48,6 +67,27 @@ public class UssChangeTagTest {
     public void tstUssChangeTagChangeToBinarySuccess() throws ZosmfRequestException {
         final UssChangeTag ussChangeTag = new UssChangeTag(connection, mockJsonPutRequest);
         final Response response = ussChangeTag.binary("/xxx/xx/xx");
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
+    }
+
+    @Test
+    public void tstUssChangeTagToggleAuthSuccess() throws ZosmfRequestException {
+        final UssChangeTag ussChangeTag = new UssChangeTag(connection, mockJsonPutRequestAuth);
+
+        connection.setCookie(new Cookie("hello=hello"));
+        Response response = ussChangeTag.binary("/xxx/xx/xx");
+        assertEquals("{X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
+                mockJsonPutRequestAuth.getHeaders().toString());
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
+
+        connection.setCookie(null);
+        response = ussChangeTag.binary("/xxx/xx/xx");
+        assertEquals("{Authorization=Basic MTox, X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
+                mockJsonPutRequestAuth.getHeaders().toString());
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));

--- a/src/test/java/zowe/client/sdk/zosfiles/UssChangeTagTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssChangeTagTest.java
@@ -18,13 +18,9 @@ import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.PutJsonZosmfRequest;
 import zowe.client.sdk.rest.Response;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
-import zowe.client.sdk.zosfiles.uss.input.ChangeModeParams;
 import zowe.client.sdk.zosfiles.uss.input.ChangeTagParams;
-import zowe.client.sdk.zosfiles.uss.methods.UssChangeMode;
 import zowe.client.sdk.zosfiles.uss.methods.UssChangeTag;
 import zowe.client.sdk.zosfiles.uss.types.ChangeTagAction;
-
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;

--- a/src/test/java/zowe/client/sdk/zosfiles/UssCopyTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssCopyTest.java
@@ -19,12 +19,8 @@ import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.PutJsonZosmfRequest;
 import zowe.client.sdk.rest.Response;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
-import zowe.client.sdk.zosfiles.uss.input.ChangeModeParams;
 import zowe.client.sdk.zosfiles.uss.input.CopyParams;
-import zowe.client.sdk.zosfiles.uss.methods.UssChangeMode;
 import zowe.client.sdk.zosfiles.uss.methods.UssCopy;
-
-import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;

--- a/src/test/java/zowe/client/sdk/zosfiles/UssCopyTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssCopyTest.java
@@ -83,8 +83,8 @@ public class UssCopyTest {
 
         connection.setCookie(null);
         response = ussCopy.copy("/xxx/xx/xx", "/xxx/xx/xx");
-        Assertions.assertEquals("{Authorization=Basic MTox, X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
-                mockJsonPutRequestAuth.getHeaders().toString());
+        final String expectedResp = "{Authorization=Basic MTox, X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}";
+        Assertions.assertEquals(expectedResp, mockJsonPutRequestAuth.getHeaders().toString());
         Assertions.assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         Assertions.assertEquals(200, response.getStatusCode().orElse(-1));
         Assertions.assertEquals("success", response.getStatusText().orElse("n\\a"));

--- a/src/test/java/zowe/client/sdk/zosfiles/UssCopyTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssCopyTest.java
@@ -28,6 +28,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.withSettings;
 
@@ -54,7 +55,7 @@ public class UssCopyTest {
         mockJsonPutRequestAuth = Mockito.mock(PutJsonZosmfRequest.class, withSettings().useConstructor(connection));
         Mockito.when(mockJsonPutRequestAuth.executeRequest()).thenReturn(
                 new Response(new JSONObject(), 200, "success"));
-        doCallRealMethod().when(mockJsonPutRequestAuth).setHeaders(any(Map.class));
+        doCallRealMethod().when(mockJsonPutRequestAuth).setHeaders(anyMap());
         doCallRealMethod().when(mockJsonPutRequestAuth).setStandardHeaders();
         doCallRealMethod().when(mockJsonPutRequestAuth).setUrl(any());
         doCallRealMethod().when(mockJsonPutRequestAuth).setCookie(any());

--- a/src/test/java/zowe/client/sdk/zosfiles/UssCopyTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssCopyTest.java
@@ -9,6 +9,7 @@
  */
 package zowe.client.sdk.zosfiles;
 
+import kong.unirest.core.Cookie;
 import org.json.simple.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
@@ -18,10 +19,17 @@ import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.PutJsonZosmfRequest;
 import zowe.client.sdk.rest.Response;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
+import zowe.client.sdk.zosfiles.uss.input.ChangeModeParams;
 import zowe.client.sdk.zosfiles.uss.input.CopyParams;
+import zowe.client.sdk.zosfiles.uss.methods.UssChangeMode;
 import zowe.client.sdk.zosfiles.uss.methods.UssCopy;
 
+import java.util.Map;
+
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.withSettings;
 
 /**
  * Class containing unit tests for UssCopy.
@@ -34,6 +42,7 @@ public class UssCopyTest {
 
     private final ZosConnection connection = new ZosConnection("1", "1", "1", "1");
     private PutJsonZosmfRequest mockJsonPutRequest;
+    private PutJsonZosmfRequest mockJsonPutRequestAuth;
     private UssCopy ussCopy;
 
     @Before
@@ -41,6 +50,16 @@ public class UssCopyTest {
         mockJsonPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
         Mockito.when(mockJsonPutRequest.executeRequest()).thenReturn(
                 new Response(new JSONObject(), 200, "success"));
+
+        mockJsonPutRequestAuth = Mockito.mock(PutJsonZosmfRequest.class, withSettings().useConstructor(connection));
+        Mockito.when(mockJsonPutRequestAuth.executeRequest()).thenReturn(
+                new Response(new JSONObject(), 200, "success"));
+        doCallRealMethod().when(mockJsonPutRequestAuth).setHeaders(any(Map.class));
+        doCallRealMethod().when(mockJsonPutRequestAuth).setStandardHeaders();
+        doCallRealMethod().when(mockJsonPutRequestAuth).setUrl(any());
+        doCallRealMethod().when(mockJsonPutRequestAuth).setCookie(any());
+        doCallRealMethod().when(mockJsonPutRequestAuth).getHeaders();
+
         ussCopy = new UssCopy(connection);
     }
 
@@ -48,6 +67,27 @@ public class UssCopyTest {
     public void tstUssCopySuccess() throws ZosmfRequestException {
         final UssCopy ussCopy = new UssCopy(connection, mockJsonPutRequest);
         final Response response = ussCopy.copy("/xxx/xx/xx", "/xxx/xx/xx");
+        Assertions.assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        Assertions.assertEquals(200, response.getStatusCode().orElse(-1));
+        Assertions.assertEquals("success", response.getStatusText().orElse("n\\a"));
+    }
+
+    @Test
+    public void tstUssCopyToggleAuthSuccess() throws ZosmfRequestException {
+        final UssCopy ussCopy = new UssCopy(connection, mockJsonPutRequestAuth);
+
+        connection.setCookie(new Cookie("hello=hello"));
+        Response response = ussCopy.copy("/xxx/xx/xx", "/xxx/xx/xx");
+        Assertions.assertEquals("{X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
+                mockJsonPutRequestAuth.getHeaders().toString());
+        Assertions.assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        Assertions.assertEquals(200, response.getStatusCode().orElse(-1));
+        Assertions.assertEquals("success", response.getStatusText().orElse("n\\a"));
+
+        connection.setCookie(null);
+        response = ussCopy.copy("/xxx/xx/xx", "/xxx/xx/xx");
+        Assertions.assertEquals("{Authorization=Basic MTox, X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
+                mockJsonPutRequestAuth.getHeaders().toString());
         Assertions.assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         Assertions.assertEquals(200, response.getStatusCode().orElse(-1));
         Assertions.assertEquals("success", response.getStatusText().orElse("n\\a"));

--- a/src/test/java/zowe/client/sdk/zosfiles/UssCreateTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssCreateTest.java
@@ -88,9 +88,6 @@ public class UssCreateTest {
         Assertions.assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         Assertions.assertEquals(200, response.getStatusCode().orElse(-1));
         Assertions.assertEquals("success", response.getStatusText().orElse("n\\a"));
-        Assertions.assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
-        Assertions.assertEquals(200, response.getStatusCode().orElse(-1));
-        Assertions.assertEquals("success", response.getStatusText().orElse("n\\a"));
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosfiles/UssCreateTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssCreateTest.java
@@ -9,6 +9,7 @@
  */
 package zowe.client.sdk.zosfiles;
 
+import kong.unirest.core.Cookie;
 import org.json.simple.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
@@ -24,6 +25,10 @@ import zowe.client.sdk.zosfiles.uss.methods.UssCreate;
 import zowe.client.sdk.zosfiles.uss.types.CreateType;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.withSettings;
 
 /**
  * Class containing unit tests for UssCreate.
@@ -36,6 +41,7 @@ public class UssCreateTest {
 
     private final ZosConnection connection = new ZosConnection("1", "1", "1", "1");
     private PostJsonZosmfRequest mockJsonPostRequest;
+    private PostJsonZosmfRequest mockJsonPostRequestAuth;
     private UssCreate ussCreate;
 
     @Before
@@ -50,6 +56,38 @@ public class UssCreateTest {
                 new Response(new JSONObject(), 200, "success"));
         final UssCreate ussCreate = new UssCreate(connection, mockJsonPostRequest);
         final Response response = ussCreate.create("/xx/xx/x", new CreateParams(CreateType.FILE, "rwxrwxrwx"));
+        Assertions.assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        Assertions.assertEquals(200, response.getStatusCode().orElse(-1));
+        Assertions.assertEquals("success", response.getStatusText().orElse("n\\a"));
+    }
+
+    @Test
+    public void tstUssCreateToggleAuthSuccess() throws ZosmfRequestException {
+        mockJsonPostRequestAuth = Mockito.mock(PostJsonZosmfRequest.class, withSettings().useConstructor(connection));
+        Mockito.when(mockJsonPostRequestAuth.executeRequest()).thenReturn(
+                new Response(new JSONObject(), 200, "success"));
+        doCallRealMethod().when(mockJsonPostRequestAuth).setHeaders(anyMap());
+        doCallRealMethod().when(mockJsonPostRequestAuth).setStandardHeaders();
+        doCallRealMethod().when(mockJsonPostRequestAuth).setUrl(any());
+        doCallRealMethod().when(mockJsonPostRequestAuth).setCookie(any());
+        doCallRealMethod().when(mockJsonPostRequestAuth).getHeaders();
+        final UssCreate ussCreate = new UssCreate(connection, mockJsonPostRequestAuth);
+
+        connection.setCookie(new Cookie("hello=hello"));
+        Response response = ussCreate.create("/xx/xx/x", new CreateParams(CreateType.FILE, "rwxrwxrwx"));
+        Assertions.assertEquals("{X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
+                mockJsonPostRequestAuth.getHeaders().toString());
+        Assertions.assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        Assertions.assertEquals(200, response.getStatusCode().orElse(-1));
+        Assertions.assertEquals("success", response.getStatusText().orElse("n\\a"));
+
+        connection.setCookie(null);
+        response = ussCreate.create("/xx/xx/x", new CreateParams(CreateType.FILE, "rwxrwxrwx"));
+        Assertions.assertEquals("{Authorization=Basic MTox, X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
+                mockJsonPostRequestAuth.getHeaders().toString());
+        Assertions.assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        Assertions.assertEquals(200, response.getStatusCode().orElse(-1));
+        Assertions.assertEquals("success", response.getStatusText().orElse("n\\a"));
         Assertions.assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         Assertions.assertEquals(200, response.getStatusCode().orElse(-1));
         Assertions.assertEquals("success", response.getStatusText().orElse("n\\a"));

--- a/src/test/java/zowe/client/sdk/zosfiles/UssCreateTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssCreateTest.java
@@ -83,8 +83,8 @@ public class UssCreateTest {
 
         connection.setCookie(null);
         response = ussCreate.create("/xx/xx/x", new CreateParams(CreateType.FILE, "rwxrwxrwx"));
-        Assertions.assertEquals("{Authorization=Basic MTox, X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
-                mockJsonPostRequestAuth.getHeaders().toString());
+        final String expectedResp = "{Authorization=Basic MTox, X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}";
+        Assertions.assertEquals(expectedResp, mockJsonPostRequestAuth.getHeaders().toString());
         Assertions.assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         Assertions.assertEquals(200, response.getStatusCode().orElse(-1));
         Assertions.assertEquals("success", response.getStatusText().orElse("n\\a"));

--- a/src/test/java/zowe/client/sdk/zosfiles/UssDeleteTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssDeleteTest.java
@@ -9,6 +9,7 @@
  */
 package zowe.client.sdk.zosfiles;
 
+import kong.unirest.core.Cookie;
 import org.json.simple.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
@@ -21,6 +22,10 @@ import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosfiles.uss.methods.UssDelete;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.withSettings;
 
 /**
  * Class containing unit tests for UssDelete.
@@ -33,6 +38,7 @@ public class UssDeleteTest {
 
     private final ZosConnection connection = new ZosConnection("1", "1", "1", "1");
     private DeleteJsonZosmfRequest mockJsonDeleteRequest;
+    private DeleteJsonZosmfRequest mockJsonDeleteRequestAuth;
     private UssDelete ussDelete;
 
     @Before
@@ -40,6 +46,16 @@ public class UssDeleteTest {
         mockJsonDeleteRequest = Mockito.mock(DeleteJsonZosmfRequest.class);
         Mockito.when(mockJsonDeleteRequest.executeRequest()).thenReturn(
                 new Response(new JSONObject(), 200, "success"));
+
+        mockJsonDeleteRequestAuth = Mockito.mock(DeleteJsonZosmfRequest.class, withSettings().useConstructor(connection));
+        Mockito.when(mockJsonDeleteRequestAuth.executeRequest()).thenReturn(
+                new Response(new JSONObject(), 200, "success"));
+        doCallRealMethod().when(mockJsonDeleteRequestAuth).setHeaders(anyMap());
+        doCallRealMethod().when(mockJsonDeleteRequestAuth).setStandardHeaders();
+        doCallRealMethod().when(mockJsonDeleteRequestAuth).setUrl(any());
+        doCallRealMethod().when(mockJsonDeleteRequestAuth).setCookie(any());
+        doCallRealMethod().when(mockJsonDeleteRequestAuth).getHeaders();
+
         ussDelete = new UssDelete(connection);
     }
 
@@ -47,6 +63,27 @@ public class UssDeleteTest {
     public void tstUssDeleteSuccess() throws ZosmfRequestException {
         final UssDelete ussDelete = new UssDelete(connection, mockJsonDeleteRequest);
         final Response response = ussDelete.delete("/xxx/xx/xx");
+        Assertions.assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        Assertions.assertEquals(200, response.getStatusCode().orElse(-1));
+        Assertions.assertEquals("success", response.getStatusText().orElse("n\\a"));
+    }
+
+    @Test
+    public void tstUssDeleteToggleAuthSuccess() throws ZosmfRequestException {
+        final UssDelete ussDelete = new UssDelete(connection, mockJsonDeleteRequestAuth);
+
+        connection.setCookie(new Cookie("hello=hello"));
+        Response response = ussDelete.delete("/xxx/xx/xx");
+        Assertions.assertEquals("{X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
+                mockJsonDeleteRequestAuth.getHeaders().toString());
+        Assertions.assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        Assertions.assertEquals(200, response.getStatusCode().orElse(-1));
+        Assertions.assertEquals("success", response.getStatusText().orElse("n\\a"));
+
+        connection.setCookie(null);
+        response = ussDelete.delete("/xxx/xx/xx");
+        Assertions.assertEquals("{Authorization=Basic MTox, X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
+                mockJsonDeleteRequestAuth.getHeaders().toString());
         Assertions.assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         Assertions.assertEquals(200, response.getStatusCode().orElse(-1));
         Assertions.assertEquals("success", response.getStatusText().orElse("n\\a"));

--- a/src/test/java/zowe/client/sdk/zosfiles/UssDeleteTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssDeleteTest.java
@@ -82,8 +82,8 @@ public class UssDeleteTest {
 
         connection.setCookie(null);
         response = ussDelete.delete("/xxx/xx/xx");
-        Assertions.assertEquals("{Authorization=Basic MTox, X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
-                mockJsonDeleteRequestAuth.getHeaders().toString());
+        final String expectedResp = "{Authorization=Basic MTox, X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}";
+        Assertions.assertEquals(expectedResp, mockJsonDeleteRequestAuth.getHeaders().toString());
         Assertions.assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         Assertions.assertEquals(200, response.getStatusCode().orElse(-1));
         Assertions.assertEquals("success", response.getStatusText().orElse("n\\a"));

--- a/src/test/java/zowe/client/sdk/zosfiles/UssGetTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssGetTest.java
@@ -9,6 +9,7 @@
  */
 package zowe.client.sdk.zosfiles;
 
+import kong.unirest.core.Cookie;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
@@ -22,6 +23,10 @@ import zowe.client.sdk.zosfiles.uss.input.GetParams;
 import zowe.client.sdk.zosfiles.uss.methods.UssGet;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.withSettings;
 
 /**
  * Class containing unit tests for UssGet.
@@ -47,6 +52,34 @@ public class UssGetTest {
                 new Response("text", 200, "success"));
         final UssGet ussGet = new UssGet(connection, mockTextGetRequest);
         final String response = ussGet.getText("/xxx/xx");
+        Assertions.assertEquals("text", response);
+    }
+
+    @Test
+    public void tstGetTextFileTargetPathToggleAuthSuccess() throws ZosmfRequestException {
+        final GetTextZosmfRequest mockTextGetRequestAuth = Mockito.mock(GetTextZosmfRequest.class,
+                withSettings().useConstructor(connection));
+        Mockito.when(mockTextGetRequestAuth.executeRequest()).thenReturn(
+                new Response("text", 200, "success"));
+        doCallRealMethod().when(mockTextGetRequestAuth).setHeaders(anyMap());
+        doCallRealMethod().when(mockTextGetRequestAuth).setStandardHeaders();
+        doCallRealMethod().when(mockTextGetRequestAuth).setUrl(any());
+        doCallRealMethod().when(mockTextGetRequestAuth).setCookie(any());
+        doCallRealMethod().when(mockTextGetRequestAuth).getHeaders();
+
+        final UssGet ussGet = new UssGet(connection, mockTextGetRequestAuth);
+        connection.setCookie(new Cookie("hello=hello"));
+        String response = ussGet.getText("/xxx/xx");
+        String expectedResponse = "{X-IBM-Data-Type=text, X-CSRF-ZOSMF-HEADER=true, " +
+                "Content-Type=text/plain; charset=UTF-8}";
+        Assertions.assertEquals(expectedResponse, mockTextGetRequestAuth.getHeaders().toString());
+        Assertions.assertEquals("text", response);
+
+        connection.setCookie(null);
+        response = ussGet.getText("/xxx/xx");
+        expectedResponse = "{Authorization=Basic MTox, X-IBM-Data-Type=text, X-CSRF-ZOSMF-HEADER=true, " +
+                "Content-Type=text/plain; charset=UTF-8}";
+        Assertions.assertEquals(expectedResponse, mockTextGetRequestAuth.getHeaders().toString());
         Assertions.assertEquals("text", response);
     }
 

--- a/src/test/java/zowe/client/sdk/zosfiles/UssGetTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssGetTest.java
@@ -70,16 +70,16 @@ public class UssGetTest {
         final UssGet ussGet = new UssGet(connection, mockTextGetRequestAuth);
         connection.setCookie(new Cookie("hello=hello"));
         String response = ussGet.getText("/xxx/xx");
-        String expectedResponse = "{X-IBM-Data-Type=text, X-CSRF-ZOSMF-HEADER=true, " +
+        String expectedResp = "{X-IBM-Data-Type=text, X-CSRF-ZOSMF-HEADER=true, " +
                 "Content-Type=text/plain; charset=UTF-8}";
-        Assertions.assertEquals(expectedResponse, mockTextGetRequestAuth.getHeaders().toString());
+        Assertions.assertEquals(expectedResp, mockTextGetRequestAuth.getHeaders().toString());
         Assertions.assertEquals("text", response);
 
         connection.setCookie(null);
         response = ussGet.getText("/xxx/xx");
-        expectedResponse = "{Authorization=Basic MTox, X-IBM-Data-Type=text, X-CSRF-ZOSMF-HEADER=true, " +
+        expectedResp = "{Authorization=Basic MTox, X-IBM-Data-Type=text, X-CSRF-ZOSMF-HEADER=true, " +
                 "Content-Type=text/plain; charset=UTF-8}";
-        Assertions.assertEquals(expectedResponse, mockTextGetRequestAuth.getHeaders().toString());
+        Assertions.assertEquals(expectedResp, mockTextGetRequestAuth.getHeaders().toString());
         Assertions.assertEquals("text", response);
     }
 

--- a/src/test/java/zowe/client/sdk/zosfiles/UssListTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssListTest.java
@@ -146,8 +146,15 @@ public class UssListTest {
 
         final UssList ussList = new UssList(connection, mockJsonGetRequestAuth);
         connection.setCookie(new Cookie("hello=hello"));
-        final List<UnixFile> items = ussList.getFiles(new ListParams.Builder().path("/xxx/xx/x").build());
+        List<UnixFile> items = ussList.getFiles(new ListParams.Builder().path("/xxx/xx/x").build());
         Assertions.assertEquals("{X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
+                mockJsonGetRequestAuth.getHeaders().toString());
+        // should only contain two items
+        assertEquals(0, items.size());
+
+        connection.setCookie(null);
+        items = ussList.getFiles(new ListParams.Builder().path("/xxx/xx/x").build());
+        Assertions.assertEquals("{Authorization=Basic MTox, X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
                 mockJsonGetRequestAuth.getHeaders().toString());
         // should only contain two items
         assertEquals(0, items.size());

--- a/src/test/java/zowe/client/sdk/zosfiles/UssListTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssListTest.java
@@ -135,7 +135,8 @@ public class UssListTest {
 
     @Test
     public void tstUssListFileListEmptyResponseToggleAuthSuccess() throws Exception {
-        GetJsonZosmfRequest mockJsonGetRequestAuth = Mockito.mock(GetJsonZosmfRequest.class, withSettings().useConstructor(connection));
+        GetJsonZosmfRequest mockJsonGetRequestAuth = Mockito.mock(GetJsonZosmfRequest.class,
+                withSettings().useConstructor(connection));
         Mockito.when(mockJsonGetRequestAuth.executeRequest()).thenReturn(
                 new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonGetRequestAuth).setHeaders(anyMap());
@@ -154,8 +155,8 @@ public class UssListTest {
 
         connection.setCookie(null);
         items = ussList.getFiles(new ListParams.Builder().path("/xxx/xx/x").build());
-        Assertions.assertEquals("{Authorization=Basic MTox, X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
-                mockJsonGetRequestAuth.getHeaders().toString());
+        final String expectedResp = "{Authorization=Basic MTox, X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}";
+        Assertions.assertEquals(expectedResp, mockJsonGetRequestAuth.getHeaders().toString());
         // should only contain two items
         assertEquals(0, items.size());
     }

--- a/src/test/java/zowe/client/sdk/zosfiles/UssMountTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/UssMountTest.java
@@ -79,10 +79,10 @@ public class UssMountTest {
         Assertions.assertEquals(200, response.getStatusCode().orElse(-1));
         Assertions.assertEquals("success", response.getStatusText().orElse("n\\a"));
 
-        connection.setCookie(new Cookie("hello=hello"));
+        connection.setCookie(null);
         response = ussMount.mount("name", "mountpoint", "fstype");
-        Assertions.assertEquals("{X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
-                mockJsonPutRequestAuth.getHeaders().toString());
+        final String expectedResp = "{Authorization=Basic MTox, X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}";
+        Assertions.assertEquals(expectedResp, mockJsonPutRequestAuth.getHeaders().toString());
         Assertions.assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         Assertions.assertEquals(200, response.getStatusCode().orElse(-1));
         Assertions.assertEquals("success", response.getStatusText().orElse("n\\a"));

--- a/src/test/java/zowe/client/sdk/zosjobs/GetJobsByTextGetRequestTest.java
+++ b/src/test/java/zowe/client/sdk/zosjobs/GetJobsByTextGetRequestTest.java
@@ -9,8 +9,10 @@
  */
 package zowe.client.sdk.zosjobs;
 
+import kong.unirest.core.Cookie;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.mockito.Mockito;
 import org.powermock.reflect.Whitebox;
 import zowe.client.sdk.core.ZosConnection;
@@ -20,6 +22,10 @@ import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosjobs.methods.JobGet;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.withSettings;
 
 /**
  * Class containing unit tests for JobGet.
@@ -46,6 +52,35 @@ public class GetJobsByTextGetRequestTest {
                 new Response("1\n2\n3\n", 200, "success"));
 
         final String results = getJobs.getSpoolContent("jobName", "jobId", 1);
+        assertEquals("https://1:1/zosmf/restjobs/jobs/jobName/jobId/files/1/records", getJobs.getUrl());
+        assertEquals("1\n2\n3\n", results);
+    }
+
+    @Test
+    public void tstGetSpoolContentByIdToggleAuthSuccess() throws ZosmfRequestException {
+        GetTextZosmfRequest mockTextGetRequestAuth = Mockito.mock(GetTextZosmfRequest.class,
+                withSettings().useConstructor(connection));
+        Whitebox.setInternalState(getJobs, "request", mockTextGetRequestAuth);
+        Mockito.when(mockTextGetRequestAuth.executeRequest()).thenReturn(
+                new Response("1\n2\n3\n", 200, "success"));
+        doCallRealMethod().when(mockTextGetRequestAuth).setHeaders(anyMap());
+        doCallRealMethod().when(mockTextGetRequestAuth).setStandardHeaders();
+        doCallRealMethod().when(mockTextGetRequestAuth).setUrl(any());
+        doCallRealMethod().when(mockTextGetRequestAuth).setCookie(any());
+        doCallRealMethod().when(mockTextGetRequestAuth).getHeaders();
+
+        connection.setCookie(new Cookie("hello=hello"));
+        String results = getJobs.getSpoolContent("jobName", "jobId", 1);
+        Assertions.assertEquals("{X-CSRF-ZOSMF-HEADER=true, Content-Type=text/plain; charset=UTF-8}",
+                mockTextGetRequestAuth.getHeaders().toString());
+        assertEquals("https://1:1/zosmf/restjobs/jobs/jobName/jobId/files/1/records", getJobs.getUrl());
+        assertEquals("1\n2\n3\n", results);
+
+        connection.setCookie(null);
+        results = getJobs.getSpoolContent("jobName", "jobId", 1);
+        final String expectedResp = "{Authorization=Basic MTox, X-CSRF-ZOSMF-HEADER=true, " +
+                "Content-Type=text/plain; charset=UTF-8}";
+        Assertions.assertEquals(expectedResp, mockTextGetRequestAuth.getHeaders().toString());
         assertEquals("https://1:1/zosmf/restjobs/jobs/jobName/jobId/files/1/records", getJobs.getUrl());
         assertEquals("1\n2\n3\n", results);
     }


### PR DESCRIPTION
This PR adds tests for toggling between basic and token authentication. 

In addition, ZosConnection object's equals and hascode methods updated with new cookie class member. 