### PR TITLE
Refactor model and response package

### DIFF
--- a/src/main/java/zowe/client/sdk/parse/DatasetJsonParse.java
+++ b/src/main/java/zowe/client/sdk/parse/DatasetJsonParse.java
@@ -11,7 +11,7 @@ package zowe.client.sdk.parse;
 
 import org.json.simple.JSONObject;
 import zowe.client.sdk.utility.ValidateUtils;
-import zowe.client.sdk.zosfiles.dsn.response.Dataset;
+import zowe.client.sdk.zosfiles.dsn.model.Dataset;
 
 /**
  * Extract Dataset from JSON response

--- a/src/main/java/zowe/client/sdk/parse/JobFileJsonParse.java
+++ b/src/main/java/zowe/client/sdk/parse/JobFileJsonParse.java
@@ -11,7 +11,7 @@ package zowe.client.sdk.parse;
 
 import org.json.simple.JSONObject;
 import zowe.client.sdk.utility.ValidateUtils;
-import zowe.client.sdk.zosjobs.response.JobFile;
+import zowe.client.sdk.zosjobs.model.JobFile;
 
 /**
  * Parse JSON response for a job file

--- a/src/main/java/zowe/client/sdk/parse/JobJsonParse.java
+++ b/src/main/java/zowe/client/sdk/parse/JobJsonParse.java
@@ -12,8 +12,8 @@ package zowe.client.sdk.parse;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import zowe.client.sdk.utility.ValidateUtils;
-import zowe.client.sdk.zosjobs.response.Job;
-import zowe.client.sdk.zosjobs.response.JobStepData;
+import zowe.client.sdk.zosjobs.model.Job;
+import zowe.client.sdk.zosjobs.model.JobStepData;
 
 /**
  * Extract Job from JSON response

--- a/src/main/java/zowe/client/sdk/parse/MemberJsonParse.java
+++ b/src/main/java/zowe/client/sdk/parse/MemberJsonParse.java
@@ -11,7 +11,7 @@ package zowe.client.sdk.parse;
 
 import org.json.simple.JSONObject;
 import zowe.client.sdk.utility.ValidateUtils;
-import zowe.client.sdk.zosfiles.dsn.response.Member;
+import zowe.client.sdk.zosfiles.dsn.model.Member;
 
 /**
  * Extract Member from JSON response

--- a/src/main/java/zowe/client/sdk/parse/SystemInfoJsonParse.java
+++ b/src/main/java/zowe/client/sdk/parse/SystemInfoJsonParse.java
@@ -12,8 +12,8 @@ package zowe.client.sdk.parse;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import zowe.client.sdk.utility.ValidateUtils;
+import zowe.client.sdk.zosmfinfo.model.ZosmfPlugin;
 import zowe.client.sdk.zosmfinfo.response.ZosmfInfoResponse;
-import zowe.client.sdk.zosmfinfo.response.ZosmfPluginInfo;
 
 /**
  * Parse JSON response from z/OSMF status request
@@ -77,7 +77,7 @@ public final class SystemInfoJsonParse implements JsonParse {
         }
         if (plugins != null) {
             int size = plugins.size();
-            ZosmfPluginInfo[] zosmfPluginsInfo = new ZosmfPluginInfo[size];
+            ZosmfPlugin[] zosmfPluginsInfo = new ZosmfPlugin[size];
             for (int i = 0; i < size; i++) {
                 zosmfPluginsInfo[i] = parseZosmfPluginInfo((JSONObject) plugins.get(i));
             }
@@ -93,8 +93,8 @@ public final class SystemInfoJsonParse implements JsonParse {
      * @return ZosmfPluginInfo object
      * @author Frank Giordano
      */
