### PR TITLE
Upgrade and convert tests for Junit 5 version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,14 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version> <!-- latest stable -->
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>3.2.1</version>
                 <executions>
@@ -146,6 +154,20 @@
         </dependency>
 
         <!-- Test -->
+        <!-- JUnit 5 -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Mockito -->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
@@ -159,21 +181,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>5.9.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>4.2.0</version>
+            <version>5.12.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/zowe/client/sdk/utility/ValidateUtils.java
+++ b/src/main/java/zowe/client/sdk/utility/ValidateUtils.java
@@ -29,7 +29,7 @@ public final class ValidateUtils {
     }
 
     /**
-     * Check for the state of parameter by String value
+     * Check for the state of a parameter by String value
      *
      * @param value string value
      * @param name  name of attribute

--- a/src/test/java/zowe/client/sdk/core/AuthTypeTest.java
+++ b/src/test/java/zowe/client/sdk/core/AuthTypeTest.java
@@ -9,7 +9,7 @@
  */
 package zowe.client.sdk.core;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/zowe/client/sdk/core/SshConnectionTest.java
+++ b/src/test/java/zowe/client/sdk/core/SshConnectionTest.java
@@ -9,11 +9,11 @@
  */
 package zowe.client.sdk.core;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Class containing unit tests for SshConnection.

--- a/src/test/java/zowe/client/sdk/core/ZosConnectionFactoryTest.java
+++ b/src/test/java/zowe/client/sdk/core/ZosConnectionFactoryTest.java
@@ -10,7 +10,7 @@
 package zowe.client.sdk.core;
 
 import kong.unirest.core.Cookie;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 

--- a/src/test/java/zowe/client/sdk/parse/DatasetParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/DatasetParseResponseTest.java
@@ -10,15 +10,15 @@
 package zowe.client.sdk.parse;
 
 import org.json.simple.JSONObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import zowe.client.sdk.parse.type.ParseType;
 import zowe.client.sdk.zosfiles.dsn.response.Dataset;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Class containing unit tests for DatasetParseResponse.

--- a/src/test/java/zowe/client/sdk/parse/JobFileParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/JobFileParseResponseTest.java
@@ -10,15 +10,15 @@
 package zowe.client.sdk.parse;
 
 import org.json.simple.JSONObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import zowe.client.sdk.parse.type.ParseType;
 import zowe.client.sdk.zosjobs.response.JobFile;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Class containing unit tests for JobFileParseResponse.

--- a/src/test/java/zowe/client/sdk/parse/JobParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/JobParseResponseTest.java
@@ -10,15 +10,15 @@
 package zowe.client.sdk.parse;
 
 import org.json.simple.JSONObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import zowe.client.sdk.parse.type.ParseType;
 import zowe.client.sdk.zosjobs.response.Job;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Class containing unit tests for JobParseResponse.

