### PR TITLE
Long-standing inconsistencies with the z/OS log API request handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Thin JAR (recommended):
         <dependency>
           <groupId>org.zowe.client.java.sdk</groupId>
           <artifactId>zowe-client-java-sdk</artifactId>
-          <version>6.1.3</version>
+          <version>6.2.0</version>
         </dependency>
   
 Fat JAR (with dependencies):
@@ -257,7 +257,7 @@ Fat JAR (with dependencies):
         <dependency>
           <groupId>org.zowe.client.java.sdk</groupId>
           <artifactId>zowe-client-java-sdk</artifactId>
-          <version>6.1.3</version>
+          <version>6.2.0</version>
           <classifier>jar-with-dependencies</classifier>
         </dependency>  
   
@@ -265,11 +265,11 @@ For a Gradle project add the SDK as a dependency by updating your `build.gradle`
 
 Thin JAR (recommended):  
   
-    implementation group: 'org.zowe.client.java.sdk', name: 'zowe-client-java-sdk', version: '6.1.3'    
+    implementation group: 'org.zowe.client.java.sdk', name: 'zowe-client-java-sdk', version: '6.2.0'    
 
 Fat JAR (with dependencies):  
   
-    implementation group: 'org.zowe.client.java.sdk', name: 'zowe-client-java-sdk', version: '6.1.3', classifier: 'jar-with-dependencies'
+    implementation group: 'org.zowe.client.java.sdk', name: 'zowe-client-java-sdk', version: '6.2.0', classifier: 'jar-with-dependencies'
   
 ## Publishing to Maven Central  
   

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.zowe.client.java.sdk</groupId>
     <artifactId>zowe-client-java-sdk</artifactId>