-    private static ZosmfPluginInfo parseZosmfPluginInfo(final JSONObject data) {
-        return new ZosmfPluginInfo.Builder()
+    private static ZosmfPlugin parseZosmfPluginInfo(final JSONObject data) {
+        return new ZosmfPlugin.Builder()
                 .pluginVersion(data.get("pluginVersion") != null ? (String) data.get("pluginVersion") : null)
                 .pluginDefaultName(data.get("pluginDefaultName") != null ? (String) data.get("pluginDefaultName") : null)
                 .pluginStatus(data.get("pluginStatus") != null ? (String) data.get("pluginStatus") : null)

--- a/src/main/java/zowe/client/sdk/parse/SystemsJsonParse.java
+++ b/src/main/java/zowe/client/sdk/parse/SystemsJsonParse.java
@@ -12,7 +12,7 @@ package zowe.client.sdk.parse;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import zowe.client.sdk.utility.ValidateUtils;
-import zowe.client.sdk.zosmfinfo.response.DefinedSystem;
+import zowe.client.sdk.zosmfinfo.model.DefinedSystem;
 import zowe.client.sdk.zosmfinfo.response.ZosmfSystemsResponse;
 
 /**

--- a/src/main/java/zowe/client/sdk/parse/UnixFileJsonParse.java
+++ b/src/main/java/zowe/client/sdk/parse/UnixFileJsonParse.java
@@ -11,7 +11,7 @@ package zowe.client.sdk.parse;
 
 import org.json.simple.JSONObject;
 import zowe.client.sdk.utility.ValidateUtils;
-import zowe.client.sdk.zosfiles.uss.response.UnixFile;
+import zowe.client.sdk.zosfiles.uss.model.UnixFile;
 
 /**
  * Extract UNIX file from JSON response

--- a/src/main/java/zowe/client/sdk/parse/UnixZfsJsonParse.java
+++ b/src/main/java/zowe/client/sdk/parse/UnixZfsJsonParse.java
@@ -11,7 +11,7 @@ package zowe.client.sdk.parse;
 
 import org.json.simple.JSONObject;
 import zowe.client.sdk.utility.ValidateUtils;
-import zowe.client.sdk.zosfiles.uss.response.UnixZfs;
+import zowe.client.sdk.zosfiles.uss.model.UnixZfs;
 
 /**
  * Extract UNIX zfs from JSON response

--- a/src/main/java/zowe/client/sdk/parse/ZosLogItemJsonParse.java
+++ b/src/main/java/zowe/client/sdk/parse/ZosLogItemJsonParse.java
@@ -11,7 +11,7 @@ package zowe.client.sdk.parse;
 
 import org.json.simple.JSONObject;
 import zowe.client.sdk.utility.ValidateUtils;
-import zowe.client.sdk.zoslogs.response.ZosLogItem;
+import zowe.client.sdk.zoslogs.model.ZosLogItem;
 
 /**
  * Extract ZosLogItem from JSON response

--- a/src/main/java/zowe/client/sdk/parse/ZosLogReplyJsonParse.java
+++ b/src/main/java/zowe/client/sdk/parse/ZosLogReplyJsonParse.java
@@ -11,8 +11,8 @@ package zowe.client.sdk.parse;
 
 import org.json.simple.JSONObject;
 import zowe.client.sdk.utility.ValidateUtils;
-import zowe.client.sdk.zoslogs.response.ZosLogItem;
-import zowe.client.sdk.zoslogs.response.ZosLogReply;
+import zowe.client.sdk.zoslogs.model.ZosLogItem;
+import zowe.client.sdk.zoslogs.response.ZosLogResponse;
 
 import java.util.List;
 
@@ -60,12 +60,12 @@ public final class ZosLogReplyJsonParse implements JsonParse {
      */
     @SuppressWarnings("unchecked")
     @Override
-    public synchronized ZosLogReply parseResponse(final Object... args) {
+    public synchronized ZosLogResponse parseResponse(final Object... args) {
         ValidateUtils.checkNullParameter(args[0] == null, ParseConstants.DATA_NULL_MSG);
         ValidateUtils.checkNullParameter(args[1] == null, ParseConstants.LIST_OF_ZOS_LOG_ITEM_NULL_MSG);
         final JSONObject data = (JSONObject) args[0];
         final List<ZosLogItem> zosLogItems = (List<ZosLogItem>) args[1];
-        return new ZosLogReply(
+        return new ZosLogResponse(
                 data.get("timezone") != null ? (Long) data.get("timezone") : 0,
                 data.get("nextTimestamp") != null ? (Long) data.get("nextTimestamp") : 0,
                 data.get("source") != null ? (String) data.get("source") : null,

--- a/src/main/java/zowe/client/sdk/teamconfig/README.md
+++ b/src/main/java/zowe/client/sdk/teamconfig/README.md
@@ -44,7 +44,7 @@ import zowe.client.sdk.teamconfig.exception.TeamConfigException;
 import zowe.client.sdk.teamconfig.model.ProfileDao;
 import zowe.client.sdk.zosfiles.dsn.input.DsnListInputData;
 import zowe.client.sdk.zosfiles.dsn.methods.DsnList;
-import zowe.client.sdk.zosfiles.dsn.response.Member;
+import zowe.client.sdk.zosfiles.dsn.model.Member;
 
 import java.util.List;
 

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/README.md
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/README.md
@@ -332,7 +332,7 @@ import zowe.client.sdk.examples.TstZosConnection;
 import zowe.client.sdk.examples.utility.Util;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosfiles.dsn.methods.DsnGet;
-import zowe.client.sdk.zosfiles.dsn.response.Dataset;
+import zowe.client.sdk.zosfiles.dsn.model.Dataset;
 
 /**
  * Class example to showcase retrieval of dataset information functionality via DsnGet class.
@@ -592,8 +592,8 @@ import zowe.client.sdk.examples.utility.Util;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosfiles.dsn.input.DsnListInputData;
 import zowe.client.sdk.zosfiles.dsn.methods.DsnList;
-import zowe.client.sdk.zosfiles.dsn.response.Dataset;
-import zowe.client.sdk.zosfiles.dsn.response.Member;
+import zowe.client.sdk.zosfiles.dsn.model.Dataset;
+import zowe.client.sdk.zosfiles.dsn.model.Member;
 import zowe.client.sdk.zosfiles.dsn.types.AttributeType;
 
 import java.util.List;

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnGet.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnGet.java
@@ -21,7 +21,7 @@ import zowe.client.sdk.utility.ValidateUtils;
 import zowe.client.sdk.zosfiles.ZosFilesConstants;
 import zowe.client.sdk.zosfiles.dsn.input.DsnDownloadInputData;
 import zowe.client.sdk.zosfiles.dsn.input.DsnListInputData;
-import zowe.client.sdk.zosfiles.dsn.response.Dataset;
+import zowe.client.sdk.zosfiles.dsn.model.Dataset;
 import zowe.client.sdk.zosfiles.dsn.types.AttributeType;
 
 import java.io.ByteArrayInputStream;

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnList.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnList.java
@@ -24,8 +24,8 @@ import zowe.client.sdk.utility.JsonParserUtil;
 import zowe.client.sdk.utility.ValidateUtils;
 import zowe.client.sdk.zosfiles.ZosFilesConstants;
 import zowe.client.sdk.zosfiles.dsn.input.DsnListInputData;
-import zowe.client.sdk.zosfiles.dsn.response.Dataset;
-import zowe.client.sdk.zosfiles.dsn.response.Member;
+import zowe.client.sdk.zosfiles.dsn.model.Dataset;
+import zowe.client.sdk.zosfiles.dsn.model.Member;
 import zowe.client.sdk.zosfiles.dsn.types.AttributeType;
 
 import java.util.*;

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/model/Dataset.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/model/Dataset.java
@@ -7,7 +7,7 @@
  *
  * Copyright Contributors to the Zowe Project.
  */
-package zowe.client.sdk.zosfiles.dsn.response;
+package zowe.client.sdk.zosfiles.dsn.model;
 
 import java.util.Optional;
 

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/model/Member.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/model/Member.java
@@ -7,7 +7,7 @@
  *
  * Copyright Contributors to the Zowe Project.
  */
-package zowe.client.sdk.zosfiles.dsn.response;
+package zowe.client.sdk.zosfiles.dsn.model;
 
 import java.util.Optional;
 import java.util.OptionalLong;

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/model/package-info.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/model/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Model objects for z/OS dataset and member files processing
+ */
+package zowe.client.sdk.zosfiles.dsn.model;

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/response/package-info.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/response/package-info.java
@@ -1,4 +1,0 @@
-/**
- * Request response objects for z/OS dataset and member files processing
- */
-package zowe.client.sdk.zosfiles.dsn.response;

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/README.md
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/README.md
@@ -315,8 +315,8 @@ import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosfiles.uss.input.UssListInputData;
 import zowe.client.sdk.zosfiles.uss.input.UssListZfsInputData;
 import zowe.client.sdk.zosfiles.uss.methods.UssList;
-import zowe.client.sdk.zosfiles.uss.response.UnixFile;
-import zowe.client.sdk.zosfiles.uss.response.UnixZfs;
+import zowe.client.sdk.zosfiles.uss.model.UnixFile;
+import zowe.client.sdk.zosfiles.uss.model.UnixZfs;
 
 import java.util.List;
 

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssList.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssList.java
@@ -28,8 +28,8 @@ import zowe.client.sdk.utility.ValidateUtils;
 import zowe.client.sdk.zosfiles.ZosFilesConstants;
 import zowe.client.sdk.zosfiles.uss.input.UssListInputData;
 import zowe.client.sdk.zosfiles.uss.input.UssListZfsInputData;
-import zowe.client.sdk.zosfiles.uss.response.UnixFile;
-import zowe.client.sdk.zosfiles.uss.response.UnixZfs;
+import zowe.client.sdk.zosfiles.uss.model.UnixFile;
+import zowe.client.sdk.zosfiles.uss.model.UnixZfs;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/model/UnixFile.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/model/UnixFile.java
@@ -7,7 +7,7 @@
  *
  * Copyright Contributors to the Zowe Project.
  */
-package zowe.client.sdk.zosfiles.uss.response;
+package zowe.client.sdk.zosfiles.uss.model;
 
 import java.util.Optional;
 import java.util.OptionalLong;

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/model/UnixZfs.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/model/UnixZfs.java
@@ -7,7 +7,7 @@
  *
  * Copyright Contributors to the Zowe Project.
  */
-package zowe.client.sdk.zosfiles.uss.response;
+package zowe.client.sdk.zosfiles.uss.model;
 
 import java.util.Optional;
 import java.util.OptionalLong;

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/model/package-info.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/model/package-info.java
@@ -1,4 +1,4 @@
 /**
- * Request response objects for z/OS Unix System Services (USS) files processing
+ * Model objects for z/OS Unix System Services (USS) files processing
  */
-package zowe.client.sdk.zosfiles.uss.response;
+package zowe.client.sdk.zosfiles.uss.model;

--- a/src/main/java/zowe/client/sdk/zosjobs/README.md
+++ b/src/main/java/zowe/client/sdk/zosjobs/README.md
@@ -19,7 +19,7 @@ import zowe.client.sdk.rest.Response;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosjobs.input.JobModifyInputData;
 import zowe.client.sdk.zosjobs.methods.JobCancel;
-import zowe.client.sdk.zosjobs.response.Job;
+import zowe.client.sdk.zosjobs.model.Job;
 
 /**
  * Class example to showcase JobCancel class functionality.
@@ -143,7 +143,7 @@ import zowe.client.sdk.rest.Response;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosjobs.input.JobModifyInputData;
 import zowe.client.sdk.zosjobs.methods.JobDelete;
-import zowe.client.sdk.zosjobs.response.Job;
+import zowe.client.sdk.zosjobs.model.Job;
 
 /**
  * Class example to showcase JobDelete class functionality.
@@ -266,9 +266,9 @@ import zowe.client.sdk.examples.utility.Util;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosjobs.input.CommonJobInputData;
 import zowe.client.sdk.zosjobs.input.JobGetInputData;
-import zowe.client.sdk.zosjobs.response.JobFile;
+import zowe.client.sdk.zosjobs.model.Job;
+import zowe.client.sdk.zosjobs.model.JobFile;
 import zowe.client.sdk.zosjobs.methods.JobGet;
-import zowe.client.sdk.zosjobs.response.Job;
 
 import java.util.Arrays;
 import java.util.List;
@@ -643,7 +643,7 @@ import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosjobs.input.JobMonitorInputData;
 import zowe.client.sdk.zosjobs.methods.JobMonitor;
 import zowe.client.sdk.zosjobs.methods.JobSubmit;
-import zowe.client.sdk.zosjobs.response.Job;
+import zowe.client.sdk.zosjobs.model.Job;
 import zowe.client.sdk.zosjobs.types.JobStatus;
 
 /**
@@ -818,7 +818,7 @@ import zowe.client.sdk.examples.utility.Util;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosjobs.methods.JobMonitor;
 import zowe.client.sdk.zosjobs.methods.JobSubmit;
-import zowe.client.sdk.zosjobs.response.Job;
+import zowe.client.sdk.zosjobs.model.Job;
 import zowe.client.sdk.zosjobs.types.JobStatus;
 
 /**

--- a/src/main/java/zowe/client/sdk/zosjobs/methods/JobCancel.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/methods/JobCancel.java
@@ -19,7 +19,7 @@ import zowe.client.sdk.rest.type.ZosmfRequestType;
 import zowe.client.sdk.utility.ValidateUtils;
 import zowe.client.sdk.zosjobs.JobsConstants;
 import zowe.client.sdk.zosjobs.input.JobModifyInputData;
-import zowe.client.sdk.zosjobs.response.Job;
+import zowe.client.sdk.zosjobs.model.Job;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/zowe/client/sdk/zosjobs/methods/JobDelete.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/methods/JobDelete.java
@@ -18,7 +18,7 @@ import zowe.client.sdk.rest.type.ZosmfRequestType;
 import zowe.client.sdk.utility.ValidateUtils;
 import zowe.client.sdk.zosjobs.JobsConstants;
 import zowe.client.sdk.zosjobs.input.JobModifyInputData;
-import zowe.client.sdk.zosjobs.response.Job;
+import zowe.client.sdk.zosjobs.model.Job;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/zowe/client/sdk/zosjobs/methods/JobGet.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/methods/JobGet.java
@@ -23,8 +23,8 @@ import zowe.client.sdk.utility.ValidateUtils;
 import zowe.client.sdk.zosjobs.JobsConstants;
 import zowe.client.sdk.zosjobs.input.CommonJobInputData;
 import zowe.client.sdk.zosjobs.input.JobGetInputData;
-import zowe.client.sdk.zosjobs.response.Job;
-import zowe.client.sdk.zosjobs.response.JobFile;
+import zowe.client.sdk.zosjobs.model.Job;
+import zowe.client.sdk.zosjobs.model.JobFile;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/zowe/client/sdk/zosjobs/methods/JobMonitor.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/methods/JobMonitor.java
@@ -20,9 +20,9 @@ import zowe.client.sdk.zosjobs.JobsConstants;
 import zowe.client.sdk.zosjobs.input.CommonJobInputData;
 import zowe.client.sdk.zosjobs.input.JobGetInputData;
 import zowe.client.sdk.zosjobs.input.JobMonitorInputData;
-import zowe.client.sdk.zosjobs.response.CheckJobStatus;
-import zowe.client.sdk.zosjobs.response.Job;
-import zowe.client.sdk.zosjobs.response.JobFile;
+import zowe.client.sdk.zosjobs.model.Job;
+import zowe.client.sdk.zosjobs.model.JobFile;
+import zowe.client.sdk.zosjobs.response.CheckStatusResponse;
 import zowe.client.sdk.zosjobs.types.JobStatus;
 
 import java.util.List;
@@ -166,7 +166,7 @@ public class JobMonitor {
      * @throws ZosmfRequestException request error state
      * @author Frank Giordano
      */
-    private CheckJobStatus checkStatus(final JobMonitorInputData monitorInputData) throws ZosmfRequestException {
+    private CheckStatusResponse checkStatus(final JobMonitorInputData monitorInputData) throws ZosmfRequestException {
         return checkStatus(monitorInputData, false);
     }
 
@@ -178,7 +178,7 @@ public class JobMonitor {
      * @throws ZosmfRequestException request error state
      * @author Frank Giordano
      */
-    private CheckJobStatus checkStatus(final JobMonitorInputData monitorInputData, final boolean isStepData)
+    private CheckStatusResponse checkStatus(final JobMonitorInputData monitorInputData, final boolean isStepData)
             throws ZosmfRequestException {
         final JobGet getJobs = new JobGet(connection);
         final String statusNameCheck = monitorInputData.getJobStatus().orElse(DEFAULT_STATUS).toString();
@@ -187,7 +187,7 @@ public class JobMonitor {
                 monitorInputData.getJobId().orElse(""), monitorInputData.getJobName().orElse(""), isStepData));
 
         if (statusNameCheck.equals(job.getStatus().orElse(DEFAULT_STATUS.toString()))) {
-            return new CheckJobStatus(true, job);
+            return new CheckStatusResponse(true, job);
         }
 
         final String invalidStatusMsg = "Invalid status when checking for status ordering.";
@@ -203,10 +203,10 @@ public class JobMonitor {
         }
 
         if (orderIndexOfCurrRunningJobStatus > orderIndexOfDesiredJobStatus) {
-            return new CheckJobStatus(true, job);
+            return new CheckStatusResponse(true, job);
         }
 
-        return new CheckJobStatus(false, job);
+        return new CheckStatusResponse(false, job);
     }
 
     /**
@@ -296,7 +296,7 @@ public class JobMonitor {
         String statusName = monitorInputData.getJobStatus().orElse(DEFAULT_STATUS).toString();
         LOG.info("Waiting for status \"{}\"", statusName);
 
-        CheckJobStatus checkJobStatus;
+        CheckStatusResponse checkJobStatus;
         do {
             numOfAttempts++;
             checkJobStatus = checkStatus(monitorInputData);

--- a/src/main/java/zowe/client/sdk/zosjobs/methods/JobSubmit.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/methods/JobSubmit.java
@@ -24,7 +24,7 @@ import zowe.client.sdk.utility.ValidateUtils;
 import zowe.client.sdk.zosjobs.JobsConstants;
 import zowe.client.sdk.zosjobs.input.JobSubmitInputData;
 import zowe.client.sdk.zosjobs.input.JobSubmitJclInputData;
-import zowe.client.sdk.zosjobs.response.Job;
+import zowe.client.sdk.zosjobs.model.Job;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/zowe/client/sdk/zosjobs/model/Job.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/model/Job.java
@@ -7,7 +7,7 @@
  *
  * Copyright Contributors to the Zowe Project.
  */
-package zowe.client.sdk.zosjobs.response;
+package zowe.client.sdk.zosjobs.model;
 
 import java.util.Optional;
 import java.util.OptionalLong;

--- a/src/main/java/zowe/client/sdk/zosjobs/model/JobFile.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/model/JobFile.java
@@ -7,7 +7,7 @@
  *
  * Copyright Contributors to the Zowe Project.
  */
-package zowe.client.sdk.zosjobs.response;
+package zowe.client.sdk.zosjobs.model;
 
 import java.util.Optional;
 import java.util.OptionalLong;

--- a/src/main/java/zowe/client/sdk/zosjobs/model/JobStepData.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/model/JobStepData.java
@@ -7,7 +7,7 @@
  *
  * Copyright Contributors to the Zowe Project.
  */
-package zowe.client.sdk.zosjobs.response;
+package zowe.client.sdk.zosjobs.model;
 
 import java.util.Optional;
 import java.util.OptionalLong;

--- a/src/main/java/zowe/client/sdk/zosjobs/model/package-info.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/model/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Model objects for z/OS jobs processing
+ */
+package zowe.client.sdk.zosjobs.model;

--- a/src/main/java/zowe/client/sdk/zosjobs/response/CheckStatusResponse.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/response/CheckStatusResponse.java
@@ -10,13 +10,15 @@
  */
 package zowe.client.sdk.zosjobs.response;
 
+import zowe.client.sdk.zosjobs.model.Job;
+
 /**
  * Class used internally to help determine current job status
  *
  * @author Frank Giordano
  * @version 5.0
  */
-public class CheckJobStatus {
+public class CheckStatusResponse {
 
     /**
      * Has the desired job status been seen, true or false?
@@ -35,7 +37,7 @@ public class CheckJobStatus {
      * @param job         job used for status checking
      * @author Frank Giordano
      */
-    public CheckJobStatus(final boolean statusFound, final Job job) {
+    public CheckStatusResponse(final boolean statusFound, final Job job) {
         this.statusFound = statusFound;
         this.job = job;
     }
@@ -65,7 +67,7 @@ public class CheckJobStatus {
      */
     @Override
     public String toString() {
-        return "CheckJobStatus{" +
+        return "CheckStatusResponse{" +
                 "statusFound=" + statusFound +
                 ", job=" + job +
                 '}';

--- a/src/main/java/zowe/client/sdk/zosjobs/response/package-info.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/response/package-info.java
@@ -1,4 +1,4 @@
 /**
- * Request responses objects for z/OS jobs processing
+ * Request response objects for z/OS jobs processing
  */
 package zowe.client.sdk.zosjobs.response;

--- a/src/main/java/zowe/client/sdk/zoslogs/README.md
+++ b/src/main/java/zowe/client/sdk/zoslogs/README.md
@@ -19,7 +19,7 @@ import zowe.client.sdk.examples.utility.Util;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zoslogs.input.ZosLogInputData;
 import zowe.client.sdk.zoslogs.method.ZosLog;
-import zowe.client.sdk.zoslogs.response.ZosLogReply;
+import zowe.client.sdk.zoslogs.response.ZosLogResponse;
 import zowe.client.sdk.zoslogs.types.DirectionType;
 import zowe.client.sdk.zoslogs.types.HardCopyType;
 
@@ -49,7 +49,7 @@ public class ZosLogExp extends TstZosConnection {
                 .direction(DirectionType.BACKWARD)
                 .processResponses(true)
                 .build();
-        ZosLogReply zosLogReply;
+        ZosLogResponse zosLogReply;
         try {
             zosLogReply = zosLog.issueCommand(zosLogInputData);
         } catch (ZosmfRequestException e) {

--- a/src/main/java/zowe/client/sdk/zoslogs/method/ZosLog.java
+++ b/src/main/java/zowe/client/sdk/zoslogs/method/ZosLog.java
@@ -25,8 +25,8 @@ import zowe.client.sdk.rest.type.ZosmfRequestType;
 import zowe.client.sdk.utility.JsonParserUtil;
 import zowe.client.sdk.utility.ValidateUtils;
 import zowe.client.sdk.zoslogs.input.ZosLogInputData;
-import zowe.client.sdk.zoslogs.response.ZosLogItem;
-import zowe.client.sdk.zoslogs.response.ZosLogReply;
+import zowe.client.sdk.zoslogs.model.ZosLogItem;
+import zowe.client.sdk.zoslogs.response.ZosLogResponse;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -88,7 +88,7 @@ public class ZosLog {
      * @throws ZosmfRequestException request error state
      * @author Frank Giordano
      */
-    public ZosLogReply issueCommand(final ZosLogInputData logInputData) throws ZosmfRequestException {
+    public ZosLogResponse issueCommand(final ZosLogInputData logInputData) throws ZosmfRequestException {
         ValidateUtils.checkNullParameter(logInputData == null, "logInputData is null");
 
         final String defaultUrl = connection.getZosmfUrl() + RESOURCE;

--- a/src/main/java/zowe/client/sdk/zoslogs/model/ZosLogItem.java
+++ b/src/main/java/zowe/client/sdk/zoslogs/model/ZosLogItem.java
@@ -8,7 +8,7 @@
  * Copyright Contributors to the Zowe Project.
  *
  */
-package zowe.client.sdk.zoslogs.response;
+package zowe.client.sdk.zoslogs.model;
 
 import java.util.Optional;
 import java.util.OptionalLong;

--- a/src/main/java/zowe/client/sdk/zoslogs/model/package-info.java
+++ b/src/main/java/zowe/client/sdk/zoslogs/model/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Model objects for zos logs processing
+ */
+package zowe.client.sdk.zoslogs.model;

--- a/src/main/java/zowe/client/sdk/zoslogs/response/ZosLogResponse.java
+++ b/src/main/java/zowe/client/sdk/zoslogs/response/ZosLogResponse.java
@@ -10,6 +10,8 @@
  */
 package zowe.client.sdk.zoslogs.response;
 
+import zowe.client.sdk.zoslogs.model.ZosLogItem;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -20,7 +22,7 @@ import java.util.OptionalLong;
  * @author Frank Giordano
  * @version 5.0
  */
-public class ZosLogReply {
+public class ZosLogResponse {
 
     /**
      * Specify the timezone of the z/OS system. Valid values for the timezone range from -12 to 12.
@@ -60,8 +62,8 @@ public class ZosLogReply {
      * @param items         ZosLogItem object items returned from response
      * @author Frank Giordano
      */
-    public ZosLogReply(final Long timeZone, final Long nextTimeStamp, final String source, final Long totalItems,
-                       final List<ZosLogItem> items) {
+    public ZosLogResponse(final Long timeZone, final Long nextTimeStamp, final String source, final Long totalItems,
+                          final List<ZosLogItem> items) {
         this.timeZone = timeZone;
         this.nextTimeStamp = nextTimeStamp;
         this.source = source;

--- a/src/main/java/zowe/client/sdk/zosmfinfo/model/DefinedSystem.java
+++ b/src/main/java/zowe/client/sdk/zosmfinfo/model/DefinedSystem.java
@@ -7,7 +7,7 @@
  *
  * Copyright Contributors to the Zowe Project.
  */
-package zowe.client.sdk.zosmfinfo.response;
+package zowe.client.sdk.zosmfinfo.model;
 
 import java.util.Optional;
 

--- a/src/main/java/zowe/client/sdk/zosmfinfo/model/ZosmfPlugin.java
+++ b/src/main/java/zowe/client/sdk/zosmfinfo/model/ZosmfPlugin.java
@@ -7,7 +7,7 @@
  *
  * Copyright Contributors to the Zowe Project.
  */
-package zowe.client.sdk.zosmfinfo.response;
+package zowe.client.sdk.zosmfinfo.model;
 
 import java.util.Optional;
 
@@ -17,7 +17,7 @@ import java.util.Optional;
  * @author Frank Giordano
  * @version 5.0
  */
-public class ZosmfPluginInfo {
+public class ZosmfPlugin {
 
     /**
      * Plugin version
@@ -40,7 +40,7 @@ public class ZosmfPluginInfo {
      * @param builder Builder Object
      * @author Frank Giordano
      */
-    private ZosmfPluginInfo(final Builder builder) {
+    private ZosmfPlugin(final Builder builder) {
         this.pluginVersion = builder.pluginVersion;
         this.pluginDefaultName = builder.pluginDefaultName;
         this.pluginStatus = builder.pluginStatus;
@@ -151,8 +151,8 @@ public class ZosmfPluginInfo {
          *
          * @return ZosmfPluginInfo this object
          */
-        public ZosmfPluginInfo build() {
-            return new ZosmfPluginInfo(this);
+        public ZosmfPlugin build() {
+            return new ZosmfPlugin(this);
         }
 
     }

--- a/src/main/java/zowe/client/sdk/zosmfinfo/model/package-info.java
+++ b/src/main/java/zowe/client/sdk/zosmfinfo/model/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Model objects for z/OSMF info processing
+ */
+package zowe.client.sdk.zosmfinfo.model;

--- a/src/main/java/zowe/client/sdk/zosmfinfo/response/ZosmfInfoResponse.java
+++ b/src/main/java/zowe/client/sdk/zosmfinfo/response/ZosmfInfoResponse.java
@@ -9,6 +9,8 @@
  */
 package zowe.client.sdk.zosmfinfo.response;
 
+import zowe.client.sdk.zosmfinfo.model.ZosmfPlugin;
+
 import java.util.Optional;
 
 /**
@@ -57,7 +59,7 @@ public class ZosmfInfoResponse {
     /**
      * Zosmf plugin information
      */
-    private final ZosmfPluginInfo[] zosmfPluginsInfo;
+    private final ZosmfPlugin[] zosmfPluginsInfo;
 
     /**
      * ZosmfInfoResponse constructor
@@ -117,7 +119,7 @@ public class ZosmfInfoResponse {
      *
      * @return zosmfPluginsInfo value
      */
-    public Optional<ZosmfPluginInfo[]> getZosmfPluginsInfo() {
+    public Optional<ZosmfPlugin[]> getZosmfPluginsInfo() {
         return Optional.ofNullable(zosmfPluginsInfo);
     }
 
@@ -210,7 +212,7 @@ public class ZosmfInfoResponse {
         /**
          * Zosmf plugin information
          */
-        private ZosmfPluginInfo[] zosmfPluginsInfo;
+        private ZosmfPlugin[] zosmfPluginsInfo;
 
         /**
          * Builder constructor
@@ -268,7 +270,7 @@ public class ZosmfInfoResponse {
          * @param zosmfPluginsInfo string value
          * @return Builder this object
          */
-        public Builder zosmfPluginsInfo(final ZosmfPluginInfo[] zosmfPluginsInfo) {
+        public Builder zosmfPluginsInfo(final ZosmfPlugin[] zosmfPluginsInfo) {
             this.zosmfPluginsInfo = zosmfPluginsInfo;
             return this;
         }

--- a/src/main/java/zowe/client/sdk/zosmfinfo/response/ZosmfSystemsResponse.java
+++ b/src/main/java/zowe/client/sdk/zosmfinfo/response/ZosmfSystemsResponse.java
@@ -9,6 +9,8 @@
  */
 package zowe.client.sdk.zosmfinfo.response;
 
+import zowe.client.sdk.zosmfinfo.model.DefinedSystem;
+
 import java.util.Optional;
 import java.util.OptionalLong;
 

--- a/src/test/java/zowe/client/sdk/parse/DatasetParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/DatasetParseResponseTest.java
@@ -12,7 +12,7 @@ package zowe.client.sdk.parse;
 import org.json.simple.JSONObject;
 import org.junit.jupiter.api.Test;
 import zowe.client.sdk.parse.type.ParseType;
-import zowe.client.sdk.zosfiles.dsn.response.Dataset;
+import zowe.client.sdk.zosfiles.dsn.model.Dataset;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/test/java/zowe/client/sdk/parse/JobFileParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/JobFileParseResponseTest.java
@@ -12,7 +12,7 @@ package zowe.client.sdk.parse;
 import org.json.simple.JSONObject;
 import org.junit.jupiter.api.Test;
 import zowe.client.sdk.parse.type.ParseType;
-import zowe.client.sdk.zosjobs.response.JobFile;
+import zowe.client.sdk.zosjobs.model.JobFile;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/test/java/zowe/client/sdk/parse/JobParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/JobParseResponseTest.java
@@ -12,7 +12,7 @@ package zowe.client.sdk.parse;
 import org.json.simple.JSONObject;
 import org.junit.jupiter.api.Test;
 import zowe.client.sdk.parse.type.ParseType;
-import zowe.client.sdk.zosjobs.response.Job;
+import zowe.client.sdk.zosjobs.model.Job;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/test/java/zowe/client/sdk/parse/MemberParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/MemberParseResponseTest.java
@@ -12,7 +12,7 @@ package zowe.client.sdk.parse;
 import org.json.simple.JSONObject;
 import org.junit.jupiter.api.Test;
 import zowe.client.sdk.parse.type.ParseType;
-import zowe.client.sdk.zosfiles.dsn.response.Member;
+import zowe.client.sdk.zosfiles.dsn.model.Member;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/test/java/zowe/client/sdk/parse/UnixFileParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/UnixFileParseResponseTest.java
@@ -12,7 +12,7 @@ package zowe.client.sdk.parse;
 import org.json.simple.JSONObject;
 import org.junit.jupiter.api.Test;
 import zowe.client.sdk.parse.type.ParseType;
-import zowe.client.sdk.zosfiles.uss.response.UnixFile;
+import zowe.client.sdk.zosfiles.uss.model.UnixFile;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/test/java/zowe/client/sdk/parse/UnixZfsParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/UnixZfsParseResponseTest.java
@@ -12,7 +12,7 @@ package zowe.client.sdk.parse;
 import org.json.simple.JSONObject;
 import org.junit.jupiter.api.Test;
 import zowe.client.sdk.parse.type.ParseType;
-import zowe.client.sdk.zosfiles.uss.response.UnixZfs;
+import zowe.client.sdk.zosfiles.uss.model.UnixZfs;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/test/java/zowe/client/sdk/parse/ZosLogItemParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/ZosLogItemParseResponseTest.java
@@ -12,7 +12,7 @@ package zowe.client.sdk.parse;
 import org.json.simple.JSONObject;
 import org.junit.jupiter.api.Test;
 import zowe.client.sdk.parse.type.ParseType;
-import zowe.client.sdk.zoslogs.response.ZosLogItem;
+import zowe.client.sdk.zoslogs.model.ZosLogItem;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/test/java/zowe/client/sdk/parse/ZosLogReplyParseResponseTest.java
+++ b/src/test/java/zowe/client/sdk/parse/ZosLogReplyParseResponseTest.java
@@ -12,7 +12,7 @@ package zowe.client.sdk.parse;
 import org.json.simple.JSONObject;
 import org.junit.jupiter.api.Test;
 import zowe.client.sdk.parse.type.ParseType;
-import zowe.client.sdk.zoslogs.response.ZosLogReply;
+import zowe.client.sdk.zoslogs.response.ZosLogResponse;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -56,7 +56,7 @@ public class ZosLogReplyParseResponseTest {
 
         final ZosLogReplyJsonParse parser = (ZosLogReplyJsonParse)
                 JsonParseFactory.buildParser(ParseType.ZOS_LOG_REPLY);
-        final ZosLogReply response = parser.parseResponse(json, new ArrayList<>());
+        final ZosLogResponse response = parser.parseResponse(json, new ArrayList<>());
         assertEquals(Long.parseLong("1"), response.getTotalItems().orElse(-1L));
         assertEquals("dev", response.getSource().orElse("n\\a"));
     }

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssListTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssListTest.java
@@ -24,8 +24,8 @@ import zowe.client.sdk.utility.JsonParserUtil;
 import zowe.client.sdk.zosfiles.ZosFilesConstants;
 import zowe.client.sdk.zosfiles.uss.input.UssListInputData;
 import zowe.client.sdk.zosfiles.uss.input.UssListZfsInputData;
-import zowe.client.sdk.zosfiles.uss.response.UnixFile;
-import zowe.client.sdk.zosfiles.uss.response.UnixZfs;
+import zowe.client.sdk.zosfiles.uss.model.UnixFile;
+import zowe.client.sdk.zosfiles.uss.model.UnixZfs;
 
 import java.util.List;
 

--- a/src/test/java/zowe/client/sdk/zosjobs/methods/JobCancelTest.java
+++ b/src/test/java/zowe/client/sdk/zosjobs/methods/JobCancelTest.java
@@ -20,7 +20,7 @@ import zowe.client.sdk.rest.PutJsonZosmfRequest;
 import zowe.client.sdk.rest.Response;
 import zowe.client.sdk.rest.ZosmfRequest;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
-import zowe.client.sdk.zosjobs.response.Job;
+import zowe.client.sdk.zosjobs.model.Job;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;

--- a/src/test/java/zowe/client/sdk/zosjobs/methods/JobGetJsonTest.java
+++ b/src/test/java/zowe/client/sdk/zosjobs/methods/JobGetJsonTest.java
@@ -21,7 +21,7 @@ import zowe.client.sdk.rest.*;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.rest.type.ZosmfRequestType;
 import zowe.client.sdk.zosjobs.JobsConstants;
-import zowe.client.sdk.zosjobs.response.Job;
+import zowe.client.sdk.zosjobs.model.Job;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/test/java/zowe/client/sdk/zosjobs/methods/JobSubmitTest.java
+++ b/src/test/java/zowe/client/sdk/zosjobs/methods/JobSubmitTest.java
@@ -20,7 +20,7 @@ import zowe.client.sdk.rest.PutJsonZosmfRequest;
 import zowe.client.sdk.rest.Response;
 import zowe.client.sdk.rest.ZosmfRequest;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
-import zowe.client.sdk.zosjobs.response.Job;
+import zowe.client.sdk.zosjobs.model.Job;
 
 import java.util.HashMap;
 import java.util.Map;


### PR DESCRIPTION
Inspected response package for each component package and noticed some classes are used as model (regular POJO) containers. Moved these classes into a new model package accordingly. 

In addition, some of the response classes I renamed with "Response" at the end to keep naming convention consistent project wide. 