### PR TITLE
Standardize port handling across connection objects

### DIFF
--- a/src/main/java/zowe/client/sdk/core/ZosConnection.java
+++ b/src/main/java/zowe/client/sdk/core/ZosConnection.java
@@ -29,7 +29,7 @@ public final class ZosConnection {
     /**
      * Host z/OSMF port number pointing to the backend z/OS instance
      */
-    private final String zosmfPort;
+    private final int zosmfPort;
     /**
      * AuthType: BASIC, TOKEN or SSL enum value for http request processing
      */
@@ -67,30 +67,19 @@ public final class ZosConnection {
      * Use ZosConnectionFactory to initiate a ZosConnection Object.
      *
      * @param host      string value
-     * @param zosmfPort string value
+     * @param zosmfPort int value
      * @param basePath  string value
      * @param authType  AuthType enum value
      * @author Frank Giordano
      */
-    ZosConnection(final String host, final String zosmfPort, final String basePath, final AuthType authType) {
+    ZosConnection(final String host, final int zosmfPort, final String basePath, final AuthType authType) {
         this.host = host;
-        validatePort(zosmfPort);
+        if (zosmfPort < 1 || zosmfPort > 65535) {
+            throw new IllegalArgumentException("invalid port number: " + zosmfPort);
+        }
         this.zosmfPort = zosmfPort;
         this.basePath = basePath == null ? null : getNormalizedPath(basePath);
         this.authType = authType;
-    }
-
-    private static void validatePort(String zosmfPort) {
-        int port;
-        try {
-            port = Integer.parseInt(zosmfPort);
-        } catch (NumberFormatException e) {
-            throw new IllegalArgumentException("non numeric exception: " + zosmfPort);
-        }
-
-        if (port < 1 || port > 65535) {
-            throw new IllegalArgumentException("invalid port number: " + port);
-        }
     }
 
     /**
@@ -107,7 +96,7 @@ public final class ZosConnection {
      *
      * @return string value
      */
-    public String getZosmfPort() {
+    public int getZosmfPort() {
         return zosmfPort;
     }
 
@@ -321,7 +310,7 @@ public final class ZosConnection {
     public String toString() {
         return "ZosConnection{" +
                 "host='" + ((host == null) ? "" : host) + '\'' +
-                ", zosmfPort='" + ((zosmfPort == null) ? "" : zosmfPort) + '\'' +
+                ", zosmfPort='" + zosmfPort + '\'' +
                 ", authType=" + authType +
                 ", user='" + ((user == null) ? "" : user) + '\'' +
                 ", password='" + ((password == null || password.isEmpty()) ? "" : "*****") + '\'' +

--- a/src/main/java/zowe/client/sdk/core/ZosConnectionFactory.java
+++ b/src/main/java/zowe/client/sdk/core/ZosConnectionFactory.java
@@ -39,7 +39,7 @@ public class ZosConnectionFactory {
      * @author Shabaz Kowthalam
      */
     public static ZosConnection createBasicConnection(final String host,
-                                                      final String port,
+                                                      final int port,
                                                       final String user,
                                                       final String password) {
         return createBasicZosConnection(host, port, user, password, null);
@@ -58,7 +58,7 @@ public class ZosConnectionFactory {
      * @author Shabaz Kowthalam
      */
     public static ZosConnection createBasicConnection(final String host,
-                                                      final String port,
+                                                      final int port,
                                                       final String user,
                                                       final String password,
                                                       final String basePath) {
@@ -80,12 +80,11 @@ public class ZosConnectionFactory {
      * @author Shabaz Kowthalam
      */
     private static ZosConnection createBasicZosConnection(final String host,
-                                                          final String port,
+                                                          final int port,
                                                           final String user,
                                                           final String password,
                                                           final String basePath) {
         ValidateUtils.checkIllegalParameter(host, "host");
-        ValidateUtils.checkIllegalParameter(port, "port");
         ValidateUtils.checkIllegalParameter(user, "user");
         ValidateUtils.checkIllegalParameter(password, "password");
 
@@ -106,7 +105,7 @@ public class ZosConnectionFactory {
      * @author Shabaz Kowthalam
      */
     public static ZosConnection createTokenConnection(final String host,
-                                                      final String port,
+                                                      final int port,
                                                       final Cookie token) {
         return createTokenZosConnection(host, port, token, null);
     }
@@ -123,7 +122,7 @@ public class ZosConnectionFactory {
      * @author Shabaz Kowthalam
      */
     public static ZosConnection createTokenConnection(final String host,
-                                                      final String port,
+                                                      final int port,
                                                       final Cookie token,
                                                       final String basePath) {
         ValidateUtils.checkIllegalParameter(basePath, "basePath");
@@ -143,11 +142,10 @@ public class ZosConnectionFactory {
      * @author Shabaz Kowthalam
      */
     private static ZosConnection createTokenZosConnection(final String host,
-                                                          final String port,
+                                                          final int port,
                                                           final Cookie token,
                                                           final String basePath) {
         ValidateUtils.checkIllegalParameter(host, "host");
-        ValidateUtils.checkIllegalParameter(port, "port");
         ValidateUtils.checkNullParameter(token == null, "token is null");
 
         ZosConnection zosConnection = new ZosConnection(host, port, basePath, AuthType.TOKEN);
@@ -167,7 +165,7 @@ public class ZosConnectionFactory {
      * @author Shabaz Kowthalam
      */
     public static ZosConnection createSslConnection(final String host,
-                                                    final String port,
+                                                    final int port,
                                                     final String certFilePath,
                                                     final String certPassword) {
         return createSslZosConnection(host, port, certFilePath, certPassword, null);
@@ -186,7 +184,7 @@ public class ZosConnectionFactory {
      * @author Shabaz Kowthalam
      */
     public static ZosConnection createSslConnection(final String host,
-                                                    final String port,
+                                                    final int port,
                                                     final String certFilePath,
                                                     final String certPassword,
                                                     final String basePath) {
@@ -208,12 +206,11 @@ public class ZosConnectionFactory {
      * @author Shabaz Kowthalam
      */
     private static ZosConnection createSslZosConnection(final String host,
-                                                        final String port,
+                                                        final int port,
                                                         final String certFilePath,
                                                         final String certPassword,
                                                         final String basePath) {
         ValidateUtils.checkIllegalParameter(host, "host");
-        ValidateUtils.checkIllegalParameter(port, "port");
         ValidateUtils.checkIllegalParameter(certFilePath, "certificate file path (.p12)");
         ValidateUtils.checkIllegalParameter(certPassword, "certPassword");
 

--- a/src/test/java/zowe/client/sdk/core/ZosConnectionFactoryTest.java
+++ b/src/test/java/zowe/client/sdk/core/ZosConnectionFactoryTest.java
@@ -26,25 +26,25 @@ public class ZosConnectionFactoryTest {
     @Test
     public void tstZosConnectionFactoryReferenceNotEqualsSuccess() {
         final ZosConnection zc1 = ZosConnectionFactory.createBasicConnection(
-                "test", "443", "user", "password");
+                "test", 443, "user", "password");
         final ZosConnection zc2 = ZosConnectionFactory.createBasicConnection(
-                "test", "443", "user", "password");
+                "test", 443, "user", "password");
         assertNotSame(zc1, zc2);
     }
 
     @Test
     public void tstZosConnectionFactoryReferenceNotEqualsWithCookieSuccess() {
         final ZosConnection zc1 = ZosConnectionFactory.createTokenConnection(
-                "test", "443", new Cookie("hello", "world"));
+                "test", 443, new Cookie("hello", "world"));
         final ZosConnection zc2 = ZosConnectionFactory.createTokenConnection(
-                "test", "443", new Cookie("hello1", "world"));
+                "test", 443, new Cookie("hello1", "world"));
         assertNotSame(zc1, zc2);
     }
 
     @Test
     public void tstZosConnectionFactoryReferenceEqualsSuccess() {
         final ZosConnection zc1 = ZosConnectionFactory.createBasicConnection(
-                "test", "443", "user", "password");
+                "test", 443, "user", "password");
         final ZosConnection zc2 = zc1;
         assertEquals(zc1, zc2);
     }
@@ -52,7 +52,7 @@ public class ZosConnectionFactoryTest {
     @Test
     public void tstZosConnectionFactoryReferenceEqualsWithCookieSuccess() {
         final ZosConnection zc1 = ZosConnectionFactory.createTokenConnection(
-                "test", "443", new Cookie("hello", "world"));
+                "test", 443, new Cookie("hello", "world"));
         final ZosConnection zc2 = zc1;
         assertEquals(zc1, zc2);
     }
@@ -60,45 +60,45 @@ public class ZosConnectionFactoryTest {
     @Test
     public void tstZosConnectionFactoryEqualsSuccess() {
         final ZosConnection zc1 = ZosConnectionFactory.createBasicConnection(
-                "test", "443", "user", "password");
+                "test", 443, "user", "password");
         final ZosConnection zc2 = ZosConnectionFactory.createBasicConnection(
-                "test", "443", "user", "password");
+                "test", 443, "user", "password");
         assertEquals(zc1, zc2);
     }
 
     @Test
     public void tstZosConnectionFactoryEqualsWithCookieSuccess() {
         final ZosConnection zc1 = ZosConnectionFactory.createTokenConnection(
-                "test", "1", new Cookie("hello", "world"));
+                "test", 443, new Cookie("hello", "world"));
         final ZosConnection zc2 = ZosConnectionFactory.createTokenConnection(
-                "test", "1", new Cookie("hello", "world"));
+                "test", 443, new Cookie("hello", "world"));
         assertEquals(zc1, zc2);
     }
 
     @Test
     public void tstZosConnectionFactoryNotEqualsSuccess() {
         final ZosConnection zc1 = ZosConnectionFactory.createBasicConnection(
-                "test", "1", "user", "password");
+                "test", 443, "user", "password");
         final ZosConnection zc2 = ZosConnectionFactory.createBasicConnection(
-                "test2", "1", "user", "password");
+                "test2", 443, "user", "password");
         assertNotEquals(zc1, zc2);
     }
 
     @Test
     public void tstZosConnectionFactoryNotEqualsWithCookieSuccess() {
         final ZosConnection zc1 = ZosConnectionFactory.createTokenConnection(
-                "test", "443", new Cookie("hello", "world1"));
+                "test", 443, new Cookie("hello", "world1"));
         final ZosConnection zc2 = ZosConnectionFactory.createTokenConnection(
-                "test", "443", new Cookie("hello", "world"));
+                "test", 443, new Cookie("hello", "world"));
         assertNotEquals(zc1, zc2);
     }
 
     @Test
     public void tstZosConnectionFactoryHashCodeMapWithSecondHostDifferentSuccess() {
         final ZosConnection zc1 = ZosConnectionFactory.createBasicConnection(
-                "test", "443", "user", "password");
+                "test", 443, "user", "password");
         final ZosConnection zc2 = ZosConnectionFactory.createBasicConnection(
-                "test2", "443", "user", "password");
+                "test2", 443, "user", "password");
         final var zcs = new HashMap<ZosConnection, Integer>();
         zcs.put(zc1, 1);
         zcs.put(zc2, 2);
@@ -108,9 +108,9 @@ public class ZosConnectionFactoryTest {
     @Test
     public void tstZosConnectionFactoryHashCodeMapWithSecondZosmfPortDifferentSuccess() {
         final ZosConnection zc1 = ZosConnectionFactory.createBasicConnection(
-                "test", "443", "user", "password");
+                "test", 443, "user", "password");
         final ZosConnection zc2 = ZosConnectionFactory.createBasicConnection(
-                "test", "4432", "user", "password");
+                "test", 4432, "user", "password");
         final var zcs = new HashMap<ZosConnection, Integer>();
         zcs.put(zc1, 1);
         zcs.put(zc2, 2);
@@ -120,9 +120,9 @@ public class ZosConnectionFactoryTest {
     @Test
     public void tstZosConnectionFactoryHashCodeMapWithSecondUserDifferentSuccess() {
         final ZosConnection zc1 = ZosConnectionFactory.createBasicConnection(
-                "test", "443", "user", "password");
+                "test", 443, "user", "password");
         final ZosConnection zc2 = ZosConnectionFactory.createBasicConnection(
-                "test", "443", "user2", "password");
+                "test", 443, "user2", "password");
         final var zcs = new HashMap<ZosConnection, Integer>();
         zcs.put(zc1, 1);
         zcs.put(zc2, 2);
@@ -132,9 +132,9 @@ public class ZosConnectionFactoryTest {
     @Test
     public void tstZosConnectionFactoryHashCodeMapWithSecondPasswordDifferentSuccess() {
         final ZosConnection zc1 = ZosConnectionFactory.createBasicConnection(
-                "test", "443", "user", "password");
+                "test", 443, "user", "password");
         final ZosConnection zc2 = ZosConnectionFactory.createBasicConnection(
-                "test", "443", "user", "password2");
+                "test", 443, "user", "password2");
         final var zcs = new HashMap<ZosConnection, Integer>();
         zcs.put(zc1, 1);
         zcs.put(zc2, 2);
@@ -144,9 +144,9 @@ public class ZosConnectionFactoryTest {
     @Test
     public void tstZosConnectionFactoryHashCodeMapNoDuplicateSuccess() {
         final ZosConnection zc1 = ZosConnectionFactory.createBasicConnection(
-                "test", "443", "user", "password");
+                "test", 443, "user", "password");
         final ZosConnection zc2 = ZosConnectionFactory.createBasicConnection(
-                "test", "443", "user", "password");
+                "test", 443, "user", "password");
         final var zcs = new HashMap<ZosConnection, Integer>();
         zcs.put(zc1, 1);
         zcs.put(zc2, 2);
@@ -156,7 +156,7 @@ public class ZosConnectionFactoryTest {
     @Test
     public void tstZosConnectionFactoryBasePathSetGetSuccess() {
         final ZosConnection connection = ZosConnectionFactory.createBasicConnection(
-                "test", "443", "user", "password", "/custom/path");
+                "test", 443, "user", "password", "/custom/path");
         assertEquals("/custom/path",
                 (connection.getBasePath().isPresent() ? connection.getBasePath().get() : ""));
     }
@@ -164,34 +164,34 @@ public class ZosConnectionFactoryTest {
     @Test
     public void tstZosConnectionFactoryBasePathDefaultEmptySuccess() {
         final ZosConnection connection = ZosConnectionFactory.createBasicConnection(
-                "test", "443", "user", "password");
+                "test", 443, "user", "password");
         assertTrue(connection.getBasePath().isEmpty());
     }
 
     @Test
     public void tstZosConnectionFactoryBasePathEqualsSuccess() {
         final ZosConnection zc1 = ZosConnectionFactory.createBasicConnection(
-                "test", "443", "user", "password", "/custom/path");
+                "test", 443, "user", "password", "/custom/path");
         final ZosConnection zc2 = ZosConnectionFactory.createBasicConnection(
-                "test", "443", "user", "password", "/custom/path");
+                "test", 443, "user", "password", "/custom/path");
         assertEquals(zc1, zc2);
     }
 
     @Test
     public void tstZosConnectionFactoryBasePathNotEqualsSuccess() {
         final ZosConnection zc1 = ZosConnectionFactory.createBasicConnection(
-                "test", "443", "user", "password", "/custom/path1");
+                "test", 443, "user", "password", "/custom/path1");
         final ZosConnection zc2 = ZosConnectionFactory.createBasicConnection(
-                "test", "443", "user", "password", "/custom/path2");
+                "test", 443, "user", "password", "/custom/path2");
         assertNotEquals(zc1, zc2);
     }
 
     @Test
     public void tstZosConnectionFactoryBasePathHashCodeMapWithDifferentPathsSuccess() {
         final ZosConnection zc1 = ZosConnectionFactory.createBasicConnection(
-                "test", "443", "user", "password", "/custom/path1");
+                "test", 443, "user", "password", "/custom/path1");
         final ZosConnection zc2 = ZosConnectionFactory.createBasicConnection(
-                "test", "443", "user", "password", "/custom/path2");
+                "test", 443, "user", "password", "/custom/path2");
         final var zcs = new HashMap<ZosConnection, Integer>();
         zcs.put(zc1, 1);
         zcs.put(zc2, 2);
@@ -201,15 +201,15 @@ public class ZosConnectionFactoryTest {
     @Test
     public void tstZosConnectionFactoryBasePathHashCodeMapWithSamePathsSuccess() {
         final ZosConnection zc1 = ZosConnectionFactory.createBasicConnection(
-                "test", "443", "user", "password", "/custom/path");
+                "test", 443, "user", "password", "/custom/path");
         final ZosConnection zc2 = ZosConnectionFactory.createBasicConnection(
-                "test", "443", "user", "password", "/custom/path");
+                "test", 443, "user", "password", "/custom/path");
         final ZosConnection zc3 = ZosConnectionFactory.createBasicConnection(
-                "test", "443", "user", "password", "custom/path/");
+                "test", 443, "user", "password", "custom/path/");
         final ZosConnection zc4 = ZosConnectionFactory.createBasicConnection(
-                "test", "443", "user", "password", "custom/path");
+                "test", 443, "user", "password", "custom/path");
         final ZosConnection zc5 = ZosConnectionFactory.createBasicConnection(
-                "test", "443", "user", "password", "\\custom\\path");
+                "test", 443, "user", "password", "\\custom\\path");
         final var zcs = new HashMap<ZosConnection, Integer>();
         zcs.put(zc1, 1);
         zcs.put(zc2, 2);
@@ -222,81 +222,81 @@ public class ZosConnectionFactoryTest {
     @Test
     public void tstZosConnectionFactoryBasePathTokenSuccess() {
         final ZosConnection zc1 = ZosConnectionFactory.createTokenConnection(
-                "test", "443", new Cookie("hello", "world"), "/custom/path");
+                "test", 443, new Cookie("hello", "world"), "/custom/path");
         assertEquals("/custom/path", (zc1.getBasePath().isPresent() ? zc1.getBasePath().get() : ""));
     }
 
     @Test
     public void tstZosConnectionFactoryBasePathSslSuccess() {
         final ZosConnection zc1 = ZosConnectionFactory.createSslConnection(
-                "test", "4431", "certPath", "certPassword", "/custom/path");
+                "test", 4431, "certPath", "certPassword", "/custom/path");
         assertEquals("/custom/path", (zc1.getBasePath().isPresent() ? zc1.getBasePath().get() : ""));
     }
 
     @Test
     public void tstZosConnectionFactoryBasicInvalidStatesFailure() {
         assertThrows(IllegalArgumentException.class, () -> ZosConnectionFactory.createBasicConnection(
-                null, "443", "user", "password"));
+                null, 443, "user", "password"));
         assertThrows(IllegalArgumentException.class, () -> ZosConnectionFactory.createBasicConnection(
-                "", "443", "user", "password"));
+                "", 443, "user", "password"));
         assertThrows(IllegalArgumentException.class, () -> ZosConnectionFactory.createBasicConnection(
-                "host", null, "user", "password"));
+                "host", 657777, "user", "password"));
         assertThrows(IllegalArgumentException.class, () -> ZosConnectionFactory.createBasicConnection(
-                "host", " ", "user", "password"));
+                "host", 0, "user", "password"));
         assertThrows(IllegalArgumentException.class, () -> ZosConnectionFactory.createBasicConnection(
-                "host", "443", null, "password"));
+                "host", 443, null, "password"));
         assertThrows(IllegalArgumentException.class, () -> ZosConnectionFactory.createBasicConnection(
-                "host", "443", "", "password"));
+                "host", 443, "", "password"));
         assertThrows(IllegalArgumentException.class, () -> ZosConnectionFactory.createBasicConnection(
-                "host", "443", "user", null));
+                "host", 443, "user", null));
         assertThrows(IllegalArgumentException.class, () -> ZosConnectionFactory.createBasicConnection(
-                "host", "443", "user", ""));
+                "host", 443, "user", ""));
         assertThrows(IllegalArgumentException.class, () -> ZosConnectionFactory.createBasicConnection(
-                "host", "443", "user", "password", null));
+                "host", 443, "user", "password", null));
         assertThrows(IllegalArgumentException.class, () -> ZosConnectionFactory.createBasicConnection(
-                "host", "443", "user", "password", ""));
+                "host", 443, "user", "password", ""));
     }
 
     @Test
     public void tstZosConnectionFactorySslInvalidStatesFailure() {
         assertThrows(IllegalArgumentException.class, () -> ZosConnectionFactory.createSslConnection(
-                null, "443", "user", "password"));
+                null, 443, "user", "password"));
         assertThrows(IllegalArgumentException.class, () -> ZosConnectionFactory.createSslConnection(
-                "", "443", "user", "password"));
+                "", 443, "user", "password"));
         assertThrows(IllegalArgumentException.class, () -> ZosConnectionFactory.createSslConnection(
-                "host", null, "user", "password"));
+                "host", 657777, "user", "password"));
         assertThrows(IllegalArgumentException.class, () -> ZosConnectionFactory.createSslConnection(
-                "host", " ", "user", "password"));
+                "host", 0, "user", "password"));
         assertThrows(IllegalArgumentException.class, () -> ZosConnectionFactory.createSslConnection(
-                "host", "443", null, "password"));
+                "host", 443, null, "password"));
         assertThrows(IllegalArgumentException.class, () -> ZosConnectionFactory.createSslConnection(
-                "host", "443", "", "password"));
+                "host", 443, "", "password"));
         assertThrows(IllegalArgumentException.class, () -> ZosConnectionFactory.createSslConnection(
-                "host", "443", "user", null));
+                "host", 443, "user", null));
         assertThrows(IllegalArgumentException.class, () -> ZosConnectionFactory.createSslConnection(
-                "host", "443", "user", ""));
+                "host", 443, "user", ""));
         assertThrows(IllegalArgumentException.class, () -> ZosConnectionFactory.createSslConnection(
-                "host", "443", "user", "password", null));
+                "host", 443, "user", "password", null));
         assertThrows(IllegalArgumentException.class, () -> ZosConnectionFactory.createSslConnection(
-                "host", "443", "user", "password", ""));
+                "host", 443, "user", "password", ""));
     }
 
     @Test
     public void tstZosConnectionFactoryTokenInvalidStatesFailure() {
         assertThrows(IllegalArgumentException.class, () -> ZosConnectionFactory.createTokenConnection(
-                null, "443", new Cookie("foo", "bar")));
+                null, 443, new Cookie("foo", "bar")));
         assertThrows(IllegalArgumentException.class, () -> ZosConnectionFactory.createTokenConnection(
-                "", "443", new Cookie("foo", "bar")));
+                "", 443, new Cookie("foo", "bar")));
         assertThrows(IllegalArgumentException.class, () -> ZosConnectionFactory.createTokenConnection(
-                "host", null, new Cookie("foo", "bar")));
+                "host", 657777, new Cookie("foo", "bar")));
         assertThrows(IllegalArgumentException.class, () -> ZosConnectionFactory.createTokenConnection(
-                "host", " ", new Cookie("foo", "bar")));
+                "host", 0, new Cookie("foo", "bar")));
         assertThrows(NullPointerException.class, () -> ZosConnectionFactory.createTokenConnection(
-                "host", "443", null));
+                "host", 443, null));
         assertThrows(IllegalArgumentException.class, () -> ZosConnectionFactory.createTokenConnection(
-                "host", "443", new Cookie("foo", "bar"), null));
+                "host", 443, new Cookie("foo", "bar"), null));
         assertThrows(IllegalArgumentException.class, () -> ZosConnectionFactory.createTokenConnection(
-                "host", "443", new Cookie("foo", "bar"), ""));
+                "host", 443, new Cookie("foo", "bar"), ""));
     }
 
 }