--- a/src/test/java/zowe/client/sdk/parse/MemberParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/MemberParseResponseTest.java
@@ -10,15 +10,16 @@
 package zowe.client.sdk.parse;
 
 import org.json.simple.JSONObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import zowe.client.sdk.parse.type.ParseType;
 import zowe.client.sdk.zosfiles.dsn.response.Member;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
 
 /**
  * Class containing unit tests for emberParseResponse.

--- a/src/test/java/zowe/client/sdk/parse/MvsConsoleParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/MvsConsoleParseResponseTest.java
@@ -10,15 +10,15 @@
 package zowe.client.sdk.parse;
 
 import org.json.simple.JSONObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import zowe.client.sdk.parse.type.ParseType;
 import zowe.client.sdk.zosconsole.response.ZosmfIssueResponse;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Class containing unit tests for MvsConsoleParseResponse.

--- a/src/test/java/zowe/client/sdk/parse/PropsParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/PropsParseResponseTest.java
@@ -10,14 +10,14 @@
 package zowe.client.sdk.parse;
 
 import org.json.simple.JSONObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import zowe.client.sdk.parse.type.ParseType;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Class containing unit tests for PropsParseResponse.

--- a/src/test/java/zowe/client/sdk/parse/SystemInfoParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/SystemInfoParseResponseTest.java
@@ -10,15 +10,15 @@
 package zowe.client.sdk.parse;
 
 import org.json.simple.JSONObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import zowe.client.sdk.parse.type.ParseType;
 import zowe.client.sdk.zosmfinfo.response.ZosmfInfoResponse;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Class containing unit tests for SystemInfoParseResponse.

--- a/src/test/java/zowe/client/sdk/parse/SystemsParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/SystemsParseResponseTest.java
@@ -11,12 +11,12 @@ package zowe.client.sdk.parse;
 
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import zowe.client.sdk.parse.type.ParseType;
 import zowe.client.sdk.zosmfinfo.response.ZosmfSystemsResponse;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Class containing unit tests for SystemsParseResponse.

--- a/src/test/java/zowe/client/sdk/parse/UnixFileParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/UnixFileParseResponseTest.java
@@ -10,15 +10,15 @@
 package zowe.client.sdk.parse;
 
 import org.json.simple.JSONObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import zowe.client.sdk.parse.type.ParseType;
 import zowe.client.sdk.zosfiles.uss.response.UnixFile;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Class containing unit tests for UnixFileParseResponse.

--- a/src/test/java/zowe/client/sdk/parse/UnixZfsParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/UnixZfsParseResponseTest.java
@@ -10,15 +10,15 @@
 package zowe.client.sdk.parse;
 
 import org.json.simple.JSONObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import zowe.client.sdk.parse.type.ParseType;
 import zowe.client.sdk.zosfiles.uss.response.UnixZfs;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Class containing unit tests for UnixZfsParseResponse.

--- a/src/test/java/zowe/client/sdk/parse/ZosLogItemParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/ZosLogItemParseResponseTest.java
@@ -10,15 +10,16 @@
 package zowe.client.sdk.parse;
 
 import org.json.simple.JSONObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import zowe.client.sdk.parse.type.ParseType;
 import zowe.client.sdk.zoslogs.response.ZosLogItem;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
 
 /**
  * Class containing unit tests for ZosLogItemParseResponse.

--- a/src/test/java/zowe/client/sdk/parse/ZosLogReplyParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/ZosLogReplyParseResponseTest.java
@@ -10,7 +10,7 @@
 package zowe.client.sdk.parse;
 
 import org.json.simple.JSONObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import zowe.client.sdk.parse.type.ParseType;
 import zowe.client.sdk.zoslogs.response.ZosLogReply;
 
@@ -18,8 +18,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Class containing unit tests for ZosLogReplyParseResponse.

--- a/src/test/java/zowe/client/sdk/rest/QueryConstantsTest.java
+++ b/src/test/java/zowe/client/sdk/rest/QueryConstantsTest.java
@@ -9,7 +9,7 @@
  */
 package zowe.client.sdk.rest;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import zowe.client.sdk.utility.Utils;
 
 /**

--- a/src/test/java/zowe/client/sdk/rest/RestConstantTest.java
+++ b/src/test/java/zowe/client/sdk/rest/RestConstantTest.java
@@ -1,9 +1,10 @@
 package zowe.client.sdk.rest;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 
 /**
  * Class containing unit test for RestConstant.

--- a/src/test/java/zowe/client/sdk/rest/ZosmfHeadersTest.java
+++ b/src/test/java/zowe/client/sdk/rest/ZosmfHeadersTest.java
@@ -9,7 +9,7 @@
  */
 package zowe.client.sdk.rest;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import zowe.client.sdk.utility.Utils;
 
 /**

--- a/src/test/java/zowe/client/sdk/rest/ZoweRequestFactoryTest.java
+++ b/src/test/java/zowe/client/sdk/rest/ZoweRequestFactoryTest.java
@@ -9,7 +9,7 @@
  */
 package zowe.client.sdk.rest;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import zowe.client.sdk.utility.Utils;
 
 /**

--- a/src/test/java/zowe/client/sdk/rest/ZoweRequestTest.java
+++ b/src/test/java/zowe/client/sdk/rest/ZoweRequestTest.java
@@ -12,15 +12,15 @@ package zowe.client.sdk.rest;
 import kong.unirest.core.Cookie;
 import kong.unirest.core.HttpResponse;
 import kong.unirest.core.JsonNode;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.core.ZosConnectionFactory;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.rest.type.ZosmfRequestType;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Class containing unit test for ZoweRequest.
@@ -34,7 +34,7 @@ public class ZoweRequestTest {
     private ZosConnection connection;
 
     @SuppressWarnings("unchecked")
-    @Before
+    @BeforeEach
     public void init() {
         mockReply = Mockito.mock(HttpResponse.class);
         connection = ZosConnectionFactory.createBasicConnection("1", "1", "1", "1");

--- a/src/test/java/zowe/client/sdk/teamconfig/TeamConfigTest.java
+++ b/src/test/java/zowe/client/sdk/teamconfig/TeamConfigTest.java
@@ -10,8 +10,8 @@
 package zowe.client.sdk.teamconfig;
 
 import org.json.simple.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import zowe.client.sdk.teamconfig.exception.TeamConfigException;
 import zowe.client.sdk.teamconfig.keytar.KeyTarConfig;
@@ -24,7 +24,7 @@ import zowe.client.sdk.teamconfig.service.TeamConfigService;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 
 /**
@@ -38,7 +38,7 @@ public class TeamConfigTest {
     private TeamConfigService teamConfigServiceMock;
     private KeyTarService keyTarServiceMock;
 
-    @Before
+    @BeforeEach
     public void init() {
         teamConfigServiceMock = Mockito.mock(TeamConfigService.class);
         keyTarServiceMock = Mockito.mock(KeyTarService.class);

--- a/src/test/java/zowe/client/sdk/utility/EncodeUtilsTest.java
+++ b/src/test/java/zowe/client/sdk/utility/EncodeUtilsTest.java
@@ -9,7 +9,7 @@
  */
 package zowe.client.sdk.utility;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Class containing unit test for EncodeUtils.

--- a/src/test/java/zowe/client/sdk/utility/FileUtilsTest.java
+++ b/src/test/java/zowe/client/sdk/utility/FileUtilsTest.java
@@ -9,9 +9,9 @@
  */
 package zowe.client.sdk.utility;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Class containing unit tests for FileUtils.

