### PR TITLE
Updates to TeamConfig processing. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.zowe.client.java.sdk</groupId>
     <artifactId>zowe-client-java-sdk</artifactId>
-    <version>3.0.5</version>
+    <version>3.0.6</version>
     <build>
         <plugins>
             <plugin>

--- a/src/main/java/zowe/client/sdk/teamconfig/README.md
+++ b/src/main/java/zowe/client/sdk/teamconfig/README.md
@@ -3,13 +3,38 @@
 The TeamConfig package provides API method(s) to retrieve a profile section from Zowe Global Team Configuration with
 keytar information to help perform connection processing without hard coding username and password. Keytar represents
 credentials stored securely on your computer when performing the Zowe global initialize command which prompts you for
-username and password.
+username and password.  
 
+## Description of retrieving a profile.
+  
+With the following team configuration:
+  
+    "$schema": "./zowe.schema.json",
+        "profiles": {
+            "frank": {
+                "type": "zosmf",
+                "properties": {
+                    "port": 4433
+                },
+                "secure": []
+            }
+        },
+        "defaults": {
+            "zosmf": "frank"
+        }
+    }  
+  
+To retrieve the profile name "frank" with the credentials from the credential store, perform the following:
+  
+ProfileDao profile = teamConfig.getDefaultProfileByName("zosmf");
+  
+This should return the profile named "frank" with its attributes.
+  
 ## API Example
 
 **Retrieve the default "zosmf" profile from team config. Use it to create a ZOSConnection object without hard coding
-username and password and retrieve a list of members from the dataset input string.**
-
+username and password and retrieve a list of members from the dataset input string.**  
+  
 ````java
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;