--- a/src/test/java/zowe/client/sdk/core/ZosConnectionTest.java
+++ b/src/test/java/zowe/client/sdk/core/ZosConnectionTest.java
@@ -28,9 +28,9 @@ class ZosConnectionTest {
     @Test
     void tstBasicConnectionsEqualSuccess() {
         final ZosConnection conn1 = ZosConnectionFactory
-                .createBasicConnection("host1", "443", "userA", "passA");
+                .createBasicConnection("host1", 443, "userA", "passA");
         final ZosConnection conn2 = ZosConnectionFactory
-                .createBasicConnection("host1", "443", "userA", "passA");
+                .createBasicConnection("host1", 443, "userA", "passA");
 
         assertEquals(conn1, conn2);
         assertEquals(conn1.hashCode(), conn2.hashCode());
@@ -39,9 +39,9 @@ class ZosConnectionTest {
     @Test
     void tstBasicConnectionsNotEqualWithDifferentUserSuccess() {
         final ZosConnection conn1 = ZosConnectionFactory
-                .createBasicConnection("host1", "443", "userA", "passA");
+                .createBasicConnection("host1", 443, "userA", "passA");
         final ZosConnection conn2 = ZosConnectionFactory
-                .createBasicConnection("host1", "443", "userB", "passA");
+                .createBasicConnection("host1", 443, "userB", "passA");
 
         assertNotEquals(conn1, conn2);
     }
@@ -49,9 +49,9 @@ class ZosConnectionTest {
     @Test
     void tstBasicConnectionsNotEqualWithDifferentHost() {
         final ZosConnection conn1 = ZosConnectionFactory
-                .createBasicConnection("host1", "443", "userA", "passA");
+                .createBasicConnection("host1", 443, "userA", "passA");
         final ZosConnection conn2 = ZosConnectionFactory
-                .createBasicConnection("host2", "443", "userA", "passA");
+                .createBasicConnection("host2", 443, "userA", "passA");
 
         assertNotEquals(conn1, conn2);
     }
@@ -59,7 +59,7 @@ class ZosConnectionTest {
     @Test
     void tstBasicConnectionsMaskPasswordAndOthersEmptySuccess() {
         final ZosConnection conn = ZosConnectionFactory
-                .createBasicConnection("zos", "443", "user", "pass", "/zosmf");
+                .createBasicConnection("zos", 443, "user", "pass", "/zosmf");
         String result = conn.toString();
         System.out.println(result);
 
@@ -71,7 +71,7 @@ class ZosConnectionTest {
     @Test
     void tstBasicConnectionBasePathNormalizationSuccess() {
         final ZosConnection conn = ZosConnectionFactory
-                .createBasicConnection("host1", "443", "user", "pass", "zosmf/api/");
+                .createBasicConnection("host1", 443, "user", "pass", "zosmf/api/");
 
         assertEquals("/zosmf/api", conn.getBasePath().orElse(null));
     }
@@ -79,7 +79,7 @@ class ZosConnectionTest {
     @Test
     void tstBasicConnectionBasePathBackslashNormalizationSuccess() {
         final ZosConnection conn = ZosConnectionFactory
-                .createBasicConnection("host1", "443", "user", "pass", "\\zosmf\\api\\");
+                .createBasicConnection("host1", 443, "user", "pass", "\\zosmf\\api\\");
 
         assertEquals("/zosmf/api", conn.getBasePath().orElse(null));
     }
@@ -88,9 +88,9 @@ class ZosConnectionTest {
     void tstTokenConnectionsEqualSuccess() {
         Cookie cookie = new Cookie("LtpaToken2", "abcdef");
         final ZosConnection conn1 = ZosConnectionFactory
-                .createTokenConnection("host1", "443", cookie);
+                .createTokenConnection("host1", 443, cookie);
         final ZosConnection conn2 = ZosConnectionFactory
-                .createTokenConnection("host1", "443", new Cookie("LtpaToken2", "abcdef"));
+                .createTokenConnection("host1", 443, new Cookie("LtpaToken2", "abcdef"));
 
         assertEquals(conn1, conn2);
         assertEquals(conn1.hashCode(), conn2.hashCode());
@@ -100,7 +100,7 @@ class ZosConnectionTest {
     void tstTokenConnectionsMaskTokenAndOtherPasswordsEmptySuccess() {
         Cookie cookie = new Cookie("LtpaToken2", "abcdef");
         final ZosConnection conn = ZosConnectionFactory
-                .createTokenConnection("host1", "443", cookie);
+                .createTokenConnection("host1", 443, cookie);
         String result = conn.toString();
         System.out.println(result);
 
@@ -121,9 +121,9 @@ class ZosConnectionTest {
         Cookie cookie2 = new Cookie("LtpaToken2", "xyz123");
 
         final ZosConnection conn1 = ZosConnectionFactory.
-                createTokenConnection("host1", "443", cookie1);
+                createTokenConnection("host1", 443, cookie1);
         final ZosConnection conn2 = ZosConnectionFactory.
-                createTokenConnection("host1", "443", cookie2);
+                createTokenConnection("host1", 443, cookie2);
 
         assertNotEquals(conn1, conn2);
     }
@@ -133,7 +133,7 @@ class ZosConnectionTest {
         Cookie cookie = new Cookie("LtpaToken2", "abc123");
 
         final ZosConnection conn = ZosConnectionFactory
-                .createTokenConnection("host1", "443", cookie, "zosmf/api/");
+                .createTokenConnection("host1", 443, cookie, "zosmf/api/");
 
         assertEquals("/zosmf/api", conn.getBasePath().orElse(null));
     }
@@ -143,7 +143,7 @@ class ZosConnectionTest {
         Cookie cookie = new Cookie("LtpaToken2", "abc123");
 
         final ZosConnection conn = ZosConnectionFactory
-                .createTokenConnection("host1", "443", cookie, "\\zosmf\\api\\");
+                .createTokenConnection("host1", 443, cookie, "\\zosmf\\api\\");
 
         assertEquals("/zosmf/api", conn.getBasePath().orElse(null));
     }
@@ -151,9 +151,9 @@ class ZosConnectionTest {
     @Test
     void tstSslConnectionsEqualSuccess() {
         final ZosConnection conn1 = ZosConnectionFactory
-                .createSslConnection("host1", "443", "/certs/certA.p12", "certpass");
+                .createSslConnection("host1", 443, "/certs/certA.p12", "certpass");
         final ZosConnection conn2 = ZosConnectionFactory
-                .createSslConnection("host1", "443", "/certs/certA.p12", "certpass");
+                .createSslConnection("host1", 443, "/certs/certA.p12", "certpass");
 
         assertEquals(conn1, conn2);
         assertEquals(conn1.hashCode(), conn2.hashCode());
@@ -162,9 +162,9 @@ class ZosConnectionTest {
     @Test
     void tstSslConnectionsNotEqualWithDifferentCertFileSuccess() {
         final ZosConnection conn1 = ZosConnectionFactory
-                .createSslConnection("host1", "443", "/certs/certA.p12", "certpass");
+                .createSslConnection("host1", 443, "/certs/certA.p12", "certpass");
         final ZosConnection conn2 = ZosConnectionFactory
-                .createSslConnection("host1", "443", "/certs/certB.p12", "certpass");
+                .createSslConnection("host1", 443, "/certs/certB.p12", "certpass");
 
         assertNotEquals(conn1, conn2);
     }
@@ -172,7 +172,7 @@ class ZosConnectionTest {
     @Test
     void tstSslConnectionsMaskCertPasswordAndOthersEmptySuccess() {
         final ZosConnection conn = ZosConnectionFactory
-                .createSslConnection("host1", "443", "/certs/certA.p12", "certpass");
+                .createSslConnection("host1", 443, "/certs/certA.p12", "certpass");
         String result = conn.toString();
         System.out.println(result);
 
@@ -190,7 +190,7 @@ class ZosConnectionTest {
     @Test
     void tstSslConnectionBasePathNormalizationSuccess() {
         final ZosConnection conn = ZosConnectionFactory
-                .createSslConnection("host1", "443",
+                .createSslConnection("host1", 443,
                         "/certs/cert.p12", "certpass", "zosmf/api/");
 
         assertEquals("/zosmf/api", conn.getBasePath().orElse(null));
@@ -199,7 +199,7 @@ class ZosConnectionTest {
     @Test
     void tstSslConnectionBasePathBackslashNormalizationSuccess() {
         final ZosConnection conn = ZosConnectionFactory
-                .createSslConnection("host1", "443",
+                .createSslConnection("host1", 443,
                         "/certs/cert.p12", "certpass", "\\zosmf\\api\\");
 
         assertEquals("/zosmf/api", conn.getBasePath().orElse(null));
@@ -208,10 +208,10 @@ class ZosConnectionTest {
     @Test
     void tstDifferentAuthTypesNotEqualSuccess() {
         final ZosConnection basicConn = ZosConnectionFactory
-                .createBasicConnection("host1", "443", "userA", "passA");
+                .createBasicConnection("host1", 443, "userA", "passA");
         Cookie cookie = new Cookie("LtpaToken2", "abcdef");
         final ZosConnection tokenConn = ZosConnectionFactory.
-                createTokenConnection("host1", "443", cookie);
+                createTokenConnection("host1", 443, cookie);
 
         assertNotEquals(basicConn, tokenConn);
     }
@@ -219,9 +219,9 @@ class ZosConnectionTest {
     @Test
     void tstEqualityIsSymmetricAndConsistentSuccess() {
         final ZosConnection conn1 = ZosConnectionFactory
-                .createBasicConnection("host1", "443", "userA", "passA");
+                .createBasicConnection("host1", 443, "userA", "passA");
         final ZosConnection conn2 = ZosConnectionFactory
-                .createBasicConnection("host1", "443", "userA", "passA");
+                .createBasicConnection("host1", 443, "userA", "passA");
 
         assertTrue(conn1.equals(conn2) && conn2.equals(conn1));
         assertEquals(conn1.hashCode(), conn2.hashCode());
@@ -234,7 +234,7 @@ class ZosConnectionTest {
     @Test
     void tstNotEqualToNullOrDifferentClassSuccess() {
         final ZosConnection conn = ZosConnectionFactory
-                .createBasicConnection("host1", "443", "userA", "passA");
+                .createBasicConnection("host1", 443, "userA", "passA");
 
         assertNotEquals(null, conn);
         assertNotEquals("stringValue", conn);
@@ -243,9 +243,9 @@ class ZosConnectionTest {
     @Test
     void testBasicConnectionsEqualSuccess() {
         final ZosConnection conn1 = ZosConnectionFactory
-                .createBasicConnection("host1", "443", "userA", "passA");
+                .createBasicConnection("host1", 443, "userA", "passA");
         final ZosConnection conn2 = ZosConnectionFactory
-                .createBasicConnection("host1", "443", "userA", "passA");
+                .createBasicConnection("host1", 443, "userA", "passA");
 
         assertEquals(conn1, conn2);
         assertEquals(conn1.hashCode(), conn2.hashCode());
@@ -253,12 +253,12 @@ class ZosConnectionTest {
 
     @Test
     void tstSettersAndGettersForBasicAuthSuccess() {
-        final ZosConnection conn = new ZosConnection("myhost", "1443", "/zosmf/api", AuthType.BASIC);
+        final ZosConnection conn = new ZosConnection("myhost", 1443, "/zosmf/api", AuthType.BASIC);
         conn.setUser("testuser");
         conn.setPassword("testpass");
 
         assertEquals("myhost", conn.getHost());
-        assertEquals("1443", conn.getZosmfPort());
+        assertEquals(1443, conn.getZosmfPort());
         assertEquals("testuser", conn.getUser());
         assertEquals("testpass", conn.getPassword());
         assertEquals(AuthType.BASIC, conn.getAuthType());
@@ -268,26 +268,26 @@ class ZosConnectionTest {
     @Test
     void tstSettersAndGettersForTokenAuthSuccess() {
         Cookie cookie = new Cookie("LtpaToken2", "abc123");
-        final ZosConnection conn = new ZosConnection("zoshost", "443", "/api/v1", AuthType.TOKEN);
+        final ZosConnection conn = new ZosConnection("zoshost", 443, "/api/v1", AuthType.TOKEN);
         conn.setToken(cookie);
 
         assertEquals(cookie, conn.getToken());
         assertEquals("zoshost", conn.getHost());
-        assertEquals("443", conn.getZosmfPort());
+        assertEquals(443, conn.getZosmfPort());
         assertEquals(AuthType.TOKEN, conn.getAuthType());
         assertEquals("/api/v1", conn.getBasePath().orElse(null));
     }
 
     @Test
     void tstSettersAndGettersForSslAuthSuccess() {
-        final ZosConnection conn = new ZosConnection("zosssl", "8443", "/zosmf", AuthType.SSL);
+        final ZosConnection conn = new ZosConnection("zosssl", 8443, "/zosmf", AuthType.SSL);
         conn.setCertFilePath("/certs/secure.p12");
         conn.setCertPassword("mypassword");
 
         assertEquals("/certs/secure.p12", conn.getCertFilePath());
         assertEquals("mypassword", conn.getCertPassword());
         assertEquals("zosssl", conn.getHost());
-        assertEquals("8443", conn.getZosmfPort());
+        assertEquals(8443, conn.getZosmfPort());
         assertEquals(AuthType.SSL, conn.getAuthType());
         assertEquals("/zosmf", conn.getBasePath().orElse(null));
     }
@@ -295,7 +295,7 @@ class ZosConnectionTest {
     @Test
     void tstToStringIncludesImportantFieldsSuccess() {
         final ZosConnection conn = ZosConnectionFactory
-                .createBasicConnection("zos", "443", "user", "pass", "/zosmf");
+                .createBasicConnection("zos", 443, "user", "pass", "/zosmf");
         String result = conn.toString();
         System.out.println(result);
 
@@ -313,9 +313,9 @@ class ZosConnectionTest {
     @Test
     void tstEqualsIsReflexiveSymmetricAndConsistentSuccess() {
         final ZosConnection conn1 = ZosConnectionFactory
-                .createBasicConnection("host", "443", "user", "pass");
+                .createBasicConnection("host", 443, "user", "pass");
         final ZosConnection conn2 = ZosConnectionFactory
-                .createBasicConnection("host", "443", "user", "pass");
+                .createBasicConnection("host", 443, "user", "pass");
 
         assertEquals(conn1, conn1);  // reflexive
         assertTrue(conn1.equals(conn2) && conn2.equals(conn1)); // symmetric
@@ -326,7 +326,7 @@ class ZosConnectionTest {
     @Test
     void tstNotEqualToDifferentObjectTypeSuccess() {
         final ZosConnection conn = ZosConnectionFactory
-                .createBasicConnection("zos", "443", "user", "pass");
+                .createBasicConnection("zos", 443, "user", "pass");
         assertNotEquals("string", conn);
     }
 
@@ -334,18 +334,13 @@ class ZosConnectionTest {
     void tstInvalidPortNumbersFailure() {
         // capture and verify port out of range
         IllegalArgumentException outOfRangeEx = assertThrows(IllegalArgumentException.class,
-                () -> ZosConnectionFactory.createBasicConnection("zos", "443666666", "user", "pass"));
+                () -> ZosConnectionFactory.createBasicConnection("zos", 443666666, "user", "pass"));
         assertTrue(outOfRangeEx.getMessage().contains("port"), "invalid port number: 443666666");
 
         // capture and verify invalid port 0
         IllegalArgumentException zeroPortEx = assertThrows(IllegalArgumentException.class,
-                () -> ZosConnectionFactory.createSslConnection("host1", "0", "/certs/cert.p12", "certpass", "zosmf/api/"));
+                () -> ZosConnectionFactory.createSslConnection("host1", 0, "/certs/cert.p12", "certpass", "zosmf/api/"));
         assertEquals("invalid port number: 0", zeroPortEx.getMessage());
-
-        // capture and verify non-numeric port
-        IllegalArgumentException nonNumericEx = assertThrows(IllegalArgumentException.class,
-                () -> ZosConnectionFactory.createTokenConnection("host1", "frank", new Cookie("LtpaToken2", "abcdef")));
-        assertEquals("non numeric exception: frank", nonNumericEx.getMessage());
     }
 
 }

--- a/src/test/java/zowe/client/sdk/rest/ZoweRequestTest.java
+++ b/src/test/java/zowe/client/sdk/rest/ZoweRequestTest.java
@@ -37,7 +37,7 @@ public class ZoweRequestTest {
     @BeforeEach
     public void init() {
         mockReply = Mockito.mock(HttpResponse.class);
-        connection = ZosConnectionFactory.createBasicConnection("1", "1", "1", "1");
+        connection = ZosConnectionFactory.createBasicConnection("1", 443, "1", "1");
     }
 
     @Test
@@ -131,7 +131,7 @@ public class ZoweRequestTest {
 
     @Test
     public void tstZoweRequestInitializeSslSetupFailure() {
-        final ZosConnection connection = ZosConnectionFactory.createSslConnection("host", "443",
+        final ZosConnection connection = ZosConnectionFactory.createSslConnection("host", 443,
                 "/file/file1", "dummy");
         final String errMsgWindows = "kong.unirest.core.UnirestConfigException: " +
                 "java.io.FileNotFoundException: \\file\\file1 (The system cannot find the path specified)";
@@ -146,7 +146,7 @@ public class ZoweRequestTest {
 
     @Test
     public void tstZoweRequestInitializeSslSetupCertPasswordFailure() {
-        final ZosConnection connection = ZosConnectionFactory.createSslConnection("host", "443",
+        final ZosConnection connection = ZosConnectionFactory.createSslConnection("host", 443,
                 "src/test/resources/certs/badssl.com-client.p12", "dummy");
         final String errMsg = "java.io.IOException: keystore password was incorrect";
         try {
@@ -158,7 +158,7 @@ public class ZoweRequestTest {
 
     @Test
     public void tstZoweRequestInitializeSslSetupCertPasswordSuccess() {
-        final ZosConnection connection = ZosConnectionFactory.createSslConnection("host", "443",
+        final ZosConnection connection = ZosConnectionFactory.createSslConnection("host", 443,
                 "src/test/resources/certs/badssl.com-client.p12", "badssl.com");
         try {
             ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
@@ -170,7 +170,7 @@ public class ZoweRequestTest {
     @Test
     public void tstZoweRequestInitializeBasicSetupSuccess() {
         final ZosConnection connection = ZosConnectionFactory
-                .createBasicConnection("host", "443", "user", "password");
+                .createBasicConnection("host", 443, "user", "password");
         final ZosmfRequest request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
         assertNotNull(request.getHeaders().get("Authorization"));
     }
@@ -178,7 +178,7 @@ public class ZoweRequestTest {
     @Test
     public void tstZoweRequestInitializeTokenSetupSuccess() {
         final ZosConnection connection = ZosConnectionFactory
-                .createTokenConnection("host", "443", new Cookie("hello", "world"));
+                .createTokenConnection("host", 443, new Cookie("hello", "world"));
         final ZosmfRequest request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
         assertNull(request.getHeaders().get("Authorization"));
     }
@@ -187,7 +187,7 @@ public class ZoweRequestTest {
     public void tstUrlConstructionWithBasePathSuccess() {
         // Create a connection with a base path
         final ZosConnection connection = ZosConnectionFactory
-                .createBasicConnection("test.host", "443", "user", "password", "/custom/base/path");
+                .createBasicConnection("test.host", 443, "user", "password", "/custom/base/path");
 
         // Create a mock request to verify URL
         final ZosmfRequest request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.GET_JSON);
@@ -205,7 +205,7 @@ public class ZoweRequestTest {
     public void tstUrlConstructionWithoutBasePathSuccess() {
         // Create a connection without setting a base path
         final ZosConnection connection = ZosConnectionFactory
-                .createBasicConnection("test.host", "443", "user", "password");
+                .createBasicConnection("test.host", 443, "user", "password");
 
         // Create a mock request to verify URL
         final ZosmfRequest request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.GET_JSON);
@@ -223,7 +223,7 @@ public class ZoweRequestTest {
     public void tstUrlConstructionWithInvalidHostNameFailure() {
         // Create a connection and set an empty base path
         final ZosConnection connection = ZosConnectionFactory
-                .createBasicConnection("test.host:123foo", "443", "user", "password");
+                .createBasicConnection("test.host:123foo", 443, "user", "password");
         // Create a mock request to verify URL
         final ZosmfRequest request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.GET_JSON);
 
@@ -234,7 +234,7 @@ public class ZoweRequestTest {
     public void tstUrlConstructionWithInvalidBasePathFailure() {
         // Create a connection and set an invalid base path
         final ZosConnection connection = ZosConnectionFactory
-                .createBasicConnection("test.host", "443", "user", "password", "/test^/");
+                .createBasicConnection("test.host", 443, "user", "password", "/test^/");
         // Create a mock request to verify URL
         final ZosmfRequest request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.GET_JSON);
 

--- a/src/test/java/zowe/client/sdk/zosconsole/method/ConsoleCmdTest.java
+++ b/src/test/java/zowe/client/sdk/zosconsole/method/ConsoleCmdTest.java
@@ -45,9 +45,9 @@ import static org.mockito.Mockito.withSettings;
 public class ConsoleCmdTest {
 
     private final ZosConnection connection = ZosConnectionFactory
-            .createBasicConnection("1", "1", "1", "1");
+            .createBasicConnection("1", 443, "1", "1");
     private final ZosConnection tokenConnection = ZosConnectionFactory
-            .createTokenConnection("1", "1", new Cookie("hello=hello"));
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
     private PutJsonZosmfRequest mockJsonPutRequest;
 
     @BeforeEach

--- a/src/test/java/zowe/client/sdk/zosconsole/method/ConsoleGetTest.java
+++ b/src/test/java/zowe/client/sdk/zosconsole/method/ConsoleGetTest.java
@@ -40,9 +40,9 @@ import static org.mockito.Mockito.withSettings;
 public class ConsoleGetTest {
 
     private final ZosConnection connection =
-            ZosConnectionFactory.createBasicConnection("1", "1", "1", "1");
+            ZosConnectionFactory.createBasicConnection("1", 443, "1", "1");
     private final ZosConnection tokenConnection =
-            ZosConnectionFactory.createTokenConnection("1", "1", new Cookie("hello=hello"));
+            ZosConnectionFactory.createTokenConnection("1", 443, new Cookie("hello=hello"));
     private GetJsonZosmfRequest mockJsonGetRequest;
 
     @BeforeEach

--- a/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnCopyTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnCopyTest.java
@@ -34,9 +34,9 @@ import static org.mockito.Mockito.*;
 public class DsnCopyTest {
 
     private final ZosConnection connection = ZosConnectionFactory
-            .createBasicConnection("1", "1", "1", "1");
+            .createBasicConnection("1", 443, "1", "1");
     private final ZosConnection tokenConnection = ZosConnectionFactory
-            .createTokenConnection("1", "1", new Cookie("hello=hello"));
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
     private PutJsonZosmfRequest mockJsonPutRequest;
     private PutJsonZosmfRequest mockJsonPutRequestToken;
 
@@ -66,7 +66,7 @@ public class DsnCopyTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/ds/to", mockJsonPutRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/ds/to", mockJsonPutRequest.getUrl());
     }
 
     @Test
@@ -78,7 +78,7 @@ public class DsnCopyTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/ds/to", mockJsonPutRequestToken.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/ds/to", mockJsonPutRequestToken.getUrl());
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnCreateTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnCreateTest.java
@@ -37,9 +37,9 @@ import static org.mockito.Mockito.withSettings;
 public class DsnCreateTest {
 
     private final ZosConnection connection = ZosConnectionFactory
-            .createBasicConnection("1", "1", "1", "1");
+            .createBasicConnection("1", 443, "1", "1");
     private final ZosConnection tokenConnection = ZosConnectionFactory
-            .createTokenConnection("1", "1", new Cookie("hello=hello"));
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
     private PostJsonZosmfRequest mockPostRequest;
     private PostJsonZosmfRequest mockPostRequestToken;
 
@@ -69,7 +69,7 @@ public class DsnCreateTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/ds/TEST.PDS", mockPostRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/ds/TEST.PDS", mockPostRequest.getUrl());
     }
 
     @Test
@@ -81,7 +81,7 @@ public class DsnCreateTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/ds/TEST.PDS", mockPostRequestToken.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/ds/TEST.PDS", mockPostRequestToken.getUrl());
     }
 
     @Test
@@ -91,7 +91,7 @@ public class DsnCreateTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/ds/TEST.PDS", mockPostRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/ds/TEST.PDS", mockPostRequest.getUrl());
     }
 
     @Test
@@ -101,7 +101,7 @@ public class DsnCreateTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/ds/TEST.PDS", mockPostRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/ds/TEST.PDS", mockPostRequest.getUrl());
     }
 
     public static DsnCreateInputData classic() {

--- a/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnDeleteTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnDeleteTest.java
@@ -36,9 +36,9 @@ import static org.mockito.Mockito.withSettings;
 public class DsnDeleteTest {
 
     private final ZosConnection connection = ZosConnectionFactory
-            .createBasicConnection("1", "1", "1", "1");
+            .createBasicConnection("1", 443, "1", "1");
     private final ZosConnection tokenConnection = ZosConnectionFactory
-            .createTokenConnection("1", "1", new Cookie("hello=hello"));
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
     private DeleteJsonZosmfRequest mockDeleteRequest;
     private DeleteJsonZosmfRequest mockDeleteRequestToken;
 
@@ -68,7 +68,7 @@ public class DsnDeleteTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/ds/TEST.DATASET", mockDeleteRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/ds/TEST.DATASET", mockDeleteRequest.getUrl());
     }
 
     @Test
@@ -79,14 +79,14 @@ public class DsnDeleteTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/ds/TEST.DATASET", mockDeleteRequestToken.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/ds/TEST.DATASET", mockDeleteRequestToken.getUrl());
     }
 
     @Test
     public void tstDsnDeleteWithDatasetMemberNotationSuccess() throws ZosmfRequestException {
         final DsnDelete dsnDelete = new DsnDelete(connection, mockDeleteRequest);
         final Response response = dsnDelete.delete("TEST.DATASET(MEMBER)");
-        assertEquals("https://1:1/zosmf/restfiles/ds/TEST.DATASET(MEMBER)", mockDeleteRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/ds/TEST.DATASET(MEMBER)", mockDeleteRequest.getUrl());
         assertEquals(200, response.getStatusCode().orElse(-1));
     }
 
@@ -94,7 +94,7 @@ public class DsnDeleteTest {
     public void tstDsnDeleteWithDatasetMemberSeparateParametersSuccess() throws ZosmfRequestException {
         final DsnDelete dsnDelete = new DsnDelete(connection, mockDeleteRequest);
         final Response response = dsnDelete.delete("TEST.DATASET", "MEMBER");
-        assertEquals("https://1:1/zosmf/restfiles/ds/TEST.DATASET(MEMBER)", mockDeleteRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/ds/TEST.DATASET(MEMBER)", mockDeleteRequest.getUrl());
         assertEquals(200, response.getStatusCode().orElse(-1));
     }
 

--- a/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnGetTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnGetTest.java
@@ -43,9 +43,9 @@ import static org.mockito.Mockito.withSettings;
 public class DsnGetTest {
 
     private final ZosConnection connection = ZosConnectionFactory
-            .createBasicConnection("1", "1", "1", "1");
+            .createBasicConnection("1", 443, "1", "1");
     private final ZosConnection tokenConnection = ZosConnectionFactory
-            .createTokenConnection("1", "1", new Cookie("hello=hello"));
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
     private GetStreamZosmfRequest mockGetRequest;
     private GetStreamZosmfRequest mockGetRequestToken;
 
@@ -74,7 +74,7 @@ public class DsnGetTest {
         final DsnDownloadInputData downloadInputData = new DsnDownloadInputData.Builder().binary(true).build();
         final InputStream inputStream = dsnGet.get("TEST.DATASET", downloadInputData);
         assertEquals("test data", new String(inputStream.readAllBytes()));
-        assertEquals("https://1:1/zosmf/restfiles/ds/TEST.DATASET", mockGetRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/ds/TEST.DATASET", mockGetRequest.getUrl());
     }
 
     @Test
@@ -85,7 +85,7 @@ public class DsnGetTest {
         assertEquals("{X-IBM-Data-Type=binary, Accept-Encoding=gzip, X-CSRF-ZOSMF-HEADER=true, " +
                 "Content-Type=application/json}", mockGetRequestToken.getHeaders().toString());
         assertEquals("test data", new String(inputStream.readAllBytes()));
-        assertEquals("https://1:1/zosmf/restfiles/ds/TEST.DATASET", mockGetRequestToken.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/ds/TEST.DATASET", mockGetRequestToken.getUrl());
     }
 
     @Test
@@ -103,7 +103,7 @@ public class DsnGetTest {
                         "X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
                 mockGetRequestToken.getHeaders().toString());
         assertEquals("test data", new String(inputStream.readAllBytes()));
-        assertEquals("https://1:1/zosmf/restfiles/ds/TEST.DATASET", mockGetRequestToken.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/ds/TEST.DATASET", mockGetRequestToken.getUrl());
     }
 
     @Test
@@ -120,7 +120,7 @@ public class DsnGetTest {
                         "X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
                 mockGetRequestToken.getHeaders().toString());
         assertEquals("test data", new String(inputStream.readAllBytes()));
-        assertEquals("https://1:1/zosmf/restfiles/ds/TEST.DATASET", mockGetRequestToken.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/ds/TEST.DATASET", mockGetRequestToken.getUrl());
     }
 
     @Test
@@ -135,7 +135,7 @@ public class DsnGetTest {
                         "X-IBM-Response-Timeout=30, X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
                 mockGetRequestToken.getHeaders().toString());
         assertEquals("test data", new String(inputStream.readAllBytes()));
-        assertEquals("https://1:1/zosmf/restfiles/ds/TEST.DATASET", mockGetRequestToken.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/ds/TEST.DATASET", mockGetRequestToken.getUrl());
     }
 
     @Test
@@ -151,7 +151,7 @@ public class DsnGetTest {
                         "X-IBM-Response-Timeout=30, X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
                 mockGetRequestToken.getHeaders().toString());
         assertEquals("test data", new String(inputStream.readAllBytes()));
-        assertEquals("https://1:1/zosmf/restfiles/ds/TEST.DATASET", mockGetRequestToken.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/ds/TEST.DATASET", mockGetRequestToken.getUrl());
     }
 
     @Test
@@ -167,7 +167,7 @@ public class DsnGetTest {
                         " Content-Type=application/json}",
                 mockGetRequestToken.getHeaders().toString());
         assertEquals("test data", new String(inputStream.readAllBytes()));
-        assertEquals("https://1:1/zosmf/restfiles/ds/TEST.DATASET", mockGetRequestToken.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/ds/TEST.DATASET", mockGetRequestToken.getUrl());
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnListTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnListTest.java
@@ -37,9 +37,9 @@ import static org.mockito.Mockito.withSettings;
 public class DsnListTest {
 
     private final ZosConnection connection = ZosConnectionFactory
-            .createBasicConnection("1", "1", "1", "1");
+            .createBasicConnection("1", 443, "1", "1");
     private final ZosConnection tokenConnection = ZosConnectionFactory
-            .createTokenConnection("1", "1", new Cookie("hello=hello"));
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
     private GetJsonZosmfRequest mockGetRequest;
     private GetJsonZosmfRequest mockGetRequestToken;
 
@@ -67,7 +67,7 @@ public class DsnListTest {
         final DsnList dsnList = new DsnList(connection, mockGetRequest);
         final DsnListInputData listInputData = new DsnListInputData.Builder().responseTimeout("10").volume("vol1").build();
         dsnList.getMembers("TEST.DATASET", listInputData);
-        assertEquals("https://1:1/zosmf/restfiles/ds/TEST.DATASET/member", mockGetRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/ds/TEST.DATASET/member", mockGetRequest.getUrl());
     }
 
     @Test
@@ -78,7 +78,7 @@ public class DsnListTest {
         assertEquals("{X-IBM-Max-Items=0, Accept-Encoding=gzip, X-IBM-Response-Timeout=10, " +
                         "X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
                 mockGetRequestToken.getHeaders().toString());
-        assertEquals("https://1:1/zosmf/restfiles/ds/TEST.DATASET/member", mockGetRequestToken.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/ds/TEST.DATASET/member", mockGetRequestToken.getUrl());
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnRenameTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnRenameTest.java
@@ -36,9 +36,9 @@ import static org.mockito.Mockito.withSettings;
 public class DsnRenameTest {
 
     private final ZosConnection connection = ZosConnectionFactory
-            .createBasicConnection("1", "1", "1", "1");
+            .createBasicConnection("1", 443, "1", "1");
     private final ZosConnection tokenConnection = ZosConnectionFactory
-            .createTokenConnection("1", "1", new Cookie("hello=hello"));
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
     private PutJsonZosmfRequest mockJsonPutRequest;
     private PutJsonZosmfRequest mockJsonPutRequestToken;
 
@@ -68,7 +68,7 @@ public class DsnRenameTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/ds/destination", mockJsonPutRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/ds/destination", mockJsonPutRequest.getUrl());
     }
 
     @Test
@@ -80,7 +80,7 @@ public class DsnRenameTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/ds/source(newName)", mockJsonPutRequestToken.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/ds/source(newName)", mockJsonPutRequestToken.getUrl());
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnWriteTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnWriteTest.java
@@ -36,9 +36,9 @@ import static org.mockito.Mockito.withSettings;
 public class DsnWriteTest {
 
     private final ZosConnection connection = ZosConnectionFactory
-            .createBasicConnection("1", "1", "1", "1");
+            .createBasicConnection("1", 443, "1", "1");
     private final ZosConnection tokenConnection = ZosConnectionFactory
-            .createTokenConnection("1", "1", new Cookie("hello=hello"));
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
     private PutTextZosmfRequest mockTextPutRequest;
     private PutTextZosmfRequest mockTextPutRequestToken;
 
@@ -68,7 +68,7 @@ public class DsnWriteTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/ds/TEXT_PDS", mockTextPutRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/ds/TEXT_PDS", mockTextPutRequest.getUrl());
     }
 
     @Test
@@ -80,7 +80,7 @@ public class DsnWriteTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/ds/TEXT_PDS", mockTextPutRequestToken.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/ds/TEXT_PDS", mockTextPutRequestToken.getUrl());
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeModeTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeModeTest.java
@@ -36,9 +36,9 @@ import static org.mockito.Mockito.*;
 public class UssChangeModeTest {
 
     private final ZosConnection connection = ZosConnectionFactory
-            .createBasicConnection("1", "1", "1", "1");
+            .createBasicConnection("1", 443, "1", "1");
     private final ZosConnection tokenConnection = ZosConnectionFactory
-            .createTokenConnection("1", "1", new Cookie("hello=hello"));
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
     private PutJsonZosmfRequest mockJsonPutRequest;
     private PutJsonZosmfRequest mockJsonPutRequestToken;
     private UssChangeMode ussChangeMode;
@@ -72,7 +72,7 @@ public class UssChangeModeTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequest.getUrl());
     }
 
     @Test
@@ -85,7 +85,7 @@ public class UssChangeModeTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequestToken.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequestToken.getUrl());
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeOwnerTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeOwnerTest.java
@@ -38,9 +38,9 @@ import static org.mockito.Mockito.withSettings;
 public class UssChangeOwnerTest {
 
     private final ZosConnection connection = ZosConnectionFactory
-            .createBasicConnection("1", "1", "1", "1");
+            .createBasicConnection("1", 443, "1", "1");
     private final ZosConnection tokenConnection = ZosConnectionFactory
-            .createTokenConnection("1", "1", new Cookie("hello=hello"));
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
     private PutJsonZosmfRequest mockJsonPutRequest;
     private PutJsonZosmfRequest mockJsonPutRequestToken;
     private UssChangeOwner ussChangeOwner;
@@ -73,7 +73,7 @@ public class UssChangeOwnerTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequest.getUrl());
     }
 
     @Test
@@ -85,7 +85,7 @@ public class UssChangeOwnerTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequestToken.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequestToken.getUrl());
     }
 
     @Test
@@ -96,7 +96,7 @@ public class UssChangeOwnerTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequest.getUrl());
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeTagTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeTagTest.java
@@ -40,9 +40,9 @@ import static org.mockito.Mockito.withSettings;
 public class UssChangeTagTest {
 
     private final ZosConnection connection = ZosConnectionFactory
-            .createBasicConnection("1", "1", "1", "1");
+            .createBasicConnection("1", 443, "1", "1");
     private final ZosConnection tokenConnection = ZosConnectionFactory
-            .createTokenConnection("1", "1", new Cookie("hello=hello"));
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
     private PutJsonZosmfRequest mockJsonPutRequest;
     private PutJsonZosmfRequest mockJsonPutRequestToken;
     private UssChangeTag ussChangeTag;
@@ -75,7 +75,7 @@ public class UssChangeTagTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequest.getUrl());
     }
 
     @Test
@@ -87,7 +87,7 @@ public class UssChangeTagTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequestToken.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequestToken.getUrl());
     }
 
     @Test
@@ -97,7 +97,7 @@ public class UssChangeTagTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequest.getUrl());
     }
 
     @Test
@@ -107,7 +107,7 @@ public class UssChangeTagTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequest.getUrl());
     }
 
     @Test
@@ -117,7 +117,7 @@ public class UssChangeTagTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequest.getUrl());
     }
 
     @Test
@@ -128,7 +128,7 @@ public class UssChangeTagTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequest.getUrl());
     }
 
     @Test
@@ -139,7 +139,7 @@ public class UssChangeTagTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxx%20x%2Fx%20x%2Fx%20x", mockJsonPutRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxx%20x%2Fx%20x%2Fx%20x", mockJsonPutRequest.getUrl());
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssCopyTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssCopyTest.java
@@ -38,9 +38,9 @@ import static org.mockito.Mockito.withSettings;
 public class UssCopyTest {
 
     private final ZosConnection connection = ZosConnectionFactory
-            .createBasicConnection("1", "1", "1", "1");
+            .createBasicConnection("1", 443, "1", "1");
     private final ZosConnection tokenConnection = ZosConnectionFactory
-            .createTokenConnection("1", "1", new Cookie("hello=hello"));
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
     private PutJsonZosmfRequest mockJsonPutRequest;
     private PutJsonZosmfRequest mockJsonPutRequestToken;
     private UssCopy ussCopy;
@@ -73,7 +73,7 @@ public class UssCopyTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequest.getUrl());
     }
 
     @Test
@@ -86,7 +86,7 @@ public class UssCopyTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequestToken.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequestToken.getUrl());
     }
 
     @Test
@@ -97,7 +97,7 @@ public class UssCopyTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequest.getUrl());
     }
 
     @Test
@@ -108,7 +108,7 @@ public class UssCopyTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequest.getUrl());
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssCreateTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssCreateTest.java
@@ -40,9 +40,9 @@ import static org.mockito.Mockito.withSettings;
 public class UssCreateTest {
 
     private final ZosConnection connection = ZosConnectionFactory
-            .createBasicConnection("1", "1", "1", "1");
+            .createBasicConnection("1", 443, "1", "1");
     private final ZosConnection tokenConnection = ZosConnectionFactory
-            .createTokenConnection("1", "1", new Cookie("hello=hello"));
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
     private PostJsonZosmfRequest mockJsonPostRequest;
     private PostJsonZosmfRequest mockJsonPostRequestToken;
     private UssCreate ussCreate;
@@ -75,7 +75,7 @@ public class UssCreateTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxx%2Fxx%2Fx", mockJsonPostRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxx%2Fxx%2Fx", mockJsonPostRequest.getUrl());
     }
 
     @Test
@@ -87,7 +87,7 @@ public class UssCreateTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxx%2Fxx%2Fx", mockJsonPostRequestToken.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxx%2Fxx%2Fx", mockJsonPostRequestToken.getUrl());
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssDeleteTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssDeleteTest.java
@@ -37,9 +37,9 @@ import static org.mockito.Mockito.withSettings;
 public class UssDeleteTest {
 
     private final ZosConnection connection = ZosConnectionFactory
-            .createBasicConnection("1", "1", "1", "1");
+            .createBasicConnection("1", 443, "1", "1");
     private final ZosConnection tokenConnection = ZosConnectionFactory
-            .createTokenConnection("1", "1", new Cookie("hello=hello"));
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
     private DeleteJsonZosmfRequest mockJsonDeleteRequest;
     private DeleteJsonZosmfRequest mockJsonDeleteRequestToken;
     private UssDelete ussDelete;
@@ -72,7 +72,7 @@ public class UssDeleteTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonDeleteRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonDeleteRequest.getUrl());
     }
 
     @Test
@@ -85,7 +85,7 @@ public class UssDeleteTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonDeleteRequestToken.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonDeleteRequestToken.getUrl());
     }
 
     @Test
@@ -95,7 +95,7 @@ public class UssDeleteTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonDeleteRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonDeleteRequest.getUrl());
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssExtAttrTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssExtAttrTest.java
@@ -36,9 +36,9 @@ import static org.mockito.Mockito.withSettings;
 public class UssExtAttrTest {
 
     private final ZosConnection connection = ZosConnectionFactory
-            .createBasicConnection("1", "1", "1", "1");
+            .createBasicConnection("1", 443, "1", "1");
     private final ZosConnection tokenConnection = ZosConnectionFactory
-            .createTokenConnection("1", "1", new Cookie("hello=hello"));
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
     private PutJsonZosmfRequest mockJsonPutRequest;
     private PutJsonZosmfRequest mockJsonPutRequestToken;
     public UssExtAttr ussExtAttr;
@@ -71,7 +71,7 @@ public class UssExtAttrTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Ftest", mockJsonPutRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Ftest", mockJsonPutRequest.getUrl());
     }
 
     @Test
@@ -83,7 +83,7 @@ public class UssExtAttrTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Ftest", mockJsonPutRequestToken.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Ftest", mockJsonPutRequestToken.getUrl());
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssGetTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssGetTest.java
@@ -38,9 +38,9 @@ import static org.mockito.Mockito.withSettings;
 public class UssGetTest {
 
     private final ZosConnection connection = ZosConnectionFactory
-            .createBasicConnection("1", "1", "1", "1");
+            .createBasicConnection("1", 443, "1", "1");
     private final ZosConnection tokenConnection = ZosConnectionFactory
-            .createTokenConnection("1", "1", new Cookie("hello=hello"));
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
     private GetTextZosmfRequest mockTextGetRequest;
     private GetTextZosmfRequest mockTextGetRequestToken;
     private UssGet ussGet;
@@ -71,7 +71,7 @@ public class UssGetTest {
         final UssGet ussGet = new UssGet(connection, mockTextGetRequest);
         final String response = ussGet.getText("/xxx/xx");
         assertEquals("text", response);
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxxx%2Fxx", mockTextGetRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxxx%2Fxx", mockTextGetRequest.getUrl());
     }
 
     @Test
@@ -82,7 +82,7 @@ public class UssGetTest {
                 "Content-Type=text/plain; charset=UTF-8}";
         assertEquals(expectedResp, mockTextGetRequestToken.getHeaders().toString());
         assertEquals("text", response);
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxxx%2Fxx", mockTextGetRequestToken.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxxx%2Fxx", mockTextGetRequestToken.getUrl());
     }
 
     @Test
@@ -95,7 +95,7 @@ public class UssGetTest {
         final UssGet ussGet = new UssGet(connection, mockTextGetRequest);
         final String response = ussGet.getText("/xxx/xx");
         assertEquals("", response);
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxxx%2Fxx", mockTextGetRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxxx%2Fxx", mockTextGetRequest.getUrl());
     }
 
     @Test
@@ -109,7 +109,7 @@ public class UssGetTest {
         final UssGet ussGet = new UssGet(connection, mockStreamGetRequest);
         final byte[] response = ussGet.getBinary("/xxx/xx");
         assertEquals(data, response);
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxxx%2Fxx", mockStreamGetRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxxx%2Fxx", mockStreamGetRequest.getUrl());
     }
 
     @Test
@@ -123,7 +123,7 @@ public class UssGetTest {
         final UssGet ussGet = new UssGet(connection, mockStreamGetRequest);
         final byte[] response = ussGet.getBinary("/xxx/xx");
         assertEquals(data, response);
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxxx%2Fxx", mockStreamGetRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxxx%2Fxx", mockStreamGetRequest.getUrl());
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssListTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssListTest.java
@@ -45,9 +45,9 @@ import static org.mockito.Mockito.withSettings;
 public class UssListTest {
 
     private final ZosConnection connection = ZosConnectionFactory
-            .createBasicConnection("1", "1", "1", "1");
+            .createBasicConnection("1", 443, "1", "1");
     private final ZosConnection tokenConnection = ZosConnectionFactory
-            .createTokenConnection("1", "1", new Cookie("hello=hello"));
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
     private GetJsonZosmfRequest mockJsonGetRequest;
     private GetJsonZosmfRequest mockJsonGetRequestToken;
     private UssList ussList;
@@ -148,7 +148,7 @@ public class UssListTest {
         final List<UnixFile> items = ussList.getFiles(new UssListInputData.Builder().path("/xxx/xx/x").build());
         // should only contain two items
         assertEquals(0, items.size());
-        assertEquals("https://1:1/zosmf/restfiles/fs?path=%2Fxxx%2Fxx%2Fx", mockJsonGetRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs?path=%2Fxxx%2Fxx%2Fx", mockJsonGetRequest.getUrl());
     }
 
     @Test
@@ -159,7 +159,7 @@ public class UssListTest {
                 mockJsonGetRequestToken.getHeaders().toString());
         // should only contain two items
         assertEquals(0, items.size());
-        assertEquals("https://1:1/zosmf/restfiles/fs?path=%2Fxxx%2Fxx%2Fx", mockJsonGetRequestToken.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs?path=%2Fxxx%2Fxx%2Fx", mockJsonGetRequestToken.getUrl());
     }
 
     @Test
@@ -174,7 +174,7 @@ public class UssListTest {
             msg = e.getMessage();
         }
         assertEquals(ZosFilesConstants.RESPONSE_PHRASE_ERROR, msg);
-        assertEquals("https://1:1/zosmf/restfiles/fs?path=%2Fxxx%2Fxx%2Fx", mockJsonGetRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs?path=%2Fxxx%2Fxx%2Fx", mockJsonGetRequest.getUrl());
     }
 
     @Test
@@ -184,7 +184,7 @@ public class UssListTest {
                 new Response(json, 200, "success"));
         final UssList ussList = new UssList(connection, mockJsonGetRequest);
         final List<UnixFile> items = ussList.getFiles(new UssListInputData.Builder().path("/xxx/xx/x").build());
-        assertEquals("https://1:1/zosmf/restfiles/fs?path=%2Fxxx%2Fxx%2Fx", mockJsonGetRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs?path=%2Fxxx%2Fxx%2Fx", mockJsonGetRequest.getUrl());
         // should only contain two items
         assertEquals(2, items.size());
         // verify first item's data
@@ -216,7 +216,7 @@ public class UssListTest {
                 new Response(json, 200, "success"));
         final UssList ussList = new UssList(connection, mockJsonGetRequest);
         final List<UnixFile> items = ussList.getFiles(new UssListInputData.Builder().path("/xxx/xx/x").build());
-        assertEquals("https://1:1/zosmf/restfiles/fs?path=%2Fxxx%2Fxx%2Fx", mockJsonGetRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs?path=%2Fxxx%2Fxx%2Fx", mockJsonGetRequest.getUrl());
         // should only contain two items
         assertEquals(2, items.size());
         // verify first item's data
@@ -250,7 +250,7 @@ public class UssListTest {
         final UssList ussList = new UssList(connection, mockJsonGetRequest);
         final List<UnixFile> items = ussList.getFiles(new UssListInputData.Builder().path("/xxx/xx/x").build());
         assertEquals(0, items.size());
-        assertEquals("https://1:1/zosmf/restfiles/fs?path=%2Fxxx%2Fxx%2Fx", mockJsonGetRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs?path=%2Fxxx%2Fxx%2Fx", mockJsonGetRequest.getUrl());
     }
 
     @Test
@@ -260,7 +260,7 @@ public class UssListTest {
         final UssList ussList = new UssList(connection, mockJsonGetRequest);
         final List<UnixFile> items = ussList.getFiles(new UssListInputData.Builder().path("/xxx/xx/x").build());
         assertEquals(0, items.size());
-        assertEquals("https://1:1/zosmf/restfiles/fs?path=%2Fxxx%2Fxx%2Fx", mockJsonGetRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs?path=%2Fxxx%2Fxx%2Fx", mockJsonGetRequest.getUrl());
     }
 
     @Test
@@ -286,7 +286,7 @@ public class UssListTest {
         assertEquals(907651, items.get(0).getReadibc());
         assertEquals(42, items.get(0).getWriteibc());
         assertEquals(453057, items.get(0).getDiribc());
-        assertEquals("https://1:1/zosmf/restfiles/mfs?path=%2Fxxx%2Fxx%2Fx", mockJsonGetRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/mfs?path=%2Fxxx%2Fxx%2Fx", mockJsonGetRequest.getUrl());
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssMountTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssMountTest.java
@@ -39,9 +39,9 @@ import static org.mockito.Mockito.withSettings;
 public class UssMountTest {
 
     private final ZosConnection connection = ZosConnectionFactory
-            .createBasicConnection("1", "1", "1", "1");
+            .createBasicConnection("1", 443, "1", "1");
     private final ZosConnection tokenConnection = ZosConnectionFactory
-            .createTokenConnection("1", "1", new Cookie("hello=hello"));
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
     private PutJsonZosmfRequest mockJsonPutRequest;
     private PutJsonZosmfRequest mockJsonPutRequestToken;
     private UssMount ussMount;
@@ -74,7 +74,7 @@ public class UssMountTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/mfs/name", mockJsonPutRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/mfs/name", mockJsonPutRequest.getUrl());
     }
 
     @Test
@@ -86,7 +86,7 @@ public class UssMountTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/mfs/name", mockJsonPutRequestToken.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/mfs/name", mockJsonPutRequestToken.getUrl());
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssMoveTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssMoveTest.java
@@ -36,9 +36,9 @@ import static org.mockito.Mockito.withSettings;
 public class UssMoveTest {
 
     private final ZosConnection connection = ZosConnectionFactory
-            .createBasicConnection("1", "1", "1", "1");
+            .createBasicConnection("1", 443, "1", "1");
     private final ZosConnection tokenConnection = ZosConnectionFactory
-            .createTokenConnection("1", "1", new Cookie("hello=hello"));
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
     private PutJsonZosmfRequest mockJsonPutRequest;
     private PutJsonZosmfRequest mockJsonPutRequestToken;
     private UssMove ussMove;
@@ -71,7 +71,7 @@ public class UssMoveTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequest.getUrl());
     }
 
     @Test
@@ -83,7 +83,7 @@ public class UssMoveTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequestToken.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequestToken.getUrl());
     }
 
     @Test
@@ -93,7 +93,7 @@ public class UssMoveTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxxx%2Fxx%2Fxx", mockJsonPutRequest.getUrl());
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssWriteTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssWriteTest.java
@@ -39,9 +39,9 @@ import static org.mockito.Mockito.withSettings;
 public class UssWriteTest {
 
     private final ZosConnection connection = ZosConnectionFactory
-            .createBasicConnection("1", "1", "1", "1");
+            .createBasicConnection("1", 443, "1", "1");
     private final ZosConnection tokenConnection = ZosConnectionFactory
-            .createTokenConnection("1", "1", new Cookie("hello=hello"));
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
     private PutTextZosmfRequest mockTextPutRequest;
     private PutTextZosmfRequest mockTextPutRequestToken;
     private UssWrite ussWrite;
@@ -74,7 +74,7 @@ public class UssWriteTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxx%2Fxx%2Fx", mockTextPutRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxx%2Fxx%2Fx", mockTextPutRequest.getUrl());
     }
 
     @Test
@@ -86,7 +86,7 @@ public class UssWriteTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxx%2Fxx%2Fx", mockTextPutRequestToken.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxx%2Fxx%2Fx", mockTextPutRequestToken.getUrl());
     }
 
     @Test
@@ -101,7 +101,7 @@ public class UssWriteTest {
         assertTrue(response.getResponsePhrase().orElse(null) instanceof byte[]);
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restfiles/fs%2Fxx%2Fxx%2Fx", mockStreamPutRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxx%2Fxx%2Fx", mockStreamPutRequest.getUrl());
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosjobs/methods/JobCancelTest.java
+++ b/src/test/java/zowe/client/sdk/zosjobs/methods/JobCancelTest.java
@@ -37,9 +37,9 @@ import static org.mockito.Mockito.withSettings;
 public class JobCancelTest {
 
     private final ZosConnection connection = ZosConnectionFactory
-            .createBasicConnection("1", "1", "1", "1");
+            .createBasicConnection("1", 443, "1", "1");
     private final ZosConnection tokenConnection = ZosConnectionFactory
-            .createTokenConnection("1", "1", new Cookie("hello=hello"));
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
     private PutJsonZosmfRequest mockPutJsonZosmfRequest;
     private PutJsonZosmfRequest mockPutJsonZosmfRequestToken;
 
@@ -69,7 +69,7 @@ public class JobCancelTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restjobs/jobs/JOBNAME/JOBID", mockPutJsonZosmfRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restjobs/jobs/JOBNAME/JOBID", mockPutJsonZosmfRequest.getUrl());
     }
 
     @Test
@@ -81,7 +81,7 @@ public class JobCancelTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restjobs/jobs/JOBNAME/JOBID", mockPutJsonZosmfRequestToken.getUrl());
+        assertEquals("https://1:443/zosmf/restjobs/jobs/JOBNAME/JOBID", mockPutJsonZosmfRequestToken.getUrl());
     }
 
     @Test
@@ -93,7 +93,7 @@ public class JobCancelTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restjobs/jobs/JOBNAME/JOBID", mockPutJsonZosmfRequestToken.getUrl());
+        assertEquals("https://1:443/zosmf/restjobs/jobs/JOBNAME/JOBID", mockPutJsonZosmfRequestToken.getUrl());
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosjobs/methods/JobDeleteTest.java
+++ b/src/test/java/zowe/client/sdk/zosjobs/methods/JobDeleteTest.java
@@ -36,9 +36,9 @@ import static org.mockito.Mockito.withSettings;
 public class JobDeleteTest {
 
     private final ZosConnection connection = ZosConnectionFactory
-            .createBasicConnection("1", "1", "1", "1");
+            .createBasicConnection("1", 443, "1", "1");
     private final ZosConnection tokenConnection = ZosConnectionFactory
-            .createTokenConnection("1", "1", new Cookie("hello=hello"));
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
     private DeleteJsonZosmfRequest mockJsonDeleteRequest;
     private DeleteJsonZosmfRequest mockJsonDeleteRequestToken;
 
@@ -68,7 +68,7 @@ public class JobDeleteTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restjobs/jobs/JOBNAME/JOBID", mockJsonDeleteRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restjobs/jobs/JOBNAME/JOBID", mockJsonDeleteRequest.getUrl());
     }
 
     @Test
@@ -80,7 +80,7 @@ public class JobDeleteTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restjobs/jobs/JOBNAME/JOBID", mockJsonDeleteRequestToken.getUrl());
+        assertEquals("https://1:443/zosmf/restjobs/jobs/JOBNAME/JOBID", mockJsonDeleteRequestToken.getUrl());
     }
 
     @Test
@@ -92,7 +92,7 @@ public class JobDeleteTest {
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
-        assertEquals("https://1:1/zosmf/restjobs/jobs/JOBNAME/JOBID", mockJsonDeleteRequestToken.getUrl());
+        assertEquals("https://1:443/zosmf/restjobs/jobs/JOBNAME/JOBID", mockJsonDeleteRequestToken.getUrl());
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosjobs/methods/JobGetJsonTest.java
+++ b/src/test/java/zowe/client/sdk/zosjobs/methods/JobGetJsonTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class JobGetJsonTest {
 
     private final ZosConnection connection = ZosConnectionFactory
-            .createBasicConnection("1", "1", "1", "1");
+            .createBasicConnection("1", 443, "1", "1");
     private GetJsonZosmfRequest mockJsonGetRequest;
     private JobGet getJobs;
     private JSONObject jobJson;
@@ -110,7 +110,7 @@ public class JobGetJsonTest {
             msgResult = e.getMessage();
 
         }
-        assertEquals("https://1:1/zosmf/restjobs/jobs?owner=*&jobid=1", getJobs.getUrl());
+        assertEquals("https://1:443/zosmf/restjobs/jobs?owner=*&jobid=1", getJobs.getUrl());
         assertEquals(msg, msgResult);
     }
 
@@ -124,7 +124,7 @@ public class JobGetJsonTest {
                 new Response(jsonArray, 200, "success"));
 
         final Job job = getJobs.getById("1");
-        assertEquals("https://1:1/zosmf/restjobs/jobs?owner=*&jobid=1", getJobs.getUrl());
+        assertEquals("https://1:443/zosmf/restjobs/jobs?owner=*&jobid=1", getJobs.getUrl());
         assertEquals("jobid", job.getJobId());
         assertEquals("jobname", job.getJobName());
         assertEquals("subsystem", job.getSubSystem());
@@ -153,7 +153,7 @@ public class JobGetJsonTest {
                 new Response(jsonArray, 200, "success"));
 
         final Job job = getJobs.getById("1");
-        assertEquals("https://1:1/zosmf/restjobs/jobs?owner=*&jobid=1", getJobs.getUrl());
+        assertEquals("https://1:443/zosmf/restjobs/jobs?owner=*&jobid=1", getJobs.getUrl());
         assertEquals("job", job.getJobId());
     }
 
@@ -175,7 +175,7 @@ public class JobGetJsonTest {
         final Job job = getJobs.getStatus("BLSJPRMI", "STC00052");
 
         // Validate URL built correctly (no step-data param for getStatus)
-        assertEquals("https://1:1/zosmf/restjobs/jobs/BLSJPRMI/STC00052?step-data=Y", getJobs.getUrl());
+        assertEquals("https://1:443/zosmf/restjobs/jobs/BLSJPRMI/STC00052?step-data=Y", getJobs.getUrl());
 
         // Core job fields
         assertEquals("BLSJPRMI", job.getJobName());
@@ -233,7 +233,7 @@ public class JobGetJsonTest {
         final Job job = getJobs.getStatus("BLSJPRMI", "STC00052");
 
         // Validate URL built correctly (no step-data param for getStatus)
-        assertEquals("https://1:1/zosmf/restjobs/jobs/BLSJPRMI/STC00052?step-data=Y", getJobs.getUrl());
+        assertEquals("https://1:443/zosmf/restjobs/jobs/BLSJPRMI/STC00052?step-data=Y", getJobs.getUrl());
 
         // Core job fields
         assertEquals("BLSJPRMI", job.getJobName());
@@ -282,7 +282,7 @@ public class JobGetJsonTest {
         final CommonJobInputData input = new CommonJobInputData("STC00052", "BLSJPRMI", true);
         final Job job = getJobs.getStatusCommon(input);
 
-        assertEquals("https://1:1/zosmf/restjobs/jobs/BLSJPRMI/STC00052?step-data=Y", getJobs.getUrl());
+        assertEquals("https://1:443/zosmf/restjobs/jobs/BLSJPRMI/STC00052?step-data=Y", getJobs.getUrl());
         assertEquals("BLSJPRMI", job.getJobName());
         assertEquals("STC00052", job.getJobId());
         assertEquals("ACTIVE", job.getStatus());
@@ -367,7 +367,7 @@ public class JobGetJsonTest {
                 null, null, null, null,
                 null, null, null, null,
                 null, null));
-        assertEquals("https://1:1/zosmf/restjobs/jobs/jobName/1?step-data=Y", getJobs.getUrl());
+        assertEquals("https://1:443/zosmf/restjobs/jobs/jobName/1?step-data=Y", getJobs.getUrl());
         assertEquals("jobid", job.getJobId());
         assertEquals("jobname", job.getJobName());
         assertEquals("subsystem", job.getSubSystem());

--- a/src/test/java/zowe/client/sdk/zosjobs/methods/JobGetTextTest.java
+++ b/src/test/java/zowe/client/sdk/zosjobs/methods/JobGetTextTest.java
@@ -35,9 +35,9 @@ import static org.mockito.Mockito.withSettings;
 public class JobGetTextTest {
 
     private final ZosConnection connection = ZosConnectionFactory
-            .createBasicConnection("1", "1", "1", "1");
+            .createBasicConnection("1", 443, "1", "1");
     private final ZosConnection tokenConnection = ZosConnectionFactory
-            .createTokenConnection("1", "1", new Cookie("hello=hello"));
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
     private GetTextZosmfRequest mockTextGetRequest;
 
     @BeforeEach
@@ -53,7 +53,7 @@ public class JobGetTextTest {
         Whitebox.setInternalState(getJobs, "request", mockTextGetRequest);
 
         final String results = getJobs.getSpoolContent("jobName", "jobId", 1L);
-        assertEquals("https://1:1/zosmf/restjobs/jobs/jobName/jobId/files/1/records", getJobs.getUrl());
+        assertEquals("https://1:443/zosmf/restjobs/jobs/jobName/jobId/files/1/records", getJobs.getUrl());
         assertEquals("1\n2\n3\n", results);
     }
 
@@ -73,7 +73,7 @@ public class JobGetTextTest {
         String results = getJobs.getSpoolContent("jobName", "jobId", 1L);
         assertEquals("{X-CSRF-ZOSMF-HEADER=true, Content-Type=text/plain; charset=UTF-8}",
                 mockTextGetRequestToken.getHeaders().toString());
-        assertEquals("https://1:1/zosmf/restjobs/jobs/jobName/jobId/files/1/records", getJobs.getUrl());
+        assertEquals("https://1:443/zosmf/restjobs/jobs/jobName/jobId/files/1/records", getJobs.getUrl());
         assertEquals("1\n2\n3\n", results);
     }
 

--- a/src/test/java/zowe/client/sdk/zosjobs/methods/JobSubmitTest.java
+++ b/src/test/java/zowe/client/sdk/zosjobs/methods/JobSubmitTest.java
@@ -43,11 +43,11 @@ import static org.mockito.Mockito.*;
 public class JobSubmitTest {
 
     private final ZosConnection connection = ZosConnectionFactory
-            .createBasicConnection("1", "1", "1", "1");
+            .createBasicConnection("1", 443, "1", "1");
     private final ZosConnection tokenConnection = ZosConnectionFactory
-            .createTokenConnection("1", "1", new Cookie("hello=hello"));
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
     private PutJsonZosmfRequest mockPutJsonZosmfRequest;
-    private PutTextZosmfRequest mockPutTextZosmfRequest ;
+    private PutTextZosmfRequest mockPutTextZosmfRequest;
     private PutJsonZosmfRequest mockPutJsonZosmfRequestToken;
     @TempDir
     private Path tempDir;
@@ -95,7 +95,7 @@ public class JobSubmitTest {
     public void tstJobSubmitSuccess() throws ZosmfRequestException {
         final JobSubmit jobSubmit = new JobSubmit(connection, mockPutJsonZosmfRequest);
         final Job job = jobSubmit.submit("TEST.DATASET");
-        assertEquals("https://1:1/zosmf/restjobs/jobs", mockPutJsonZosmfRequest.getUrl());
+        assertEquals("https://1:443/zosmf/restjobs/jobs", mockPutJsonZosmfRequest.getUrl());
         assertEquals("jobid", job.getJobId());
         assertEquals("jobname", job.getJobName());
         assertEquals("subsystem", job.getSubSystem());
@@ -116,7 +116,7 @@ public class JobSubmitTest {
         final Job job = jobSubmit.submit("TEST.DATASET");
         assertEquals("{X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
                 mockPutJsonZosmfRequestToken.getHeaders().toString());
-        assertEquals("https://1:1/zosmf/restjobs/jobs", mockPutJsonZosmfRequestToken.getUrl());
+        assertEquals("https://1:443/zosmf/restjobs/jobs", mockPutJsonZosmfRequestToken.getUrl());
         assertEquals("jobid", job.getJobId());
         assertEquals("jobname", job.getJobName());
         assertEquals("subsystem", job.getSubSystem());

--- a/src/test/java/zowe/client/sdk/zoslogs/method/ZosLogTest.java
+++ b/src/test/java/zowe/client/sdk/zoslogs/method/ZosLogTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class ZosLogTest {
 
     private final ZosConnection connection = ZosConnectionFactory
-            .createBasicConnection("1", "1", "1", "1");
+            .createBasicConnection("1", 443, "1", "1");
 
     private GetJsonZosmfRequest mockJsonGetRequest;
 

--- a/src/test/java/zowe/client/sdk/zosmfinfo/methods/ZosmfStatusTest.java
+++ b/src/test/java/zowe/client/sdk/zosmfinfo/methods/ZosmfStatusTest.java
@@ -31,9 +31,9 @@ import static org.junit.jupiter.api.Assertions.*;
 public class ZosmfStatusTest {
 
     private final ZosConnection connection = ZosConnectionFactory
-            .createBasicConnection("1", "1", "1", "1");
+            .createBasicConnection("1", 443, "1", "1");
     private final ZosConnection tokenConnection = ZosConnectionFactory
-            .createTokenConnection("1", "1", new Cookie("hello=hello"));
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
     private GetJsonZosmfRequest mockJsonGetRequest;
 
     @BeforeEach
@@ -61,7 +61,7 @@ public class ZosmfStatusTest {
         ZosmfInfoResponse info = status.get();
 
         assertNotNull(info);
-        assertEquals("https://1:1/zosmf", connection.getZosmfUrl());
+        assertEquals("https://1:443/zosmf", connection.getZosmfUrl());
         assertEquals("REALM", info.getZosmfSafRealm());
         assertEquals("1234", info.getZosmfPort());
         assertEquals("v1", info.getZosmfFullVersion());

--- a/src/test/java/zowe/client/sdk/zostso/methods/TsoPingTest.java
+++ b/src/test/java/zowe/client/sdk/zostso/methods/TsoPingTest.java
@@ -75,7 +75,7 @@ public class TsoPingTest {
     public void tstTsoPingSetsCorrectHeadersSuccess() throws Exception {
         PutJsonZosmfRequest putJsonZosmfRequest = Mockito.mock(PutJsonZosmfRequest.class,
                 withSettings().useConstructor(ZosConnectionFactory
-                        .createBasicConnection("1", "1", "1", "1")));
+                        .createBasicConnection("1", 443, "1", "1")));
 
         doCallRealMethod().when(putJsonZosmfRequest).setStandardHeaders();
         doCallRealMethod().when(putJsonZosmfRequest).setHeaders(anyMap());

--- a/src/test/java/zowe/client/sdk/zostso/methods/TsoReplyTest.java
+++ b/src/test/java/zowe/client/sdk/zostso/methods/TsoReplyTest.java
@@ -76,7 +76,7 @@ public class TsoReplyTest {
     public void tstTsoReplySetsCorrectHeadersSuccess() throws Exception {
         PutJsonZosmfRequest putJsonZosmfRequest = Mockito.mock(PutJsonZosmfRequest.class,
                 withSettings().useConstructor(ZosConnectionFactory
-                        .createBasicConnection("1", "1", "1", "1")));
+                        .createBasicConnection("1", 443, "1", "1")));
 
         doCallRealMethod().when(putJsonZosmfRequest).setStandardHeaders();
         doCallRealMethod().when(putJsonZosmfRequest).setHeaders(anyMap());

--- a/src/test/java/zowe/client/sdk/zostso/methods/TsoSendTest.java
+++ b/src/test/java/zowe/client/sdk/zostso/methods/TsoSendTest.java
@@ -57,7 +57,7 @@ public class TsoSendTest {
         PutJsonZosmfRequest putJsonZosmfRequest = Mockito.mock(
                 PutJsonZosmfRequest.class,
                 withSettings().useConstructor(
-                        ZosConnectionFactory.createBasicConnection("1", "1", "1", "1")
+                        ZosConnectionFactory.createBasicConnection("1", 443, "1", "1")
                 )
         );
 

--- a/src/test/java/zowe/client/sdk/zostso/methods/TsoStartTest.java
+++ b/src/test/java/zowe/client/sdk/zostso/methods/TsoStartTest.java
@@ -243,7 +243,7 @@ public class TsoStartTest {
         // withSettings().useConstructor() to force constructor being used.
         PostJsonZosmfRequest postJsonZosmfRequest = Mockito.mock(PostJsonZosmfRequest.class,
                 withSettings().useConstructor(ZosConnectionFactory
-                        .createBasicConnection("1", "1", "1", "1")));
+                        .createBasicConnection("1", 443, "1", "1")));
 
         doCallRealMethod().when(postJsonZosmfRequest).setStandardHeaders();
         doCallRealMethod().when(postJsonZosmfRequest).setHeaders(anyMap());

--- a/src/test/java/zowe/client/sdk/zostso/methods/TsoStopTest.java
+++ b/src/test/java/zowe/client/sdk/zostso/methods/TsoStopTest.java
@@ -75,7 +75,7 @@ public class TsoStopTest {
     public void tstTsoStopSetsCorrectHeadersSuccess() throws Exception {
         DeleteJsonZosmfRequest deleteJsonZosmfRequest = Mockito.mock(DeleteJsonZosmfRequest.class,
                 withSettings().useConstructor(ZosConnectionFactory
-                        .createBasicConnection("1", "1", "1", "1")));
+                        .createBasicConnection("1", 443, "1", "1")));
 
         doCallRealMethod().when(deleteJsonZosmfRequest).setStandardHeaders();
         doCallRealMethod().when(deleteJsonZosmfRequest).setHeaders(anyMap());


### PR DESCRIPTION
Change zosmfPort in ZosConnection from String to int.

This is a breaking change and will be released in version 6.0.0.