--- a/src/test/java/zowe/client/sdk/utility/JsonParserUtilTest.java
+++ b/src/test/java/zowe/client/sdk/utility/JsonParserUtilTest.java
@@ -9,7 +9,7 @@
  */
 package zowe.client.sdk.utility;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Class containing unit test for JsonParserUtil.

--- a/src/test/java/zowe/client/sdk/utility/Utils.java
+++ b/src/test/java/zowe/client/sdk/utility/Utils.java
@@ -17,8 +17,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Utility class for the test package.

--- a/src/test/java/zowe/client/sdk/utility/ValidateUtilsTest.java
+++ b/src/test/java/zowe/client/sdk/utility/ValidateUtilsTest.java
@@ -9,10 +9,10 @@
  */
 package zowe.client.sdk.utility;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Class containing unit tests for ValidateUtils.

--- a/src/test/java/zowe/client/sdk/zosconsole/ConsoleConstantsTest.java
+++ b/src/test/java/zowe/client/sdk/zosconsole/ConsoleConstantsTest.java
@@ -9,7 +9,7 @@
  */
 package zowe.client.sdk.zosconsole;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import zowe.client.sdk.utility.Utils;
 
 /**

--- a/src/test/java/zowe/client/sdk/zosconsole/method/IssueConsoleTest.java
+++ b/src/test/java/zowe/client/sdk/zosconsole/method/IssueConsoleTest.java
@@ -13,10 +13,8 @@ import kong.unirest.core.Cookie;
 import kong.unirest.core.HttpResponse;
 import kong.unirest.core.JsonNode;
 import org.json.simple.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
-import org.mockito.MockedStatic;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.core.ZosConnectionFactory;
@@ -31,16 +29,12 @@ import zowe.client.sdk.zosconsole.response.ConsoleResponse;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
-import java.util.OptionalInt;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.withSettings;
 
 /**
  * Class containing unit tests for IssueCommand.
@@ -56,7 +50,7 @@ public class IssueConsoleTest {
             .createTokenConnection("1", "1", new Cookie("hello=hello"));
     private PutJsonZosmfRequest mockJsonGetRequest;
 
-    @Before
+    @BeforeEach
     public void init() {
         mockJsonGetRequest = Mockito.mock(PutJsonZosmfRequest.class);
     }
@@ -180,8 +174,7 @@ public class IssueConsoleTest {
         try {
             new IssueConsole(null);
         } catch (NullPointerException e) {
-            assertEquals("Should throw IllegalArgumentException when connection is null",
-                    "connection is null", e.getMessage());
+            assertEquals("connection is null", e.getMessage());
         }
     }
 
@@ -196,32 +189,32 @@ public class IssueConsoleTest {
     @Test
     public void tstIssueConsoleSecondaryConstructorWithNullConnection() {
         ZosmfRequest request = Mockito.mock(PutJsonZosmfRequest.class);
-        NullPointerException exception = Assertions.assertThrows(
+        NullPointerException exception = assertThrows(
                 NullPointerException.class,
                 () -> new IssueConsole(null, request)
         );
-        Assertions.assertEquals("connection is null", exception.getMessage());
+        assertEquals("connection is null", exception.getMessage());
     }
 
     @Test
     public void tstIssueConsoleSecondaryConstructorWithNullRequest() {
         ZosConnection connection = Mockito.mock(ZosConnection.class);
-        NullPointerException exception = Assertions.assertThrows(
+        NullPointerException exception = assertThrows(
                 NullPointerException.class,
                 () -> new IssueConsole(connection, null)
         );
-        Assertions.assertEquals("request is null", exception.getMessage());
+        assertEquals("request is null", exception.getMessage());
     }
 
     @Test
     public void tstIssueConsoleSecondaryConstructorWithInvalidRequestType() {
         ZosConnection connection = Mockito.mock(ZosConnection.class);
         ZosmfRequest request = Mockito.mock(ZosmfRequest.class); // Not a PutJsonZosmfRequest
-        IllegalStateException exception = Assertions.assertThrows(
+        IllegalStateException exception = assertThrows(
                 IllegalStateException.class,
                 () -> new IssueConsole(connection, request)
         );
-        Assertions.assertEquals("PUT_JSON request type required", exception.getMessage());
+        assertEquals("PUT_JSON request type required", exception.getMessage());
     }
 
     @Test
@@ -234,11 +227,11 @@ public class IssueConsoleTest {
     @Test
     public void tstDsnCopyPrimaryConstructorWithNullConnection() {
         // When/Then
-        NullPointerException exception = Assertions.assertThrows(
+        NullPointerException exception = assertThrows(
                 NullPointerException.class,
                 () -> new IssueConsole(null)
         );
-        Assertions.assertEquals("connection is null", exception.getMessage());
+        assertEquals("connection is null", exception.getMessage());
     }
 
 }

--- a/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnCopyTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnCopyTest.java
@@ -11,8 +11,8 @@ package zowe.client.sdk.zosfiles.dsn.methods;
 
 import kong.unirest.core.Cookie;
 import org.json.simple.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.core.ZosConnectionFactory;
@@ -40,7 +40,7 @@ public class DsnCopyTest {
     private PutJsonZosmfRequest mockJsonPutRequest;
     private PutJsonZosmfRequest mockJsonPutRequestToken;
 
-    @Before
+    @BeforeEach
     public void init() throws ZosmfRequestException {
         mockJsonPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
         Mockito.when(mockJsonPutRequest.executeRequest()).thenReturn(

--- a/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnCreateTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnCreateTest.java
@@ -11,8 +11,8 @@ package zowe.client.sdk.zosfiles.dsn.methods;
 
 import kong.unirest.core.Cookie;
 import org.json.simple.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.core.ZosConnectionFactory;
@@ -43,7 +43,7 @@ public class DsnCreateTest {
     private PostJsonZosmfRequest mockPostRequest;
     private PostJsonZosmfRequest mockPostRequestToken;
 
-    @Before
+    @BeforeEach
     public void init() throws ZosmfRequestException {
         mockPostRequest = Mockito.mock(PostJsonZosmfRequest.class);
         Mockito.when(mockPostRequest.executeRequest()).thenReturn(

--- a/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnDeleteTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnDeleteTest.java
@@ -11,8 +11,8 @@ package zowe.client.sdk.zosfiles.dsn.methods;
 
 import kong.unirest.core.Cookie;
 import org.json.simple.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.core.ZosConnectionFactory;
@@ -42,7 +42,7 @@ public class DsnDeleteTest {
     private DeleteJsonZosmfRequest mockDeleteRequest;
     private DeleteJsonZosmfRequest mockDeleteRequestToken;
 
-    @Before
+    @BeforeEach
     public void init() throws ZosmfRequestException {
         mockDeleteRequest = Mockito.mock(DeleteJsonZosmfRequest.class);
         Mockito.when(mockDeleteRequest.executeRequest()).thenReturn(

--- a/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnGetTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnGetTest.java
@@ -10,8 +10,8 @@
 package zowe.client.sdk.zosfiles.dsn.methods;
 
 import kong.unirest.core.Cookie;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.core.ZosConnectionFactory;
@@ -45,7 +45,7 @@ public class DsnGetTest {
     private GetStreamZosmfRequest mockGetRequest;
     private GetStreamZosmfRequest mockGetRequestToken;
 
-    @Before
+    @BeforeEach
     public void init() throws ZosmfRequestException {
         mockGetRequest = Mockito.mock(GetStreamZosmfRequest.class);
         Mockito.when(mockGetRequest.executeRequest()).thenReturn(

--- a/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnListTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnListTest.java
@@ -11,8 +11,8 @@ package zowe.client.sdk.zosfiles.dsn.methods;
 
 import kong.unirest.core.Cookie;
 import org.json.simple.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.core.ZosConnectionFactory;
@@ -43,7 +43,7 @@ public class DsnListTest {
     private GetJsonZosmfRequest mockGetRequest;
     private GetJsonZosmfRequest mockGetRequestToken;
 
-    @Before
+    @BeforeEach
     public void init() throws ZosmfRequestException {
         mockGetRequest = Mockito.mock(GetJsonZosmfRequest.class);
         Mockito.when(mockGetRequest.executeRequest()).thenReturn(

--- a/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnRenameTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnRenameTest.java
@@ -11,8 +11,8 @@ package zowe.client.sdk.zosfiles.dsn.methods;
 
 import kong.unirest.core.Cookie;
 import org.json.simple.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.core.ZosConnectionFactory;
@@ -42,7 +42,7 @@ public class DsnRenameTest {
     private PutJsonZosmfRequest mockJsonPutRequest;
     private PutJsonZosmfRequest mockJsonPutRequestToken;
 
-    @Before
+    @BeforeEach
     public void init() throws ZosmfRequestException {
         mockJsonPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
         Mockito.when(mockJsonPutRequest.executeRequest()).thenReturn(

--- a/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnWriteTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnWriteTest.java
@@ -11,8 +11,8 @@ package zowe.client.sdk.zosfiles.dsn.methods;
 
 import kong.unirest.core.Cookie;
 import org.json.simple.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.core.ZosConnectionFactory;
@@ -42,7 +42,7 @@ public class DsnWriteTest {
     private PutTextZosmfRequest mockTextPutRequest;
     private PutTextZosmfRequest mockTextPutRequestToken;
 
-    @Before
+    @BeforeEach
     public void init() throws ZosmfRequestException {
         mockTextPutRequest = Mockito.mock(PutTextZosmfRequest.class);
         Mockito.when(mockTextPutRequest.executeRequest()).thenReturn(

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/UssCreateZfsInputDataTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/UssCreateZfsInputDataTest.java
@@ -9,11 +9,11 @@
  */
 package zowe.client.sdk.zosfiles.uss;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import zowe.client.sdk.zosfiles.uss.input.UssCreateZfsInputData;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Class containing unit tests for UssCreateZfsInputData.

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeModeTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeModeTest.java
@@ -11,9 +11,8 @@ package zowe.client.sdk.zosfiles.uss.methods;
 
 import kong.unirest.core.Cookie;
 import org.json.simple.JSONObject;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.core.ZosConnectionFactory;
