### PR TITLE
Default TeamConfig constructor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.zowe.client.java.sdk</groupId>
     <artifactId>zowe-client-java-sdk</artifactId>
-    <version>3.0.6</version>
+    <version>3.1.0</version>
     <build>
         <plugins>
             <plugin>

--- a/src/main/java/zowe/client/sdk/teamconfig/README.md
+++ b/src/main/java/zowe/client/sdk/teamconfig/README.md
@@ -3,12 +3,12 @@
 The TeamConfig package provides API method(s) to retrieve a profile section from Zowe Global Team Configuration with
 keytar information to help perform connection processing without hard coding username and password. Keytar represents
 credentials stored securely on your computer when performing the Zowe global initialize command which prompts you for
-username and password.  
+username and password.
 
 ## Description of retrieving a profile.
-  
+
 With the following team configuration:
-  
+
     "$schema": "./zowe.schema.json",
         "profiles": {
             "frank": {
@@ -23,18 +23,18 @@ With the following team configuration:
             "zosmf": "frank"
         }
     }  
-  
+
 To retrieve the profile name "frank" with the credentials from the credential store, perform the following:
-  
+
 ProfileDao profile = teamConfig.getDefaultProfileByName("zosmf");
-  
+
 This should return the profile named "frank" with its attributes.
-  
+
 ## API Example
 
 **Retrieve the default "zosmf" profile from team config. Use it to create a ZOSConnection object without hard coding
-username and password and retrieve a list of members from the dataset input string.**  
-  
+username and password and retrieve a list of members from the dataset input string.**
+
 ````java
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
@@ -78,7 +78,7 @@ public class TeamConfigExp {
 
         TeamConfig teamConfig;
         try {
-            teamConfig = new TeamConfig(new KeyTarService(new KeyTarImpl()), new TeamConfigService());
+            teamConfig = new TeamConfig();
         } catch (TeamConfigException e) {
             throw new RuntimeException(e.getMessage());
         }

--- a/src/main/java/zowe/client/sdk/teamconfig/README.md
+++ b/src/main/java/zowe/client/sdk/teamconfig/README.md
@@ -28,7 +28,7 @@ To retrieve the profile name "frank" with the credentials from the credential st
 
 ProfileDao profile = teamConfig.getDefaultProfileByName("zosmf");
 
-This should return the profile named "frank" with its attributes.
+This should return the profile named "frank" with its attributes and credentials. 
 
 ## API Example
 

--- a/src/main/java/zowe/client/sdk/teamconfig/TeamConfig.java
+++ b/src/main/java/zowe/client/sdk/teamconfig/TeamConfig.java
@@ -13,6 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zowe.client.sdk.teamconfig.exception.TeamConfigException;
 import zowe.client.sdk.teamconfig.keytar.KeyTarConfig;
+import zowe.client.sdk.teamconfig.keytar.KeyTarImpl;
 import zowe.client.sdk.teamconfig.model.ConfigContainer;
 import zowe.client.sdk.teamconfig.model.Partition;
 import zowe.client.sdk.teamconfig.model.Profile;
@@ -66,7 +67,16 @@ public class TeamConfig {
     private ConfigContainer teamConfig;
 
     /**
-     * TeamConfig constructor
+     * Default TeamConfig constructor without arguments.
+     */
+    public TeamConfig() throws TeamConfigException {
+        this.keyTarService = new KeyTarService(new KeyTarImpl());
+        this.teamConfigService = new TeamConfigService();
+        config();
+    }
+
+    /**
+     * TeamConfig constructor. This is mainly used for internal code unit testing with mockito.
      *
      * @param keyTarService     required KeyTarService dependency
      * @param teamConfigService required TeamConfigService dependency


### PR DESCRIPTION
The following PR removes the need to provide too much ceremony when initializing a TeamConfig object. 

The reason for this ceremony is to perform dependency injection. This allows the ability to mock dependencies for unit test coverage.  
  
With this PR, I added a default no arguments TeamConfig constructor for the end user to use instead of the constructor with dependency arguments. 

This removes the need for the end user to initialize a TeamConfig object with boilerplate that isn't needed to perform team config processing. 

Before this PR, the only way to initialize a TeamConfig object is as follows:
 
        teamConfig = new TeamConfig(new KeyTarService(new KeyTarImpl()), new TeamConfigService());

After this PR, you can continue to use the legacy way, but now you can perform the following:

        teamConfig = new TeamConfig();
