### PR TITLE
Reintroduce Builder Pattern for Job Class

### DIFF
--- a/src/main/java/zowe/client/sdk/zosjobs/README.md
+++ b/src/main/java/zowe/client/sdk/zosjobs/README.md
@@ -101,11 +101,7 @@ public class JobCancelExp extends TstZosConnection {
         jobId = "xxx";
         jobName = "xxx";
         try {
-            Job job = new Job(jobId, "jobName", null, null, null,
-                    null, null, null, null, null,
-                    null, null, null, null,
-                    null, null, null, null,
-                    null, null);
+            Job job = new Job(Job.builder().jobId(jobId).jobName("jobName").build());
             return new JobCancel(connection).cancelByJob(job, null);
         } catch (ZosmfRequestException e) {
             String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
@@ -229,11 +225,7 @@ public class JobDeleteExp extends TstZosConnection {
         jobId = "xxx";
         jobName = "xxx";
         try {
-            Job job =new Job(jobId, "jobName", null, null, null,
-                    null, null, null, null, null,
-                    null, null, null, null,
-                    null, null, null, null,
-                    null, null);
+            Job job = new Job(Job.builder().jobId(jobId).jobName("jobName").build());
             return new JobDelete(connection).deleteByJob(job, null);
         } catch (ZosmfRequestException e) {
             String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
@@ -276,8 +268,10 @@ import zowe.client.sdk.zosjobs.input.JobGetInputData;
 import zowe.client.sdk.zosjobs.methods.JobGet;
 import zowe.client.sdk.zosjobs.model.Job;
 import zowe.client.sdk.zosjobs.model.JobFile;
+
 import java.util.Arrays;
 import java.util.List;
+
 /**
  * Class example to showcase JobGet class functionality.
  *
@@ -752,12 +746,8 @@ public class JobMonitorExp extends TstZosConnection {
      * @author Frank Giordano
      */
     public static void monitorJobForStatusByJobObject(JobStatus.Type statusType) {
-        // determine an existing job in your system that is in execute queue and make a Job for it
-        Job job = new Job("xxx", "xxx", null, null, null,
-                null, null, null, null, null,
-                null, null, null, null,
-                null, null, null, null,
-                null, null);
+        // define an existing job in your system that is in execute queue
+        Job job = new Job(Job.builder().jobId("xxx").jobName("xxx").build());
         JobMonitor jobMonitor = new JobMonitor(connection);
         try {
             job = jobMonitor.waitByStatus(job, statusType);
@@ -777,12 +767,8 @@ public class JobMonitorExp extends TstZosConnection {
      * @author Frank Giordano
      */
     public static void monitorJobForStatusByJobNameAndId(JobStatus.Type statusType) {
-        // determine an existing job in your system that is in execute queue and make a Job for it
-        Job job = new Job("xxx", "xxx", null, null, null,
-                null, null, null, null, null,
-                null, null, null, null,
-                null, null, null, null,
-                null, null);
+        // define an existing job in your system that is in execute queue
+        Job job = new Job(Job.builder().jobId("xxx").jobName("xxx").build());
         JobMonitor jobMonitor = new JobMonitor(connection);
         try {
             String jobName = job.getJobName();
@@ -804,12 +790,8 @@ public class JobMonitorExp extends TstZosConnection {
      * @author Frank Giordano
      */
     public static void monitorWaitForJobMessage(String message) {
-        // determine an existing job in your system that is in execute queue and make a Job for it
-        Job job = new Job("xxx", "xxx", null, null, null,
-                null, null, null, null, null,
-                null, null, null, null,
-                null, null, null, null,
-                null, null);
+        // define an existing job in your system that is in execute queue
+        Job job = new Job(Job.builder().jobId("xxx").jobName("xxx").build());
         JobMonitor jobMonitor = new JobMonitor(connection);
         try {
             System.out.println("Found message = " + jobMonitor.waitByMessage(job, message));
@@ -891,7 +873,7 @@ public class JobSubmitExp extends TstZosConnection {
                     .orElse(e.getMessage());
             throw new RuntimeException(errMsg);
         }
-        
+
     }
 
     /**

--- a/src/main/java/zowe/client/sdk/zosjobs/model/Job.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/model/Job.java
@@ -99,7 +99,6 @@ public class Job {
 
     /**
      * Member name of the z/OS system on which the job ran (up to 8 characters)
-     *
      */
     private final String execMember;
 
@@ -122,6 +121,20 @@ public class Job {
      * Text identifying one or more reasons why the job is not running
      */
     private final String reasonNotRunning;
+
+    /* Null-handling helpers */
+
+    private static String orEmpty(String value) {
+        return value == null ? "" : value;
+    }
+
+    private static JobStepData[] orEmpty(JobStepData[] value) {
+        return value == null ? new JobStepData[0] : value;
+    }
+
+    private static Long orZero(Long value) {
+        return value == null ? 0L : value;
+    }
 
     /**
      * Job constructor for Jackson JSON parsing.
@@ -169,53 +182,204 @@ public class Job {
             @JsonProperty("exec-started") final String execStarted,
             @JsonProperty("exec-ended") final String execEnded,
             @JsonProperty("reason-not-running") final String reasonNotRunning) {
-        this.jobId = id == null ? "" : id;
-        this.jobName = name == null ? "" : name;
-        this.subSystem = subSystem == null ? "" : subSystem;
-        this.owner = owner == null ? "" : owner;
-        this.status = status == null ? "" : status;
-        this.type = type == null ? "" : type;
-        this.classs = classs == null ? "" : classs;
-        this.retCode = retCode == null ? "" : retCode;
-        this.stepData = stepData == null ? new JobStepData[0] : stepData;
-        this.url = url == null ? "" : url;
-        this.filesUrl = filesUrl == null ? "" : filesUrl;
-        this.jobCorrelator = jobCorrelator == null ? "" : jobCorrelator;
-        this.phase = phase == null ? 0L : phase;
-        this.phaseName = phaseName == null ? "" : phaseName;
-        this.execSystem = execSystem == null ? "" : execSystem;
-        this.execMember = execMember == null ? "" : execMember;
-        this.execSubmitted = execSubmitted == null ? "" : execSubmitted;
-        this.execStarted = execStarted == null ? "" : execStarted;
-        this.execEnded = execEnded == null ? "" : execEnded;
-        this.reasonNotRunning = reasonNotRunning == null ? "" : reasonNotRunning;
+
+        this.jobId = orEmpty(id);
+        this.jobName = orEmpty(name);
+        this.subSystem = orEmpty(subSystem);
+        this.owner = orEmpty(owner);
+        this.status = orEmpty(status);
+        this.type = orEmpty(type);
+        this.classs = orEmpty(classs);
+        this.retCode = orEmpty(retCode);
+        this.stepData = orEmpty(stepData);
+        this.url = orEmpty(url);
+        this.filesUrl = orEmpty(filesUrl);
+        this.jobCorrelator = orEmpty(jobCorrelator);
+        this.phase = orZero(phase);
+        this.phaseName = orEmpty(phaseName);
+        this.execSystem = orEmpty(execSystem);
+        this.execMember = orEmpty(execMember);
+        this.execSubmitted = orEmpty(execSubmitted);
+        this.execStarted = orEmpty(execStarted);
+        this.execEnded = orEmpty(execEnded);
+        this.reasonNotRunning = orEmpty(reasonNotRunning);
+    }
+
+    /* Builder */
+
+    /**
+     * Create a new {@link Builder} for {@link Job}.
+     *
+     * @return builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
     }
 
     /**
-     * Retrieve classs specified
-     *
-     * @return classs value
+     * Builder for {@link Job}.
+     * <p>
+     * Required fields:
+     * <ul>
+     *   <li>{@code jobId}</li>
+     *   <li>{@code jobName}</li>
+     * </ul>
      */
-    public String getClasss() {
-        return classs;
-    }
+    public static final class Builder {
 
-    /**
-     * Retrieve filesUrl specified
-     *
-     * @return filesUrl value
-     */
-    public String getFilesUrl() {
-        return filesUrl;
-    }
+        private String jobId;
+        private String jobName;
+        private String subSystem;
+        private String owner;
+        private String status;
+        private String type;
+        private String classs;
+        private String retCode;
+        private JobStepData[] stepData;
+        private String url;
+        private String filesUrl;
+        private String jobCorrelator;
+        private Long phase;
+        private String phaseName;
+        private String execSystem;
+        private String execMember;
+        private String execSubmitted;
+        private String execStarted;
+        private String execEnded;
+        private String reasonNotRunning;
 
-    /**
-     * Retrieve jobCorrelator specified
-     *
-     * @return jobCorrelator value
-     */
-    public String getJobCorrelator() {
-        return jobCorrelator;
+        private Builder() {
+        }
+
+        public Builder jobId(String jobId) {
+            this.jobId = jobId;
+            return this;
+        }
+
+        public Builder jobName(String jobName) {
+            this.jobName = jobName;
+            return this;
+        }
+
+        public Builder subSystem(String subSystem) {
+            this.subSystem = subSystem;
+            return this;
+        }
+
+        public Builder owner(String owner) {
+            this.owner = owner;
+            return this;
+        }
+
+        public Builder status(String status) {
+            this.status = status;
+            return this;
+        }
+
+        public Builder type(String type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder classs(String classs) {
+            this.classs = classs;
+            return this;
+        }
+
+        public Builder retCode(String retCode) {
+            this.retCode = retCode;
+            return this;
+        }
+
+        public Builder stepData(JobStepData[] stepData) {
+            this.stepData = stepData;
+            return this;
+        }
+
+        public Builder url(String url) {
+            this.url = url;
+            return this;
+        }
+
+        public Builder filesUrl(String filesUrl) {
+            this.filesUrl = filesUrl;
+            return this;
+        }
+
+        public Builder jobCorrelator(String jobCorrelator) {
+            this.jobCorrelator = jobCorrelator;
+            return this;
+        }
+
+        public Builder phase(Long phase) {
+            this.phase = phase;
+            return this;
+        }
+
+        public Builder phaseName(String phaseName) {
+            this.phaseName = phaseName;
+            return this;
+        }
+
+        public Builder execSystem(String execSystem) {
+            this.execSystem = execSystem;
+            return this;
+        }
+
+        public Builder execMember(String execMember) {
+            this.execMember = execMember;
+            return this;
+        }
+
+        public Builder execSubmitted(String execSubmitted) {
+            this.execSubmitted = execSubmitted;
+            return this;
+        }
+
+        public Builder execStarted(String execStarted) {
+            this.execStarted = execStarted;
+            return this;
+        }
+
+        public Builder execEnded(String execEnded) {
+            this.execEnded = execEnded;
+            return this;
+        }
+
+        public Builder reasonNotRunning(String reasonNotRunning) {
+            this.reasonNotRunning = reasonNotRunning;
+            return this;
+        }
+
+        /**
+         * Build a {@link Job}.
+         *
+         * @return immutable {@link Job}
+         */
+        public Job build() {
+            return new Job(
+                    jobId,
+                    jobName,
+                    subSystem,
+                    owner,
+                    status,
+                    type,
+                    classs,
+                    retCode,
+                    stepData,
+                    url,
+                    filesUrl,
+                    jobCorrelator,
+                    phase,
+                    phaseName,
+                    execSystem,
+                    execMember,
+                    execSubmitted,
+                    execStarted,
+                    execEnded,
+                    reasonNotRunning
+            );
+        }
     }
 
     /**
@@ -237,12 +401,92 @@ public class Job {
     }
 
     /**
+     * Retrieve subSystem specified
+     *
+     * @return subSystem value
+     */
+    public String getSubSystem() {
+        return subSystem;
+    }
+
+    /**
      * Retrieve an owner specified
      *
      * @return owner value
      */
     public String getOwner() {
         return owner;
+    }
+
+    /**
+     * Retrieve status specified
+     *
+     * @return status value
+     */
+    public String getStatus() {
+        return status;
+    }
+      /**
+     * Retrieve type specified
+     *
+     * @return type value
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * Retrieve classs specified
+     *
+     * @return classs value
+     */
+    public String getClasss() {
+        return classs;
+    }
+
+    /**
+     * Retrieve retCode specified
+     *
+     * @return retCode value
+     */
+    public String getRetCode() {
+        return retCode;
+    }
+
+    /**
+     * Retrieve stepData specified
+     *
+     * @return stepData value
+     */
+    public JobStepData[] getStepData() {
+        return stepData;
+    }
+
+    /**
+     * Retrieve url specified
+     *
+     * @return url value
+     */
+    public String getUrl() {
+        return url;
+    }
+
+    /**
+     * Retrieve filesUrl specified
+     *
+     * @return filesUrl value
+     */
+    public String getFilesUrl() {
+        return filesUrl;
+    }
+
+    /**
+     * Retrieve jobCorrelator specified
+     *
+     * @return jobCorrelator value
+     */
+    public String getJobCorrelator() {
+        return jobCorrelator;
     }
 
     /**
@@ -261,60 +505,6 @@ public class Job {
      */
     public String getPhaseName() {
         return phaseName;
-    }
-
-    /**
-     * Retrieve retCode specified
-     *
-     * @return retCode value
-     */
-    public String getRetCode() {
-        return retCode;
-    }
-
-    /**
-     * Retrieve status specified
-     *
-     * @return status value
-     */
-    public String getStatus() {
-        return status;
-    }
-
-    /**
-     * Retrieve stepData specified
-     *
-     * @return stepData value
-     */
-    public JobStepData[] getStepData() {
-        return stepData;
-    }
-
-    /**
-     * Retrieve subSystem specified
-     *
-     * @return subSystem value
-     */
-    public String getSubSystem() {
-        return subSystem;
-    }
-
-    /**
-     * Retrieve type specified
-     *
-     * @return type value
-     */
-    public String getType() {
-        return type;
-    }
-
-    /**
-     * Retrieve url specified
-     *
-     * @return url value
-     */
-    public String getUrl() {
-        return url;
     }
 
     /**

--- a/src/test/java/zowe/client/sdk/zosjobs/methods/JobCancelTest.java
+++ b/src/test/java/zowe/client/sdk/zosjobs/methods/JobCancelTest.java
@@ -196,37 +196,17 @@ public class JobCancelTest {
 
         // jobName is null or empty
         exception = assertThrows(IllegalArgumentException.class, () ->
-                jobCancel.cancelByJob(
-                        new Job("1", null, null, null, null,
-                                null, null, null, null, null,
-                                null, null, null, null,
-                                null, null, null, null,
-                                null, null),
-                        "1"));
+                jobCancel.cancelByJob(Job.builder().jobId("1").build(), "1"));
         assertTrue(exception.getMessage().contains("jobName is either null or empty"));
 
         // jobId is null or empty
         exception = assertThrows(IllegalArgumentException.class, () ->
-                jobCancel.cancelByJob(
-                        new Job(
-                                null, "name", null, null, null,
-                                null, null, null, null, null,
-                                null, null, null, null,
-                                null, null, null, null,
-                                null, null),
-                        "1"));
+                jobCancel.cancelByJob(Job.builder().jobName("name").build(), "1"));
         assertTrue(exception.getMessage().contains("jobId is either null or empty"));
 
         // invalid version specified
         exception = assertThrows(IllegalArgumentException.class, () ->
-                jobCancel.cancelByJob(
-                        new Job(
-                                "name", "1", null, null, null,
-                                null, null, null, null, null,
-                                null, null, null, null,
-                                null, null, null, null,
-                                null, null),
-                        "4"));
+                jobCancel.cancelByJob(Job.builder().jobId("name").jobName("1").build(), "4"));
         assertTrue(exception.getMessage().contains("invalid version specified"));
     }
 

--- a/src/test/java/zowe/client/sdk/zosjobs/methods/JobGetJsonTest.java
+++ b/src/test/java/zowe/client/sdk/zosjobs/methods/JobGetJsonTest.java
@@ -346,11 +346,7 @@ public class JobGetJsonTest {
     public void tstJobGetJsonStatusForJobNoParamsExceptionFailure() throws ZosmfRequestException {
         String errorMsg = "";
         try {
-            getJobs.getStatusByJob(new Job(null, null, null, null, null,
-                    null, null, null, null, null,
-                    null, null, null, null,
-                    null, null, null, null,
-                    null, null));
+            getJobs.getStatusByJob(Job.builder().build());
         } catch (IllegalStateException e) {
             errorMsg = e.getMessage();
         }
@@ -362,11 +358,7 @@ public class JobGetJsonTest {
         Mockito.when(mockJsonGetRequest.executeRequest()).thenReturn(
                 new Response(jobJson, 200, "success"));
 
-        final Job job = getJobs.getStatusByJob(new Job("1", "jobName", null, null, null,
-                null, null, null, null, null,
-                null, null, null, null,
-                null, null, null, null,
-                null, null));
+        final Job job = getJobs.getStatusByJob(Job.builder().jobId("1").jobName("jobName").build());
         assertEquals("https://1:443/zosmf/restjobs/jobs/jobName/1?step-data=Y", getJobs.getUrl());
         assertEquals("jobid", job.getJobId());
         assertEquals("jobname", job.getJobName());
@@ -478,11 +470,7 @@ public class JobGetJsonTest {
     public void tstJobGetJsonStatusForJobWithJobIdOnlyExceptionFailure() throws ZosmfRequestException {
         String errorMsg = "";
         try {
-            getJobs.getStatusByJob(new Job("1", null, null, null, null,
-                    null, null, null, null, null,
-                    null, null, null, null,
-                    null, null, null, null,
-                    null, null));
+            getJobs.getStatusByJob(Job.builder().jobId("1").build());
         } catch (IllegalStateException e) {
             errorMsg = e.getMessage();
         }
@@ -493,11 +481,7 @@ public class JobGetJsonTest {
     public void tstJobGetJsonStatusForJobWithJobNameOnlyExceptionFailure() throws ZosmfRequestException {
         String errorMsg = "";
         try {
-            getJobs.getStatusByJob(new Job(null, "jobName", null, null, null,
-                    null, null, null, null, null,
-                    null, null, null, null,
-                    null, null, null, null,
-                    null, null));
+            getJobs.getStatusByJob(Job.builder().jobName("jobName").build());
         } catch (IllegalStateException e) {
             errorMsg = e.getMessage();
         }


### PR DESCRIPTION
Description:
The Job class previously had a builder pattern that was removed under the assumption that end users would only work with Job objects returned from API JSON responses.

Upon further review, it became clear that there are legitimate use cases where end users may need to construct a Job object manually. Without the builder, creating a Job instance requires passing a large number of null values, which is cumbersome and error-prone.

This PR reintroduces the builder pattern for the Job class:

- Users can now create Job objects in a clean, readable manner.
- All fields default to the existing null/empty normalization behavior.
- Existing Jackson JSON deserialization is fully compatible and unaffected.

Example usage:

        Job job = Job.builder()
                     .jobId("1")
                     .jobName("MyJob")
                     .build();

This change improves readability, maintainability, and developer experience for both internal SDK usage and end-user code.