-    <version>6.1.3</version>
+    <version>6.2.0</version>
 
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/zowe/client/sdk/zoslogs/README.md
+++ b/src/main/java/zowe/client/sdk/zoslogs/README.md
@@ -42,7 +42,7 @@ public class ZosLogExp extends TstZosConnection {
                 .createBasicConnection(hostName, zosmfPort, userName, password);
         ZosLog zosLog = new ZosLog(connection);
         ZosLogInputData zosLogInputData = new ZosLogInputData.Builder()
-                .startTime("2022-11-27T05:06Z")
+                .startTime("2026-04-25T15:20:39Z")
                 .hardCopy(HardCopyType.SYSLOG)
                 .timeRange("24h")
                 .direction(DirectionType.BACKWARD)

--- a/src/main/java/zowe/client/sdk/zoslogs/input/ZosLogInputData.java
+++ b/src/main/java/zowe/client/sdk/zoslogs/input/ZosLogInputData.java
@@ -26,13 +26,18 @@ import java.util.Optional;
 public class ZosLogInputData {
 
     /**
-     * The z/OS log api time parameter. This field is optional.
+     * The z/OSMF log API {@code time} query parameter. This field is optional.
      * <p>
-     * Specifies when z/OSMF starts to retrieve messages in the ISO 8601 JSON date and time format.
-     * For example, 2021-01-26T03:33Z.
+     * Specifies the point in time from which z/OSMF starts retrieving messages.
+     * The value must be in ISO-8601 format, for example:
+     * {@code 2021-01-26T03:33:18.065Z} or {@code 2021-05-25T07:00Z}.
      * <p>
-     * The default value is the current UNIX timestamp on the server.
-     * This value is used if the timestamp parameter is not specified.
+     * When {@code direction} is {@code backward}, messages are retrieved backward from this time.
+     * When {@code direction} is {@code forward}, messages are retrieved forward from this time.
+     * <p>
+     * If this field is not specified, the SDK omits the {@code time} parameter and z/OSMF uses
+     * the current UNIX timestamp on the server. This avoids using a client-generated timestamp
+     * that could be ahead of the z/OSMF server time.
      */
     private final String startTime;
 

--- a/src/main/java/zowe/client/sdk/zoslogs/method/ZosLog.java
+++ b/src/main/java/zowe/client/sdk/zoslogs/method/ZosLog.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Get z/OS log via z/OSMF restful api
+ * Retrieves z/OS log data through the z/OSMF REST API.
  *
  * @author Frank Giordano
  * @version 6.0
@@ -70,7 +70,7 @@ public class ZosLog {
     /**
      * Retrieve z/OS log data from the z/OSMF REST API.
      * <p>
-     * If the API fails, you may be missing APAR see PH35930 required for log operations.
+     * If the API fails, APAR PH35930 may be required for log operations.
      *
      * @param logInputData ZosLogInputData object
      * @return ZosLogResponse object with log messages/items

--- a/src/main/java/zowe/client/sdk/zoslogs/method/ZosLog.java
+++ b/src/main/java/zowe/client/sdk/zoslogs/method/ZosLog.java
@@ -87,11 +87,18 @@ public class ZosLog {
         final String defaultUrl = connection.getZosmfUrl() + RESOURCE;
         final StringBuilder url = new StringBuilder(defaultUrl);
 
-        logInputData.getStartTime().ifPresentOrElse(time -> url.append("?time=").append(time),
-                () -> url.append("?time=").append((DATE_TIME_FORMATTER.format(Instant.now()))));
-        logInputData.getTimeRange().ifPresent(timeRange -> url.append("&timeRange=").append(timeRange));
-        logInputData.getDirection().ifPresent(direction -> url.append("&direction=").append(direction.getValue()));
-        logInputData.getHardCopy().ifPresent(hardCopy -> url.append("&hardcopy=").append(hardCopy.getValue()));
+        url.append("?time=")
+                .append(logInputData.getStartTime()
+                        .orElse(DATE_TIME_FORMATTER.format(Instant.now())));
+
+        logInputData.getTimeRange()
+                .ifPresent(timeRange -> url.append("&timeRange=").append(timeRange));
+
+        logInputData.getDirection()
+                .ifPresent(direction -> url.append("&direction=").append(direction.getValue()));
+
+        logInputData.getHardCopy()
+                .ifPresent(hardCopy -> url.append("&hardcopy=").append(hardCopy.getValue()));
 
         if (request == null) {
             request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.GET_JSON);

--- a/src/main/java/zowe/client/sdk/zoslogs/method/ZosLog.java
+++ b/src/main/java/zowe/client/sdk/zoslogs/method/ZosLog.java
@@ -89,7 +89,7 @@ public class ZosLog {
 
         url.append("?time=")
                 .append(logInputData.getStartTime()
-                        .orElse(DATE_TIME_FORMATTER.format(Instant.now())));
+                        .orElseGet(() -> DATE_TIME_FORMATTER.format(Instant.now())));
 
         logInputData.getTimeRange()
                 .ifPresent(timeRange -> url.append("&timeRange=").append(timeRange));

--- a/src/main/java/zowe/client/sdk/zoslogs/method/ZosLog.java
+++ b/src/main/java/zowe/client/sdk/zoslogs/method/ZosLog.java
@@ -21,7 +21,8 @@ import zowe.client.sdk.utility.ValidateUtils;
 import zowe.client.sdk.zoslogs.input.ZosLogInputData;
 import zowe.client.sdk.zoslogs.response.ZosLogResponse;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 
 /**
@@ -34,7 +35,8 @@ public class ZosLog {
 
     private static final String RESOURCE = "/restconsoles/v1/log";
     private static final DateTimeFormatter DATE_TIME_FORMATTER =
-            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm'Z'");
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm'Z'")
+                    .withZone(ZoneOffset.UTC);
     private final ZosConnection connection;
     private ZosmfRequest request;
 
@@ -86,7 +88,7 @@ public class ZosLog {
         final StringBuilder url = new StringBuilder(defaultUrl);
 
         logInputData.getStartTime().ifPresentOrElse(time -> url.append("?time=").append(time),
-                () -> url.append("?time=").append(LocalDateTime.now().format(DATE_TIME_FORMATTER)));
+                () -> url.append("?time=").append((DATE_TIME_FORMATTER.format(Instant.now()))));
         logInputData.getTimeRange().ifPresent(timeRange -> url.append("&timeRange=").append(timeRange));
         logInputData.getDirection().ifPresent(direction -> url.append("&direction=").append(direction.getValue()));
         logInputData.getHardCopy().ifPresent(hardCopy -> url.append("&hardcopy=").append(hardCopy.getValue()));

--- a/src/main/java/zowe/client/sdk/zoslogs/method/ZosLog.java
+++ b/src/main/java/zowe/client/sdk/zoslogs/method/ZosLog.java
@@ -21,9 +21,8 @@ import zowe.client.sdk.utility.ValidateUtils;
 import zowe.client.sdk.zoslogs.input.ZosLogInputData;
 import zowe.client.sdk.zoslogs.response.ZosLogResponse;
 
-import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Get z/OS log via z/OSMF restful api
@@ -34,9 +33,6 @@ import java.time.format.DateTimeFormatter;
 public class ZosLog {
 
     private static final String RESOURCE = "/restconsoles/v1/log";
-    private static final DateTimeFormatter DATE_TIME_FORMATTER =
-            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm'Z'")
-                    .withZone(ZoneOffset.UTC);
     private final ZosConnection connection;
     private ZosmfRequest request;
 
@@ -84,21 +80,29 @@ public class ZosLog {
     public ZosLogResponse issueCommand(final ZosLogInputData logInputData) throws ZosmfRequestException {
         ValidateUtils.checkNullParameter(logInputData, "logInputData");
 
-        final String defaultUrl = connection.getZosmfUrl() + RESOURCE;
-        final StringBuilder url = new StringBuilder(defaultUrl);
+        final StringBuilder url = new StringBuilder(connection.getZosmfUrl())
+                .append(RESOURCE);
 
-        url.append("?time=")
-                .append(logInputData.getStartTime()
-                        .orElseGet(() -> DATE_TIME_FORMATTER.format(Instant.now())));
+        final List<String> queryParams = new ArrayList<>();
+
+        // IBM documents the time parameter as optional. When it is omitted, z/OSMF defaults to the
+        // current UNIX timestamp on the server. This avoids sending a client-side "now" value that
+        // could be a few seconds ahead of the z/OSMF server’s current time.
+        logInputData.getStartTime()
+                .ifPresent(startTime -> queryParams.add("time=" + startTime));
 
         logInputData.getTimeRange()
-                .ifPresent(timeRange -> url.append("&timeRange=").append(timeRange));
+                .ifPresent(timeRange -> queryParams.add("timeRange=" + timeRange));
 
         logInputData.getDirection()
-                .ifPresent(direction -> url.append("&direction=").append(direction.getValue()));
+                .ifPresent(direction -> queryParams.add("direction=" + direction.getValue()));
 
         logInputData.getHardCopy()
-                .ifPresent(hardCopy -> url.append("&hardcopy=").append(hardCopy.getValue()));
+                .ifPresent(hardCopy -> queryParams.add("hardcopy=" + hardCopy.getValue()));
+
+        if (!queryParams.isEmpty()) {
+            url.append("?").append(String.join("&", queryParams));
+        }
 
         if (request == null) {
             request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.GET_JSON);

--- a/src/test/java/zowe/client/sdk/zoslogs/method/ZosLogTest.java
+++ b/src/test/java/zowe/client/sdk/zoslogs/method/ZosLogTest.java
@@ -266,4 +266,27 @@ public class ZosLogTest {
                 "https://1:443/zosmf/restconsoles/v1/log\\?time=[^&]+&timeRange=10m&direction=forward"));
     }
 
+    @Test
+    public void tstIssueCommandWithOutTimeSuccess() throws ZosmfRequestException {
+        String json = "{\n" +
+                "  \"nextTimestamp\": 0,\n" +
+                "  \"source\": \"OPERLOGS\",\n" +
+                "  \"totalitems\": 0,\n" +
+                "  \"items\": []\n" +
+                "}";
+        Mockito.when(mockJsonGetRequest.executeRequest()).thenReturn(
+                new Response(json, 200, "success"));
+
+        ZosLog zosLog = new ZosLog(connection, mockJsonGetRequest);
+        ZosLogInputData inputData = new ZosLogInputData.Builder()
+                .timeRange("10m")
+                .direction(DirectionType.FORWARD)
+                .build();
+
+        zosLog.issueCommand(inputData);
+
+        assertTrue(mockJsonGetRequest.getUrl().matches(
+                "https://1:443/zosmf/restconsoles/v1/log\\?timeRange=10m&direction=forward"));
+    }
+
 }

--- a/src/test/java/zowe/client/sdk/zoslogs/method/ZosLogTest.java
+++ b/src/test/java/zowe/client/sdk/zoslogs/method/ZosLogTest.java
@@ -255,6 +255,7 @@ public class ZosLogTest {
 
         ZosLog zosLog = new ZosLog(connection, mockJsonGetRequest);
         ZosLogInputData inputData = new ZosLogInputData.Builder()
+                .startTime("2026-04-25T15:20:39Z")
                 .timeRange("10m")
                 .direction(DirectionType.FORWARD)
                 .build();


### PR DESCRIPTION
## Description

This PR fixes long-standing inconsistencies with the z/OS log API request handling.

The z/OS log request URL is now built more accurately, and the SDK no longer sends a client-generated `time` parameter unless the caller explicitly provides a `startTime`.

Previously, the SDK always added a `time` query parameter when calling the z/OS log API. When `startTime` was not provided, the default value was generated on the client side using the local/runtime clock. This caused two issues:

1. Additional query parameters could be appended incorrectly depending on the input combination.
2. The generated client-side time could be slightly ahead of the z/OSMF server time, causing z/OSMF to reject the request with:

       The time or timestamp specified is a future time. Only a past time point is valid.

Internal testing with formatter as UTC-compatible exposed the remaining timing issue: even a correctly formatted UTC timestamp can still be rejected if the client clock is ahead of the z/OSMF server clock.

The fix now omits the `time` parameter unless `startTime` is explicitly provided. This lets z/OSMF use its own server-side current time, which avoids client/server clock drift issues and aligns with the documented API behavior.

The query-string construction was also simplified by collecting optional query parameters and joining them with `&`, preventing malformed URLs when multiple optional parameters are supplied.