### PR TITLE
Fix malformed z/OS log query strings when optional parameters are combined

### DIFF
--- a/src/main/java/zowe/client/sdk/zoslogs/method/ZosLog.java
+++ b/src/main/java/zowe/client/sdk/zoslogs/method/ZosLog.java
@@ -87,32 +87,14 @@ public class ZosLog {
 
         logInputData.getStartTime().ifPresentOrElse(time -> url.append("?time=").append(time),
                 () -> url.append("?time=").append(LocalDateTime.now().format(formatter)));
-        logInputData.getTimeRange().ifPresent(timeRange -> {
-            if (logInputData.getQueryCount() > 1) {
-                url.append("&timeRange=").append(timeRange);
-            } else {
-                url.append("?timeRange=").append(timeRange);
-            }
-        });
-        logInputData.getDirection().ifPresent(direction -> {
-            if (logInputData.getQueryCount() > 1) {
-                url.append("&direction=").append(direction.getValue());
-            } else {
-                url.append("?direction=").append(direction.getValue());
-            }
-        });
-        logInputData.getHardCopy().ifPresent(hardCopy -> {
-            if (logInputData.getQueryCount() > 1) {
-                url.append("&hardcopy=").append(hardCopy.getValue());
-            } else {
-                url.append("?hardcopy=").append(hardCopy.getValue());
-            }
-        });
+        logInputData.getTimeRange().ifPresent(timeRange -> url.append("&timeRange=").append(timeRange));
+        logInputData.getDirection().ifPresent(direction -> url.append("&direction=").append(direction.getValue()));
+        logInputData.getHardCopy().ifPresent(hardCopy -> url.append("&hardcopy=").append(hardCopy.getValue()));
 
         if (request == null) {
             request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.GET_JSON);
         }
-        request.setUrl(url.toString().replace("?&", "?"));
+        request.setUrl(url.toString());
 
         final String responsePhrase = request.executeRequest()
                 .getResponsePhrase()

--- a/src/test/java/zowe/client/sdk/zoslogs/method/ZosLogTest.java
+++ b/src/test/java/zowe/client/sdk/zoslogs/method/ZosLogTest.java
@@ -17,12 +17,15 @@ import zowe.client.sdk.core.ZosConnectionFactory;
 import zowe.client.sdk.rest.GetJsonZosmfRequest;
 import zowe.client.sdk.rest.Response;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
+import zowe.client.sdk.zoslogs.types.DirectionType;
 import zowe.client.sdk.zoslogs.input.ZosLogInputData;
 import zowe.client.sdk.zoslogs.response.ZosLogResponse;
 
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
 
 /**
  * Class containing unit test for ZosLog class.
@@ -40,6 +43,8 @@ public class ZosLogTest {
     @BeforeEach
     public void init() {
         mockJsonGetRequest = Mockito.mock(GetJsonZosmfRequest.class);
+        doCallRealMethod().when(mockJsonGetRequest).setUrl(any());
+        doCallRealMethod().when(mockJsonGetRequest).getUrl();
     }
 
     @Test
@@ -235,6 +240,23 @@ public class ZosLogTest {
         assertEquals("", response.getItems().get(0).getSystem());
         assertEquals("", response.getItems().get(0).getColor());
         assertEquals("", response.getItems().get(0).getMessage());
+    }
+
+    @Test
+    public void tstIssueCommandAppendsAdditionalQueryParametersWithAmpersandsSuccess() throws ZosmfRequestException {
+        Mockito.when(mockJsonGetRequest.executeRequest()).thenReturn(
+                new Response("{\"nextTimestamp\":0,\"source\":\"OPERLOGS\",\"totalitems\":0,\"items\":[]}", 200, "success"));
+
+        ZosLog zosLog = new ZosLog(connection, mockJsonGetRequest);
+        ZosLogInputData inputData = new ZosLogInputData.Builder()
+                .timeRange("10m")
+                .direction(DirectionType.FORWARD)
+                .build();
+
+        zosLog.issueCommand(inputData);
+
+        assertTrue(mockJsonGetRequest.getUrl().matches(
+                "https://1:443/zosmf/restconsoles/v1/log\\?time=[^&]+&timeRange=10m&direction=forward"));
     }
 
 }


### PR DESCRIPTION

This PR fixes query string construction in `ZosLog.issueCommand()`.

Previously, the `time` parameter was always added first, but optional parameters like `timeRange`, `direction`, and `hardcopy` could still be appended with `?` depending on `queryCount`. That could produce malformed URLs such as:

```text
.../restconsoles/v1/log?time=2026-04-24T10:00Z?timeRange=10m
```

This change makes query delimiter handling deterministic:
- `time` is always added first with `?`
- all additional optional parameters are appended with `&`

What’s included:
- fix in `ZosLog.java`
- regression test covering combined optional query parameters in `ZosLogTest.java`

Validation:
- ran `./mvnw.cmd -q test`
- full test suite passed
Hey @frankgiordano , I found this potential bug while exploring the codebase & thought it's urgent enough so raised a PR. This matters because malformed query strings can break valid z/OS log requests whenever users combine optional filters. Do lemme know your thoughts! If you want me to raise an issue first for this or from next time onwards , do tell