@@ -44,7 +43,7 @@ public class UssChangeModeTest {
     private PutJsonZosmfRequest mockJsonPutRequestToken;
     private UssChangeMode ussChangeMode;
 
-    @Before
+    @BeforeEach
     public void init() throws ZosmfRequestException {
         mockJsonPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
         Mockito.when(mockJsonPutRequest.executeRequest()).thenReturn(
@@ -181,8 +180,7 @@ public class UssChangeModeTest {
         try {
             new UssChangeMode(null);
         } catch (NullPointerException e) {
-            Assert.assertEquals("Should throw IllegalArgumentException when connection is null",
-                    "connection is null", e.getMessage());
+            assertEquals("connection is null", e.getMessage());
         }
     }
 

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeOwnerTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeOwnerTest.java
@@ -11,9 +11,8 @@ package zowe.client.sdk.zosfiles.uss.methods;
 
 import kong.unirest.core.Cookie;
 import org.json.simple.JSONObject;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.core.ZosConnectionFactory;
@@ -46,7 +45,7 @@ public class UssChangeOwnerTest {
     private PutJsonZosmfRequest mockJsonPutRequestToken;
     private UssChangeOwner ussChangeOwner;
 
-    @Before
+    @BeforeEach
     public void init() throws ZosmfRequestException {
         mockJsonPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
         Mockito.when(mockJsonPutRequest.executeRequest()).thenReturn(
@@ -215,8 +214,7 @@ public class UssChangeOwnerTest {
         try {
             new UssChangeOwner(null);
         } catch (NullPointerException e) {
-            Assert.assertEquals("Should throw IllegalArgumentException when connection is null",
-                    "connection is null", e.getMessage());
+            assertEquals("connection is null", e.getMessage());
         }
     }
 

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeTagTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeTagTest.java
@@ -11,9 +11,8 @@ package zowe.client.sdk.zosfiles.uss.methods;
 
 import kong.unirest.core.Cookie;
 import kong.unirest.core.json.JSONObject;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.core.ZosConnectionFactory;
@@ -48,7 +47,7 @@ public class UssChangeTagTest {
     private PutJsonZosmfRequest mockJsonPutRequestToken;
     private UssChangeTag ussChangeTag;
 
-    @Before
+    @BeforeEach
     public void init() throws ZosmfRequestException {
         mockJsonPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
         Mockito.when(mockJsonPutRequest.executeRequest()).thenReturn(
@@ -382,8 +381,7 @@ public class UssChangeTagTest {
         try {
             new UssChangeTag(null);
         } catch (NullPointerException e) {
-            Assert.assertEquals("Should throw IllegalArgumentException when connection is null",
-                    "connection is null", e.getMessage());
+            assertEquals("connection is null", e.getMessage());
         }
     }
 

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssCopyTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssCopyTest.java
@@ -11,8 +11,8 @@ package zowe.client.sdk.zosfiles.uss.methods;
 
 import kong.unirest.core.Cookie;
 import org.json.simple.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.core.ZosConnectionFactory;
@@ -22,9 +22,7 @@ import zowe.client.sdk.rest.ZosmfRequest;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosfiles.uss.input.UssCopyInputData;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -47,7 +45,7 @@ public class UssCopyTest {
     private PutJsonZosmfRequest mockJsonPutRequestToken;
     private UssCopy ussCopy;
 
-    @Before
+    @BeforeEach
     public void init() throws ZosmfRequestException {
         mockJsonPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
         Mockito.when(mockJsonPutRequest.executeRequest()).thenReturn(
@@ -272,8 +270,7 @@ public class UssCopyTest {
         try {
             new UssCopy(null);
         } catch (NullPointerException e) {
-            assertEquals("Should throw IllegalArgumentException when connection is null",
-                    "connection is null", e.getMessage());
+            assertEquals("connection is null", e.getMessage());
         }
     }
 

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssCreateTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssCreateTest.java
@@ -11,8 +11,8 @@ package zowe.client.sdk.zosfiles.uss.methods;
 
 import kong.unirest.core.Cookie;
 import org.json.simple.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.core.ZosConnectionFactory;
@@ -24,9 +24,7 @@ import zowe.client.sdk.zosfiles.uss.input.UssCreateInputData;
 import zowe.client.sdk.zosfiles.uss.input.UssCreateZfsInputData;
 import zowe.client.sdk.zosfiles.uss.types.CreateType;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -49,7 +47,7 @@ public class UssCreateTest {
     private PostJsonZosmfRequest mockJsonPostRequestToken;
     private UssCreate ussCreate;
 
-    @Before
+    @BeforeEach
     public void init() throws ZosmfRequestException {
         mockJsonPostRequest = Mockito.mock(PostJsonZosmfRequest.class);
         Mockito.when(mockJsonPostRequest.executeRequest()).thenReturn(
@@ -285,8 +283,7 @@ public class UssCreateTest {
         try {
             new UssCreate(null);
         } catch (NullPointerException e) {
-            assertEquals("Should throw IllegalArgumentException when connection is null",
-                    "connection is null", e.getMessage());
+            assertEquals("connection is null", e.getMessage());
         }
     }
 

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssDeleteTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssDeleteTest.java
@@ -11,8 +11,8 @@ package zowe.client.sdk.zosfiles.uss.methods;
 
 import kong.unirest.core.Cookie;
 import org.json.simple.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.core.ZosConnectionFactory;
@@ -21,9 +21,7 @@ import zowe.client.sdk.rest.Response;
 import zowe.client.sdk.rest.ZosmfRequest;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -46,7 +44,7 @@ public class UssDeleteTest {
     private DeleteJsonZosmfRequest mockJsonDeleteRequestToken;
     private UssDelete ussDelete;
 
-    @Before
+    @BeforeEach
     public void init() throws ZosmfRequestException {
         mockJsonDeleteRequest = Mockito.mock(DeleteJsonZosmfRequest.class);
         Mockito.when(mockJsonDeleteRequest.executeRequest()).thenReturn(
@@ -215,8 +213,7 @@ public class UssDeleteTest {
         try {
             new UssDelete(null);
         } catch (NullPointerException e) {
-            assertEquals("Should throw IllegalArgumentException when connection is null",
-                    "connection is null", e.getMessage());
+            assertEquals("connection is null", e.getMessage());
         }
     }
 

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssExtAttrTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssExtAttrTest.java
@@ -11,8 +11,8 @@ package zowe.client.sdk.zosfiles.uss.methods;
 
 import kong.unirest.core.Cookie;
 import org.json.simple.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.core.ZosConnectionFactory;
@@ -21,9 +21,7 @@ import zowe.client.sdk.rest.Response;
 import zowe.client.sdk.rest.ZosmfRequest;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -45,7 +43,7 @@ public class UssExtAttrTest {
     private PutJsonZosmfRequest mockJsonPutRequestToken;
     public UssExtAttr ussExtAttr;
 
-    @Before
+    @BeforeEach
     public void init() throws ZosmfRequestException {
         mockJsonPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
         Mockito.when(mockJsonPutRequest.executeRequest()).thenReturn(
@@ -214,8 +212,7 @@ public class UssExtAttrTest {
         try {
             new UssExtAttr(null);
         } catch (NullPointerException e) {
-            assertEquals("Should throw IllegalArgumentException when connection is null",
-                    "connection is null", e.getMessage());
+            assertEquals("connection is null", e.getMessage());
         }
     }
 

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssGetTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssGetTest.java
@@ -10,8 +10,8 @@
 package zowe.client.sdk.zosfiles.uss.methods;
 
 import kong.unirest.core.Cookie;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.core.ZosConnectionFactory;
@@ -22,9 +22,7 @@ import zowe.client.sdk.rest.ZosmfRequest;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosfiles.uss.input.UssGetInputData;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -47,7 +45,7 @@ public class UssGetTest {
     private GetTextZosmfRequest mockTextGetRequestToken;
     private UssGet ussGet;
 
-    @Before
+    @BeforeEach
     public void init() throws ZosmfRequestException {
         mockTextGetRequest = Mockito.mock(GetTextZosmfRequest.class);
         Mockito.when(mockTextGetRequest.executeRequest()).thenReturn(
@@ -243,8 +241,7 @@ public class UssGetTest {
         try {
             new UssGet(null);
         } catch (NullPointerException e) {
-            assertEquals("Should throw IllegalArgumentException when connection is null",
-                    "connection is null", e.getMessage());
+            assertEquals("connection is null", e.getMessage());
         }
     }
 

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssListTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssListTest.java
@@ -11,8 +11,8 @@ package zowe.client.sdk.zosfiles.uss.methods;
 
 import kong.unirest.core.Cookie;
 import org.json.simple.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.core.ZosConnectionFactory;
@@ -29,10 +29,7 @@ import zowe.client.sdk.zosfiles.uss.response.UnixZfs;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -123,7 +120,7 @@ public class UssListTest {
             "   \"JSONversion\": 1\n" +
             "}";
 
-    @Before
+    @BeforeEach
     public void init() throws ZosmfRequestException {
         mockJsonGetRequest = Mockito.mock(GetJsonZosmfRequest.class);
         mockJsonGetRequestToken = Mockito.mock(GetJsonZosmfRequest.class);
@@ -450,8 +447,7 @@ public class UssListTest {
         try {
             new UssList(null);
         } catch (NullPointerException e) {
-            assertEquals("Should throw IllegalArgumentException when connection is null",
-                    "connection is null", e.getMessage());
+            assertEquals("connection is null", e.getMessage());
         }
     }
 

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssMountTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssMountTest.java
@@ -11,8 +11,8 @@ package zowe.client.sdk.zosfiles.uss.methods;
 
 import kong.unirest.core.Cookie;
 import org.json.simple.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.core.ZosConnectionFactory;
@@ -23,9 +23,7 @@ import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosfiles.uss.input.UssMountInputData;
 import zowe.client.sdk.zosfiles.uss.types.MountActionType;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -48,7 +46,7 @@ public class UssMountTest {
     private PutJsonZosmfRequest mockJsonPutRequestToken;
     private UssMount ussMount;
 
-    @Before
+    @BeforeEach
     public void init() throws ZosmfRequestException {
         mockJsonPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
         Mockito.when(mockJsonPutRequest.executeRequest()).thenReturn(
@@ -298,8 +296,7 @@ public class UssMountTest {
         try {
             new UssMount(null);
         } catch (NullPointerException e) {
-            assertEquals("Should throw IllegalArgumentException when connection is null",
-                    "connection is null", e.getMessage());
+            assertEquals("connection is null", e.getMessage());
         }
     }
 

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssMoveTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssMoveTest.java
@@ -11,9 +11,8 @@ package zowe.client.sdk.zosfiles.uss.methods;
 
 import kong.unirest.core.Cookie;
 import org.json.simple.JSONObject;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.core.ZosConnectionFactory;
@@ -44,7 +43,7 @@ public class UssMoveTest {
     private PutJsonZosmfRequest mockJsonPutRequestToken;
     private UssMove ussMove;
 
-    @Before
+    @BeforeEach
     public void init() throws ZosmfRequestException {
         mockJsonPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
         Mockito.when(mockJsonPutRequest.executeRequest()).thenReturn(
@@ -212,8 +211,7 @@ public class UssMoveTest {
         try {
             new UssMove(null);
         } catch (NullPointerException e) {
-            Assert.assertEquals("Should throw IllegalArgumentException when connection is null",
-                    "connection is null", e.getMessage());
+            assertEquals("connection is null", e.getMessage());
         }
     }
 

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssWriteTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssWriteTest.java
@@ -11,8 +11,8 @@ package zowe.client.sdk.zosfiles.uss.methods;
 
 import kong.unirest.core.Cookie;
 import org.json.simple.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.core.ZosConnectionFactory;
@@ -23,10 +23,7 @@ import zowe.client.sdk.rest.ZosmfRequest;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosfiles.uss.input.UssWriteInputData;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -49,7 +46,7 @@ public class UssWriteTest {
     private PutTextZosmfRequest mockTextPutRequestToken;
     private UssWrite ussWrite;
 
-    @Before
+    @BeforeEach
     public void init() throws ZosmfRequestException {
         mockTextPutRequest = Mockito.mock(PutTextZosmfRequest.class);
         Mockito.when(mockTextPutRequest.executeRequest()).thenReturn(
@@ -255,8 +252,7 @@ public class UssWriteTest {
         try {
             new UssWrite(null);
         } catch (NullPointerException e) {
-            assertEquals("Should throw IllegalArgumentException when connection is null",
-                    "connection is null", e.getMessage());
+            assertEquals("connection is null", e.getMessage());
         }
     }
 

--- a/src/test/java/zowe/client/sdk/zosjobs/JobsConstantsTest.java
+++ b/src/test/java/zowe/client/sdk/zosjobs/JobsConstantsTest.java
@@ -9,7 +9,7 @@
  */
 package zowe.client.sdk.zosjobs;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import zowe.client.sdk.utility.Utils;
 
 /**

--- a/src/test/java/zowe/client/sdk/zosjobs/methods/JobCancelTest.java
+++ b/src/test/java/zowe/client/sdk/zosjobs/methods/JobCancelTest.java
@@ -11,8 +11,8 @@ package zowe.client.sdk.zosjobs.methods;
 
 import kong.unirest.core.Cookie;
 import org.json.simple.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.core.ZosConnectionFactory;
@@ -43,7 +43,7 @@ public class JobCancelTest {
     private PutJsonZosmfRequest mockPutJsonZosmfRequest;
     private PutJsonZosmfRequest mockPutJsonZosmfRequestToken;
 
-    @Before
+    @BeforeEach
     public void init() throws ZosmfRequestException {
         mockPutJsonZosmfRequest = Mockito.mock(PutJsonZosmfRequest.class);
         Mockito.when(mockPutJsonZosmfRequest.executeRequest()).thenReturn(

--- a/src/test/java/zowe/client/sdk/zosjobs/methods/JobDeleteTest.java
+++ b/src/test/java/zowe/client/sdk/zosjobs/methods/JobDeleteTest.java
@@ -11,8 +11,8 @@ package zowe.client.sdk.zosjobs.methods;
 
 import kong.unirest.core.Cookie;
 import org.json.simple.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.core.ZosConnectionFactory;
@@ -42,7 +42,7 @@ public class JobDeleteTest {
     private DeleteJsonZosmfRequest mockJsonDeleteRequest;
     private DeleteJsonZosmfRequest mockJsonDeleteRequestToken;
 
-    @Before
+    @BeforeEach
     public void init() throws ZosmfRequestException {
         mockJsonDeleteRequest = Mockito.mock(DeleteJsonZosmfRequest.class);
         Mockito.when(mockJsonDeleteRequest.executeRequest()).thenReturn(

--- a/src/test/java/zowe/client/sdk/zosjobs/methods/JobGetJsonTest.java
+++ b/src/test/java/zowe/client/sdk/zosjobs/methods/JobGetJsonTest.java
@@ -11,12 +11,9 @@ package zowe.client.sdk.zosjobs.methods;
 
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.powermock.reflect.Whitebox;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.core.ZosConnectionFactory;
@@ -29,7 +26,8 @@ import zowe.client.sdk.zosjobs.response.Job;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 
 /**
  * Class containing unit tests for JobGet.
@@ -37,7 +35,6 @@ import static org.junit.Assert.*;
  * @author Frank Giordano
  * @version 5.0
  */
-@RunWith(MockitoJUnitRunner.class)
 public class JobGetJsonTest {
 
     private final ZosConnection connection = ZosConnectionFactory
@@ -46,7 +43,7 @@ public class JobGetJsonTest {
     private JobGet getJobs;
     private JSONObject jobJson;
 
-    @Before
+    @BeforeEach
     public void init() {
         mockJsonGetRequest = Mockito.mock(GetJsonZosmfRequest.class);
         getJobs = new JobGet(connection);
@@ -254,8 +251,7 @@ public class JobGetJsonTest {
         try {
             new JobGet(null);
         } catch (NullPointerException e) {
-            assertEquals("Should throw IllegalArgumentException when connection is null",
-                    "connection is null", e.getMessage());
+            assertEquals("connection is null", e.getMessage());
         }
     }
 
@@ -270,7 +266,7 @@ public class JobGetJsonTest {
     @Test
     public void tstJobGetJsonSecondaryConstructorWithNullConnection() {
         ZosmfRequest request = Mockito.mock(GetTextZosmfRequest.class);
-        NullPointerException exception = Assertions.assertThrows(
+        NullPointerException exception = assertThrows(
                 NullPointerException.class,
                 () -> new JobGet(null, request)
         );
@@ -280,7 +276,7 @@ public class JobGetJsonTest {
     @Test
     public void tstJobGetJsonSecondaryConstructorWithNullRequest() {
         ZosConnection connection = Mockito.mock(ZosConnection.class);
-        NullPointerException exception = Assertions.assertThrows(
+        NullPointerException exception = assertThrows(
                 NullPointerException.class,
                 () -> new JobGet(connection, null)
         );
@@ -291,7 +287,7 @@ public class JobGetJsonTest {
     public void tstJobGetJsonSecondaryConstructorWithInvalidRequestType() {
         ZosConnection connection = Mockito.mock(ZosConnection.class);
         ZosmfRequest request = Mockito.mock(ZosmfRequest.class);
-        IllegalStateException exception = Assertions.assertThrows(
+        IllegalStateException exception = assertThrows(
                 IllegalStateException.class,
                 () -> new JobGet(connection, request)
         );
@@ -307,7 +303,7 @@ public class JobGetJsonTest {
 
     @Test
     public void tstJobGetJsonPrimaryConstructorWithNullConnection() {
-        NullPointerException exception = Assertions.assertThrows(
+        NullPointerException exception = assertThrows(
                 NullPointerException.class,
                 () -> new JobGet(null)
         );

--- a/src/test/java/zowe/client/sdk/zosjobs/methods/JobGetTextTest.java
+++ b/src/test/java/zowe/client/sdk/zosjobs/methods/JobGetTextTest.java
@@ -10,8 +10,8 @@
 package zowe.client.sdk.zosjobs.methods;
 
 import kong.unirest.core.Cookie;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.powermock.reflect.Whitebox;
 import zowe.client.sdk.core.ZosConnection;
@@ -23,8 +23,8 @@ import zowe.client.sdk.rest.ZosmfRequestFactory;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.rest.type.ZosmfRequestType;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -44,7 +44,7 @@ public class JobGetTextTest {
             .createTokenConnection("1", "1", new Cookie("hello=hello"));
     private GetTextZosmfRequest mockTextGetRequest;
 
-    @Before
+    @BeforeEach
     public void init() {
         mockTextGetRequest = Mockito.mock(GetTextZosmfRequest.class);
     }

--- a/src/test/java/zowe/client/sdk/zosjobs/methods/JobSubmitTest.java
+++ b/src/test/java/zowe/client/sdk/zosjobs/methods/JobSubmitTest.java
@@ -11,8 +11,8 @@ package zowe.client.sdk.zosjobs.methods;
 
 import kong.unirest.core.Cookie;
 import org.json.simple.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.core.ZosConnectionFactory;
@@ -25,9 +25,7 @@ import zowe.client.sdk.zosjobs.response.Job;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -48,7 +46,7 @@ public class JobSubmitTest {
     private PutJsonZosmfRequest mockPutJsonZosmfRequest;
     private PutJsonZosmfRequest mockPutJsonZosmfRequestToken;
 
-    @Before
+    @BeforeEach
     public void init() throws ZosmfRequestException {
         final Map<String, String> jsonMap = new HashMap<>();
         jsonMap.put("jobid", "jobid");

--- a/src/test/java/zowe/client/sdk/zosmfinfo/ZosmfConstantsTest.java
+++ b/src/test/java/zowe/client/sdk/zosmfinfo/ZosmfConstantsTest.java
@@ -9,7 +9,7 @@
  */
 package zowe.client.sdk.zosmfinfo;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import zowe.client.sdk.utility.Utils;
 
 /**


### PR DESCRIPTION
Project needed to be upgraded to Junit 5 version. This keeps the test package up to date.

New features like mocking static is being implemented within the project and requires Junit 5.  