### PR TITLE
Encoding header for dsn get set incorrectly

### DIFF
--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnGet.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnGet.java
@@ -139,8 +139,12 @@ public class DsnGet {
             value = ZosmfHeaders.HEADERS.get("X_IBM_BINARY").get(1);
             headers.put(key, value);
         } else if (downloadInputData.getEncoding().isPresent()) {
-            key = ZosmfHeaders.X_IBM_TEXT;
-            value = ZosmfHeaders.X_IBM_TEXT + ZosmfHeaders.X_IBM_TEXT_ENCODING + downloadInputData.getEncoding();
+            key = ZosmfHeaders.HEADERS.get("X_IBM_TEXT").get(0);
+            value = String.format("%s%sIBM-%s",
+                    ZosmfHeaders.HEADERS.get("X_IBM_TEXT").get(1),
+                    ZosmfHeaders.HEADERS.get("X_IBM_TEXT_ENCODING").get(0),
+                    downloadInputData.getEncoding().getAsLong()
+            );
             headers.put(key, value);
         }
 

--- a/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnGetTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnGetTest.java
@@ -107,6 +107,21 @@ public class DsnGetTest {
     }
 
     @Test
+    public void tstDsnGetTokenWithOnlyEncodingParamsSuccess() throws ZosmfRequestException, IOException {
+        final DsnGet dsnGet = new DsnGet(connection, mockGetRequestToken);
+        final DsnDownloadInputData downloadInputData = new DsnDownloadInputData.Builder()
+                .encoding(1047L)
+                .build();
+        final InputStream inputStream = dsnGet.get("TEST.DATASET", downloadInputData);
+        assertEquals("{X-IBM-Data-Type=text;fileEncoding=IBM-1047, " +
+                        "Accept-Encoding=1047, X-CSRF-ZOSMF-HEADER=true, " +
+                        "Content-Type=application/json}",
+                mockGetRequestToken.getHeaders().toString());
+        assertEquals("test data", new String(inputStream.readAllBytes()));
+        assertEquals("https://1:443/zosmf/restfiles/ds/TEST.DATASET", mockGetRequestToken.getUrl());
+    }
+
+    @Test
     public void tstDsnGetTokenWithMultipleParamsWithoutEncodingSuccess() throws ZosmfRequestException, IOException {
         final DsnGet dsnGet = new DsnGet(connection, mockGetRequestToken);
         final DsnDownloadInputData downloadInputData = new DsnDownloadInputData.Builder()


### PR DESCRIPTION
While fetching data using the Zowe Java SDK, I noticed that Danish characters were rendered incorrectly.

To verify whether this was client-specific, I performed the same operation using Zowe Explorer in Visual Studio Code, where the characters appeared correctly.

I then inspected the HTTP requests sent by both clients and observed a difference in the headers. Requests from Visual Studio Code included:
X-IBM-Data-Type: text;fileEncoding=IBM-277

In contrast, requests made via the Java SDK contained:
X_IBM_TEXT: X_IBM_TEXTX_IBM_TEXT_ENCODINGOptionalLong[277]

This header format did not appear to be correct.

This PR updates the header generation to align with the structure used in the other DsnGet cases. After applying this change, I verified that Danish characters are now rendered correctly when calling Zowe through the Java SDK.