### PR TITLE
Simplify ZosmfRequestException handling across all examples

### DIFF
--- a/src/main/java/zowe/client/sdk/zosconsole/README.md
+++ b/src/main/java/zowe/client/sdk/zosconsole/README.md
@@ -49,8 +49,14 @@ public class IssueConsoleExp extends TstZosConnection {
             ConsoleCmd consoleCmd = new ConsoleCmd(connection);
             response = consoleCmd.issueCommand(cmd);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
 
         System.out.println(response.getCmdResponse());
@@ -71,8 +77,14 @@ public class IssueConsoleExp extends TstZosConnection {
             consoleInputData.setProcessResponse();
             response = consoleCmd.issueCommandCommon(ConsoleConstants.RES_DEF_CN, consoleInputData);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
 
         System.out.println(response.getCmdResponse());

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/README.md
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/README.md
@@ -72,8 +72,14 @@ public class DsnCopyExp extends TstZosConnection {
             DsnCopy dsnCopy = new DsnCopy(connection);
             response = dsnCopy.copy(fromDataSetName, toDataSetName, true, false);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
 
         System.out.println(response.toString());
@@ -105,8 +111,14 @@ public class DsnCopyExp extends TstZosConnection {
             DsnCopyInputData dsnCopyInputData = new DsnCopyInputData.Builder().fromDataSet(fromDataSetName).toDataSet(toDataSetName).build();
             response = dsnCopy.copyCommon(dsnCopyInputData);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
 
         System.out.println(response.toString());
@@ -137,8 +149,14 @@ public class DsnCopyExp extends TstZosConnection {
                     .copyAllMembers(true).build();
             response = dsnCopy.copyCommon(dsnCopyInputData);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
 
         System.out.println(response.toString());
@@ -198,8 +216,14 @@ public class DsnCreateExp extends TstZosConnection {
             DsnCreate dsnCreate = new DsnCreate(connection);
             response = dsnCreate.create(dataSetName, sequential());
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
 
         System.out.println(response.toString());
@@ -217,8 +241,14 @@ public class DsnCreateExp extends TstZosConnection {
             DsnCreate dsnCreate = new DsnCreate(connection);
             response = dsnCreate.create(dataSetName, partitioned());
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
 
         System.out.println(response.toString());
@@ -362,8 +392,14 @@ public class DsnGetInfoExp extends TstZosConnection {
             DsnGet dsnGet = new DsnGet(connection);
             return dsnGet.getDsnInfo(dataSetName);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
     }
 
@@ -420,8 +456,14 @@ public class DsnDeleteExp extends TstZosConnection {
             DsnDelete zosDsn = new DsnDelete(connection);
             response = zosDsn.delete(dataSetName);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
 
         System.out.println(response.toString());
@@ -440,8 +482,14 @@ public class DsnDeleteExp extends TstZosConnection {
             DsnDelete zosDsn = new DsnDelete(connection);
             response = zosDsn.delete(dataSetName, member);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
 
         System.out.println(response.toString());
@@ -629,8 +677,14 @@ public class DsnListExp extends TstZosConnection {
             DsnList dsnList = new DsnList(connection);
             datasets = dsnList.getMembers(dataSetName, dsnListInputData);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
         datasets.forEach(m -> System.out.println(m.toString()));
     }
@@ -649,8 +703,14 @@ public class DsnListExp extends TstZosConnection {
             DsnList dsnList = new DsnList(connection);
             datasets = dsnList.getMembers(dataSetName, dsnListInputData);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
         datasets.forEach(m -> System.out.println(m.toString()));
     }
@@ -669,8 +729,14 @@ public class DsnListExp extends TstZosConnection {
             DsnList dsnList = new DsnList(connection);
             datasets = dsnList.getDatasets(dataSetName, dsnListInputData);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
         datasets.forEach(System.out::println);
     }
@@ -689,8 +755,14 @@ public class DsnListExp extends TstZosConnection {
             DsnList dsnList = new DsnList(connection);
             datasets = dsnList.getDatasets(dataSetName, dsnListInputData);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
         datasets.forEach(System.out::println);
     }
@@ -752,8 +824,14 @@ public class DsnWriteExp extends TstZosConnection {
             DsnWrite dsnWrite = new DsnWrite(connection);
             response = dsnWrite.write(dataSetName, member, content);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
 
         System.out.println(response.toString());
@@ -772,8 +850,14 @@ public class DsnWriteExp extends TstZosConnection {
             DsnWrite dsnWrite = new DsnWrite(connection);
             response = dsnWrite.write(dataSetName, content);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
 
         System.out.println(response.toString());

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/README.md
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/README.md
@@ -60,8 +60,14 @@ public class UssCreateExp extends TstZosConnection {
             UssCreateInputData ussCreateInputData = new UssCreateInputData(CreateType.DIR, "-wx-wx-wx");
             return ussCreate.create(value, ussCreateInputData);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
     }
 
@@ -78,8 +84,14 @@ public class UssCreateExp extends TstZosConnection {
             UssCreateInputData ussCreateInputData = new UssCreateInputData(CreateType.FILE, "-wx-wx-wx");
             return ussCreate.create(value, ussCreateInputData);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
     }
 
@@ -137,8 +149,14 @@ public class UssDeleteExp extends TstZosConnection {
         try {
             return ussDelete.delete(value);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
     }
 
@@ -153,8 +171,14 @@ public class UssDeleteExp extends TstZosConnection {
         try {
             return ussDelete.delete(value, true);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
     }
 
@@ -228,8 +252,14 @@ public class UssGetExp extends TstZosConnection {
             UssGetInputData ussGetInputData = new UssGetInputData.Builder().insensitive(false).search("apple").build();
             response = ussGet.getCommon(fileNamePath, ussGetInputData);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
 
         System.out.println(response.getResponsePhrase().orElse("no response phrase"));
@@ -249,8 +279,14 @@ public class UssGetExp extends TstZosConnection {
             UssGetInputData ussGetInputData = new UssGetInputData.Builder().insensitive(false).search("Apple").build();
             response = ussGet.getCommon(fileNamePath, ussGetInputData);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
 
         System.out.println(response.getResponsePhrase().orElse("no response phrase"));
@@ -268,8 +304,14 @@ public class UssGetExp extends TstZosConnection {
             UssGet ussGet = new UssGet(connection);
             content = ussGet.getText(fileNamePath);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
 
         System.out.println(content);
@@ -288,8 +330,14 @@ public class UssGetExp extends TstZosConnection {
             UssGetInputData ussGetInputData = new UssGetInputData.Builder().recordsRange("-2").build();
             response = ussGet.getCommon(fileNamePath, ussGetInputData);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
 
         System.out.println(response.getResponsePhrase().orElse("no response phrase"));
@@ -353,8 +401,14 @@ public class UssListExp extends TstZosConnection {
             UssListZfsInputData ussListZfsInputData = new UssListZfsInputData.Builder().path(value).build();
             items = ussList.getZfsSystems(ussListZfsInputData);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
 
         items.forEach(System.out::println);
@@ -373,8 +427,14 @@ public class UssListExp extends TstZosConnection {
             UssListInputData ussListInputData = new UssListInputData.Builder().path(value).build();
             items = ussList.getFiles(ussListInputData);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
 
         items.forEach(System.out::println);

--- a/src/main/java/zowe/client/sdk/zosjobs/README.md
+++ b/src/main/java/zowe/client/sdk/zosjobs/README.md
@@ -65,8 +65,14 @@ public class JobCancelExp extends TstZosConnection {
         try {
             return new JobCancel(connection).cancelCommon(modifyInputData);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
     }
 
@@ -85,8 +91,14 @@ public class JobCancelExp extends TstZosConnection {
         try {
             return new JobCancel(connection).cancelCommon(modifyInputData);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
     }
 
@@ -104,8 +116,14 @@ public class JobCancelExp extends TstZosConnection {
             Job job = new Job(Job.builder().jobId(jobId).jobName("jobName").build());
             return new JobCancel(connection).cancelByJob(job, null);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
     }
 
@@ -122,8 +140,14 @@ public class JobCancelExp extends TstZosConnection {
         try {
             return new JobCancel(connection).cancel(jobName, jobId, null);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
     }
 
@@ -189,8 +213,14 @@ public class JobDeleteExp extends TstZosConnection {
         try {
             return new JobDelete(connection).deleteCommon(jobModifyInputData);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
     }
 
@@ -209,8 +239,14 @@ public class JobDeleteExp extends TstZosConnection {
         try {
             return new JobDelete(connection).deleteCommon(jobModifyInputData);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
     }
 
@@ -228,8 +264,14 @@ public class JobDeleteExp extends TstZosConnection {
             Job job = new Job(Job.builder().jobId(jobId).jobName("jobName").build());
             return new JobDelete(connection).deleteByJob(job, null);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
     }
 
@@ -246,8 +288,14 @@ public class JobDeleteExp extends TstZosConnection {
         try {
             return new JobDelete(connection).delete(jobName, jobId, null);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
     }
 
@@ -332,8 +380,14 @@ public class JobGetExp extends TstZosConnection {
             String response = jobGet.getJclCommon(commonJobInputData);
             System.out.println(response);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
     }
 
@@ -349,8 +403,14 @@ public class JobGetExp extends TstZosConnection {
             List<Job> jobs = jobGet.getByPrefix(prefix);
             System.out.println(jobGet.getJclByJob(jobs.get(0)));
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
     }
 
@@ -368,8 +428,14 @@ public class JobGetExp extends TstZosConnection {
             String jobId = jobs.get(0).getJobId();
             System.out.println(jobGet.getJcl(jobName, jobId));
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
     }
 
@@ -386,8 +452,14 @@ public class JobGetExp extends TstZosConnection {
             Job job = jobGet.getStatusByJob(jobs.get(0));
             System.out.println(job);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
     }
 
@@ -409,8 +481,14 @@ public class JobGetExp extends TstZosConnection {
             System.out.println(job.toString());
             Arrays.stream(job.getStepData()).forEach(System.out::println);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
     }
 
@@ -429,8 +507,14 @@ public class JobGetExp extends TstZosConnection {
             Job job = jobGet.getStatus(jobName, jobId);
             System.out.println(job.toString());
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
     }
 
@@ -445,8 +529,14 @@ public class JobGetExp extends TstZosConnection {
         try {
             jobGet.getById(jobId);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
     }
 
@@ -464,8 +554,14 @@ public class JobGetExp extends TstZosConnection {
             Job job = jobGet.getById(jobId);
             System.out.println(job.toString());
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
     }
 
@@ -483,8 +579,14 @@ public class JobGetExp extends TstZosConnection {
         try {
             jobs = jobGet.getByOwnerAndPrefix(owner, prefix);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
         jobs.forEach(System.out::println);
     }
@@ -501,8 +603,14 @@ public class JobGetExp extends TstZosConnection {
         try {
             jobs = jobGet.getByPrefix(prefix);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
         jobs.forEach(System.out::println);
     }
@@ -519,8 +627,14 @@ public class JobGetExp extends TstZosConnection {
         try {
             jobs = jobGet.getAll();
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
         jobs.forEach(System.out::println);
     }
@@ -540,8 +654,14 @@ public class JobGetExp extends TstZosConnection {
             List<JobFile> files = jobGet.getSpoolFilesByJob(jobs.get(0));
             output = jobGet.getSpoolContent(files.get(0)).split("\n");
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
         // get last 10 lines of output
         for (int i = output.length - 10; i < output.length; i++) {
@@ -561,8 +681,14 @@ public class JobGetExp extends TstZosConnection {
         try {
             jobs = jobGet.getByOwner(owner);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
         jobs.forEach(System.out::println);
     }
@@ -581,8 +707,14 @@ public class JobGetExp extends TstZosConnection {
             List<Job> jobs = jobGet.getCommon(jobGetInputData);
             files = jobGet.getSpoolFilesByJob(jobs.get(0));
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
         files.forEach(System.out::println);
     }
@@ -603,8 +735,14 @@ public class JobGetExp extends TstZosConnection {
             String jobId = jobs.get(0).getJobId();
             files = jobGet.getSpoolFiles(jobName, jobId);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
         files.forEach(System.out::println);
     }
@@ -688,8 +826,14 @@ public class JobMonitorExp extends TstZosConnection {
         try {
             System.out.println(jobMonitor.isRunning(jobMonitorInputData));
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
     }
 
@@ -708,8 +852,14 @@ public class JobMonitorExp extends TstZosConnection {
             JobMonitor jobMonitor = new JobMonitor(connection);
             job = jobMonitor.waitByOutputStatus(job);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
         System.out.println(job.getStatus());
     }
@@ -731,8 +881,14 @@ public class JobMonitorExp extends TstZosConnection {
             String jobId = job.getJobId();
             job = jobMonitor.waitByOutputStatus(jobName, jobId);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
         System.out.println(job.getStatus());
     }
@@ -752,8 +908,14 @@ public class JobMonitorExp extends TstZosConnection {
         try {
             job = jobMonitor.waitByStatus(job, statusType);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
         System.out.println(job.getStatus());
     }
@@ -775,8 +937,14 @@ public class JobMonitorExp extends TstZosConnection {
             String jobId = job.getJobId();
             job = jobMonitor.waitByStatus(jobName, jobId, statusType);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
         System.out.println(job.getStatus());
     }
@@ -796,8 +964,14 @@ public class JobMonitorExp extends TstZosConnection {
         try {
             System.out.println("Found message = " + jobMonitor.waitByMessage(job, message));
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
     }
 
@@ -862,18 +1036,15 @@ public class JobSubmitExp extends TstZosConnection {
             job = JobSubmitExp.submitByLocalFile(connection, filePath);
             System.out.println("submitByLocalFile output: \n" + job);
         } catch (ZosmfRequestException e) {
-            // Safely extracts the response phrase as a string, ensuring it is neither null nor blank nor empty JSON object;
-            // otherwise, falls back to the exception's default message.
-            Predicate<String> isNotBlankStr = s -> !s.isBlank();
-            Predicate<String> isNotEmptyJson = s -> !s.equals("{}");
-            final String errMsg = Optional.ofNullable(e.getResponse())
-                    .flatMap(Response::getResponsePhrase)
-                    .map(Object::toString)
-                    .filter(isNotBlankStr.and(isNotEmptyJson))
-                    .orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
-
     }
 
     /**

--- a/src/main/java/zowe/client/sdk/zosjobs/model/Job.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/model/Job.java
@@ -426,7 +426,8 @@ public class Job {
     public String getStatus() {
         return status;
     }
-      /**
+
+    /**
      * Retrieve type specified
      *
      * @return type value

--- a/src/main/java/zowe/client/sdk/zoslogs/README.md
+++ b/src/main/java/zowe/client/sdk/zoslogs/README.md
@@ -52,8 +52,14 @@ public class ZosLogExp extends TstZosConnection {
         try {
             zosLogReply = zosLog.issueCommand(zosLogInputData);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
         zosLogReply.getItems().forEach(i -> {
             String msg = i.getTime() + " " + i.getMessage();
@@ -70,8 +76,14 @@ public class ZosLogExp extends TstZosConnection {
         try {
             zosLogReply = zosLog.issueCommand(zosLogInputData);
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
         zosLogReply.getItems().forEach(i -> {
             String msg = i.getTime() + " " + i.getMessage();

--- a/src/main/java/zowe/client/sdk/zosmfinfo/README.md
+++ b/src/main/java/zowe/client/sdk/zosmfinfo/README.md
@@ -42,10 +42,16 @@ public class ZosmfStatusExp extends TstZosConnection {
         ZosmfInfoResponse zosmfInfoResponse;
         try {
             zosmfInfoResponse = zosmfStatus.get();
-        } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+} catch (ZosmfRequestException e) {
+    String errMsg = e.getMessage();
+    if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+        String response = e.getResponse().getResponsePhrase().get().toString();
+        if (!resp.isBlank() && !"{}".equals(response)) {
+            errMsg = response;
         }
+    }
+    throw new RuntimeException(errMsg, e);
+}
         System.out.println(zosmfInfoResponse.toString());
         Arrays.stream(zosmfInfoResponse.getZosmfPluginsInfo()).forEach(System.out::println);
     }
@@ -91,8 +97,14 @@ public class ZosmfSystemsExp extends TstZosConnection {
         try {
             zosmfInfoResponse = zosmfSystems.get();
         } catch (ZosmfRequestException e) {
-            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
-            throw new RuntimeException(errMsg);
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
+                String response = e.getResponse().getResponsePhrase().get().toString();
+                if (!resp.isBlank() && !"{}".equals(response)) {
+                    errMsg = response;
+                }
+            }
+            throw new RuntimeException(errMsg, e);
         }
         System.out.println(zosmfInfoResponse.toString());
         Arrays.stream(zosmfInfoResponse.getDefinedSystems().orElse(new DefinedSystem[0])).forEach(System.out::println);


### PR DESCRIPTION
Description:
This PR updates all example code to use a simplified and safer catch block for ZosmfRequestException. Previously, the examples used:

        } catch (ZosmfRequestException e) {
            String errMsg = (String) e.getResponse().getResponsePhrase().orElse(e.getMessage());
            throw new RuntimeException(errMsg);
        }

While concise, it assumed that getResponse() always returned a non-null Response, which isn’t always true. 

ZosmfRequestException can sometimes contain a Response object (for example, when an HTTP request went through but the server returned an error payload), or it can contain no Response at all (for example, if a network error or client-side exception occurred before a response was created).

To handle both cases safely and cleanly, all examples are updated to:

        } catch (ZosmfRequestException e) {
            String errMsg = e.getMessage();
            if (e.getResponse() != null && e.getResponse().getResponsePhrase().isPresent()) {
                String response = e.getResponse().getResponsePhrase().get().toString();
                if (!resp.isBlank() && !"{}".equals(response)) {
                    errMsg = resp;
                }
            }
            throw new RuntimeException(errMsg, e);
        }

What this change does:

- Safely checks whether a Response exists before trying to access its phrase.
- Ignores empty strings or empty JSON objects ({}) when deciding whether to override the exception message.
- Falls back to the exception’s own message if no useful response is present.
- Improves readability and maintainability of all example code.

Effectively, this gives a robust, “just works” pattern for all examples, making sure no NullPointerException sneaks in while keeping error messages meaningful.