--- a/src/main/java/zowe/client/sdk/teamconfig/TeamConfig.java
+++ b/src/main/java/zowe/client/sdk/teamconfig/TeamConfig.java
@@ -168,6 +168,9 @@ public class TeamConfig {
      * @author Frank Giordano
      */
     private void merge(final Optional<Profile> target, final Optional<Profile> base) {
+        if (target.isEmpty() || base.isEmpty()) {
+            return;
+        }
         final Optional<Map<String, String>> targetProps = Optional.ofNullable(target.get().getProperties());
         final Optional<Map<String, String>> baseProps = Optional.ofNullable(base.get().getProperties());
         if (mergeProperties.getHost().isEmpty() && targetProps.isPresent()) {

--- a/src/main/java/zowe/client/sdk/teamconfig/TeamConfig.java
+++ b/src/main/java/zowe/client/sdk/teamconfig/TeamConfig.java
@@ -111,12 +111,14 @@ public class TeamConfig {
 
         final Optional<Profile> target = teamConfig.getProfiles().stream().filter(isProfileName).findFirst();
         if (target.isEmpty()) {
-            throw new IllegalStateException("TeamConfig profile " + name + " not found");
+            throw new IllegalStateException("No TeamConfig default profile for " + name + " is found.");
+        } else if (!target.get().getType().equalsIgnoreCase(name)) {
+            throw new IllegalStateException("No TeamConfig default profile for type " + name + " is found.");
+        } else {
+            merge(target, base);
+            return new ProfileDao(target.get(), keyTarConfig.getUserName(), keyTarConfig.getPassword(),
+                    mergeProperties.getHost().orElse(null), mergeProperties.getPort().orElse(null));
         }
-
-        merge(target, base);
-        return new ProfileDao(target.get(), keyTarConfig.getUserName(), keyTarConfig.getPassword(),
-                mergeProperties.getHost().orElse(null), mergeProperties.getPort().orElse(null));
     }
 
     /**

--- a/src/main/java/zowe/client/sdk/teamconfig/model/Profile.java
+++ b/src/main/java/zowe/client/sdk/teamconfig/model/Profile.java
@@ -30,6 +30,11 @@ public class Profile {
     private final String name;
 
     /**
+     * Profile type
+     */
+    private final String type;
+
+    /**
      * Profile secure json object
      */
     private final JSONArray secure;
@@ -43,13 +48,15 @@ public class Profile {
      * Partition constructor
      *
      * @param name   profile name
+     * @param type   profile type
      * @param obj    json object of property values within profile section from Zowe Global Team Configuration
      * @param secure jsonarray value of secure section
      * @author Frank Giordano
      */
     @SuppressWarnings("unchecked")
-    public Profile(final String name, final JSONObject obj, final JSONArray secure) {
+    public Profile(final String name, final String type, final JSONObject obj, final JSONArray secure) {
         this.name = name;
+        this.type = type;
         this.secure = secure;
         properties = (Map<String, String>) JsonParseFactory.buildParser(ParseType.PROPS).parseResponse(obj);
     }
@@ -61,6 +68,15 @@ public class Profile {
      */
     public String getName() {
         return name;
+    }
+
+    /**
+     * Return profile type
+     *
+     * @return profile type string value
+     */
+    public String getType() {
+        return type;
     }
 
     /**
@@ -90,9 +106,10 @@ public class Profile {
     public String toString() {
         return "Profile{" +
                 "name='" + name + '\'' +
+                ", type='" + type + '\'' +
                 ", secure=" + secure +
                 ", properties=" + properties +
                 '}';
     }
-
+    
 }

--- a/src/main/java/zowe/client/sdk/teamconfig/model/Profile.java
+++ b/src/main/java/zowe/client/sdk/teamconfig/model/Profile.java
@@ -111,5 +111,5 @@ public class Profile {
                 ", properties=" + properties +
                 '}';
     }
-    
+
 }

--- a/src/main/java/zowe/client/sdk/teamconfig/service/TeamConfigService.java
+++ b/src/main/java/zowe/client/sdk/teamconfig/service/TeamConfigService.java
@@ -59,7 +59,8 @@ public class TeamConfigService {
                 final Set<String> jsonProfileKeys = jsonProfileObj.keySet();
                 for (final String profileKeyVal : jsonProfileKeys) {
                     final JSONObject profileTypeJsonObj = (JSONObject) jsonProfileObj.get(profileKeyVal);
-                    profiles.add(new Profile((String) profileTypeJsonObj.get("type"),
+                    profiles.add(new Profile(profileKeyVal,
+                            (String) profileTypeJsonObj.get("type"),
                             (JSONObject) profileTypeJsonObj.get("properties"),
                             (JSONArray) profileTypeJsonObj.get("secure")));
                 }
@@ -136,7 +137,8 @@ public class TeamConfigService {
                     if (isPartition(isEmbeddedKeyProfile)) {
                         partitions.add(getPartition(profileKeyVal, profileTypeJsonObj));
                     } else {
-                        profiles.add(new Profile((String) profileTypeJsonObj.get("type"),
+                        profiles.add(new Profile(profileKeyVal,
+                                (String) profileTypeJsonObj.get("type"),
                                 (JSONObject) profileTypeJsonObj.get("properties"),
                                 (JSONArray) profileTypeJsonObj.get("secure")));
                     }

--- a/src/test/java/zowe/client/sdk/teamconfig/TeamConfigTest.java
+++ b/src/test/java/zowe/client/sdk/teamconfig/TeamConfigTest.java
@@ -1,4 +1,116 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
 package zowe.client.sdk.teamconfig;
 
+import org.json.simple.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import zowe.client.sdk.teamconfig.exception.TeamConfigException;
+import zowe.client.sdk.teamconfig.keytar.KeyTarImpl;
+import zowe.client.sdk.teamconfig.model.ConfigContainer;
+import zowe.client.sdk.teamconfig.model.Profile;
+import zowe.client.sdk.teamconfig.model.ProfileDao;
+import zowe.client.sdk.teamconfig.service.KeyTarService;
+import zowe.client.sdk.teamconfig.service.TeamConfigService;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+
+/**
+ * Class containing unit test for TeamConfig.
+ *
+ * @author Frank Giordano
+ * @version 3.0
+ */
 public class TeamConfigTest {
+
+    private TeamConfigService teamConfigServiceMock;
+
+    @Before
+    public void init() {
+        teamConfigServiceMock = Mockito.mock(TeamConfigService.class);
+    }
+
+    @Test
+    public void tstGetDefaultProfileByNameFailure() throws TeamConfigException {
+        JSONObject props = new JSONObject(Map.of("port", "433"));
+        List<Profile> profiles = List.of(new Profile("frank1", "zosmf", props, null));
+        Map<String, String> defaults = Map.of("zosmf", "frank");
+        Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(
+                new ConfigContainer(null, null, profiles, defaults, null));
+
+        TeamConfig teamConfig;
+        try {
+            teamConfig = new TeamConfig(new KeyTarService(new KeyTarImpl()), teamConfigServiceMock);
+        } catch (TeamConfigException e) {
+            throw new RuntimeException(e.getMessage());
+        }
+        String errMsg = "";
+        try {
+            teamConfig.getDefaultProfileByName("zosmf");
+        } catch (Exception e) {
+            errMsg = e.getMessage();
+        }
+        assertEquals("No TeamConfig default profile for zosmf is found.", errMsg);
+    }
+
+    @Test
+    public void tstGetDefaultProfileByNameTypeNotFoundFailure() throws TeamConfigException {
+        JSONObject props = new JSONObject(Map.of("port", "433"));
+        List<Profile> profiles = List.of(new Profile("frank", "zosmf1", props, null));
+        Map<String, String> defaults = Map.of("zosmf", "frank");
+        Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(
+                new ConfigContainer(null, null, profiles, defaults, null));
+
+        TeamConfig teamConfig;
+        try {
+            teamConfig = new TeamConfig(new KeyTarService(new KeyTarImpl()), teamConfigServiceMock);
+        } catch (TeamConfigException e) {
+            throw new RuntimeException(e.getMessage());
+        }
+        String errMsg = "";
+        try {
+            teamConfig.getDefaultProfileByName("zosmf");
+        } catch (Exception e) {
+            errMsg = e.getMessage();
+        }
+        assertEquals("No TeamConfig default profile for type zosmf is found.", errMsg);
+    }
+
+    @Test
+    public void tstGetDefaultProfileByNamSuccess() throws TeamConfigException {
+        JSONObject props = new JSONObject(Map.of("port", "433"));
+        List<Profile> profiles = List.of(new Profile("frank", "zosmf", props, null));
+        Map<String, String> defaults = Map.of("zosmf", "frank");
+        Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(
+                new ConfigContainer(null, null, profiles, defaults, null));
+
+        TeamConfig teamConfig;
+        try {
+            teamConfig = new TeamConfig(new KeyTarService(new KeyTarImpl()), teamConfigServiceMock);
+        } catch (TeamConfigException e) {
+            throw new RuntimeException(e.getMessage());
+        }
+        String errMsg = "";
+        ProfileDao profileDao = null;
+        try {
+            profileDao = teamConfig.getDefaultProfileByName("zosmf");
+        } catch (Exception e) {
+            errMsg = e.getMessage();
+        }
+        assertEquals("", errMsg);
+        assertEquals("frank", profileDao.getProfile().getName());
+    }
+
 }

--- a/src/test/java/zowe/client/sdk/teamconfig/TeamConfigTest.java
+++ b/src/test/java/zowe/client/sdk/teamconfig/TeamConfigTest.java
@@ -1,0 +1,4 @@
+package zowe.client.sdk.teamconfig;
+
+public class TeamConfigTest {
+}


### PR DESCRIPTION
Updates to TeamConfig processing. 

Made some minor changes. 

This PR contains a fix for #352 
 
It also contains a tweak to avoid merging profiles if one does not exist. Where as before it would have required at least a bas profile. So now you don't need a base profile defined and the processing wont error out. 
