### PR TITLE
make account number static final

### DIFF
--- a/src/main/java/zowe/client/sdk/zostso/input/StartTsoInputData.java
+++ b/src/main/java/zowe/client/sdk/zostso/input/StartTsoInputData.java
@@ -21,7 +21,8 @@ public class StartTsoInputData {
 
     /**
      * User's z/OS permission account number.
-     * This parameter overrides the account specified in IssueTso constructor.
+     * This member is a placeholder for account value sent via IssueTso constructor.
+     * Setting this member will have no effect.
      */
     public String account;
 

--- a/src/main/java/zowe/client/sdk/zostso/method/IssueTso.java
+++ b/src/main/java/zowe/client/sdk/zostso/method/IssueTso.java
@@ -156,10 +156,8 @@ public class IssueTso {
         this.inputData = inputData;
         if (this.inputData == null) {
             this.inputData = new StartTsoInputData();
-            this.inputData.setAccount(accountNumber);
-        } else if (this.inputData.getAccount().isEmpty()) {
-            this.inputData.setAccount(accountNumber);
         }
+        this.inputData.setAccount(accountNumber);
         return tsoStartService.startTso(this.inputData);
     }
 

--- a/src/test/java/zowe/client/sdk/zostso/method/IssueTsoTest.java
+++ b/src/test/java/zowe/client/sdk/zostso/method/IssueTsoTest.java
@@ -133,7 +133,7 @@ public class IssueTsoTest {
 
         assertEquals(1, result.size());
         assertEquals("JOB STARTED", result.get(0));
-        assertEquals("ACCT456", issueTso.getInputData().getAccount().orElse(null));
+        assertEquals(account, issueTso.getInputData().getAccount().orElse(null));
 
         verify(mockTsoStartService, times(1)).startTso(any(StartTsoInputData.class));
         verify(mockTsoSendService, times(1)).sendCommand(sessionId, command);


### PR DESCRIPTION
Partial revert of PR #417 - Provide a way to override account number specified in IssueTso constructor with StartTsoInputData object. Added unit tests to validate changes in account number.

After further review on NodeJS SDK behaviour, it ignores account value being set to another value than the initial account value set in the API parameters for IssueTso. 

Make behaviour consistent with NodeJS ASK. And after further thought, changing account number from the initial setup seems like a rare need. 