### PR TITLE
Resolve security vulnerabilities in Jackson and Central publishing plugin dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Thin JAR (recommended):
         <dependency>
           <groupId>org.zowe.client.java.sdk</groupId>
           <artifactId>zowe-client-java-sdk</artifactId>
-          <version>6.1.1</version>
+          <version>6.1.2</version>
         </dependency>
   
 Fat JAR (with dependencies):
@@ -257,7 +257,7 @@ Fat JAR (with dependencies):
         <dependency>
           <groupId>org.zowe.client.java.sdk</groupId>
           <artifactId>zowe-client-java-sdk</artifactId>
-          <version>6.1.1</version>
+          <version>6.1.2</version>
           <classifier>jar-with-dependencies</classifier>
         </dependency>  
   
@@ -265,11 +265,11 @@ For a Gradle project add the SDK as a dependency by updating your `build.gradle`
 
 Thin JAR (recommended):  
   
-    implementation group: 'org.zowe.client.java.sdk', name: 'zowe-client-java-sdk', version: '6.1.1'    
+    implementation group: 'org.zowe.client.java.sdk', name: 'zowe-client-java-sdk', version: '6.1.2'    
 
 Fat JAR (with dependencies):  
   
-    implementation group: 'org.zowe.client.java.sdk', name: 'zowe-client-java-sdk', version: '6.1.1', classifier: 'jar-with-dependencies'
+    implementation group: 'org.zowe.client.java.sdk', name: 'zowe-client-java-sdk', version: '6.1.2', classifier: 'jar-with-dependencies'
   
 ## Publishing to Maven Central  
   

--- a/pom.xml
+++ b/pom.xml
@@ -85,8 +85,8 @@
         </dependency>
         <dependency>
             <groupId>com.konghq</groupId>
-            <artifactId>unirest-java-core</artifactId>
-            <version>4.4.5</version>
+            <artifactId>unirest-modules-jackson-legacy</artifactId>
+            <version>4.8.1</version>
         </dependency>
         <dependency>
             <groupId>com.konghq</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.zowe.client.java.sdk</groupId>
     <artifactId>zowe-client-java-sdk</artifactId>
-    <version>6.1.1</version>
+    <version>6.1.2</version>
 
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -217,20 +217,20 @@
                 </executions>
             </plugin>
             <plugin>
-                      <groupId>org.sonatype.central</groupId>
-                      <artifactId>central-publishing-maven-plugin</artifactId>
-                      <version>0.10.0</version>
-                      <extensions>true</extensions>
-                      <configuration>
-                          <publishingServerId>central</publishingServerId>
-                      </configuration>
-                      <dependencies>
-                          <dependency>
-                              <groupId>org.codehaus.plexus</groupId>
-                              <artifactId>plexus-utils</artifactId>
-                              <version>4.0.3</version>
-                          </dependency>
-                      </dependencies>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.10.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <publishingServerId>central</publishingServerId>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codehaus.plexus</groupId>
+                        <artifactId>plexus-utils</artifactId>
+                        <version>4.0.3</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -85,19 +85,13 @@
         </dependency>
         <dependency>
             <groupId>com.konghq</groupId>
-            <artifactId>unirest-modules-jackson-legacy</artifactId>
-            <version>4.8.1</version>
+            <artifactId>unirest-java-core</artifactId>
+            <version>4.4.5</version>
         </dependency>
         <dependency>
             <groupId>com.konghq</groupId>
-            <artifactId>unirest-objectmapper-jackson</artifactId>
-            <version>4.2.4</version>
-        </dependency>
-        <dependency>
-            <groupId>org.sonatype.central</groupId>
-            <artifactId>central-publishing-maven-plugin</artifactId>
-            <version>0.8.0</version>
-            <scope>provided</scope>
+            <artifactId>unirest-modules-jackson-legacy</artifactId>
+            <version>4.8.1</version>
         </dependency>
 
         <!-- Test -->
@@ -221,6 +215,22 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                      <groupId>org.sonatype.central</groupId>
+                      <artifactId>central-publishing-maven-plugin</artifactId>
+                      <version>0.10.0</version>
+                      <extensions>true</extensions>
+                      <configuration>
+                          <publishingServerId>central</publishingServerId>
+                      </configuration>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.codehaus.plexus</groupId>
+                              <artifactId>plexus-utils</artifactId>
+                              <version>4.0.3</version>
+                          </dependency>
+                      </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/zowe/client/sdk/zostso/methods/TsoStart.java
+++ b/src/main/java/zowe/client/sdk/zostso/methods/TsoStart.java
@@ -100,7 +100,9 @@ public class TsoStart {
         try {
             rootNode = objectMapper.readTree(responseStr);
         } catch (JsonProcessingException e) {
-            throw new ZosmfRequestException(e.getMessage(), e);
+            throw new ZosmfRequestException(
+                    "Failed to parse TSO start response: " + responseStr + " | Error: " + e.getMessage(), e
+            );
         }
 
         final JsonNode keyNode = rootNode.get("servletKey");

--- a/src/test/java/zowe/client/sdk/zostso/methods/TsoStartTest.java
+++ b/src/test/java/zowe/client/sdk/zostso/methods/TsoStartTest.java
@@ -98,7 +98,11 @@ public class TsoStartTest {
 
             ZosmfRequestException ex = assertThrows(ZosmfRequestException.class,
                     () -> tsoStart.start(input));
+            assertNotNull(ex.getMessage());
             assertTrue(ex.getMessage().contains("invalid json response"));
+            assertTrue(ex.getMessage().contains("Unrecognized token")
+                            || ex.getMessage().toLowerCase().contains("json")
+            );
         }
     }
 


### PR DESCRIPTION
**Description**

This PR addresses two dependency-related security issues identified by scanning tools.

1. Jackson vulnerability via Unirest module 

See #456

Updated the Unirest Jackson integration dependency to a newer version in order to pull in a patched Jackson stack and resolve the reported vulnerability tied to the previous Jackson-based dependency chain.

Updated dependency:

            <dependency>
                <groupId>com.konghq</groupId>
                <artifactId>unirest-modules-jackson-legacy</artifactId>
                <version>4.8.1</version>
            </dependency>

5. CVE-2025-67030 via central-publishing-maven-plugin 

See #457

Resolved the vulnerability associated with plexus-utils, which was being introduced through central-publishing-maven-plugin.

**Changes made:**

Removed central-publishing-maven-plugin from the main <dependencies> section since it is a build plugin, not a runtime dependency
Upgraded the plugin version in the ci-cd profile
Added an explicit plugin dependency override for a patched plexus-utils version

**Summary of Changes**

- Updated Jackson-related Unirest module to address the reported security issue
- Removed incorrect plugin declaration from project dependencies
- Upgraded central-publishing-maven-plugin
- Overrode plexus-utils in plugin scope to address CVE-2025-67030

**Impact**

- Resolves the two reported security findings
- Keeps publishing behavior scoped correctly to build/profile usage
- No intended runtime functional changes outside dependency security remediation

**Notes**

A JSON parsing test failure surfaced after the Jackson-related upgrade which code changes made to handle it.