### PR TITLE
Add Paginated z/OS Log Retrieval Support

### DIFF
--- a/src/main/java/zowe/client/sdk/zoslogs/README.md
+++ b/src/main/java/zowe/client/sdk/zoslogs/README.md
@@ -41,27 +41,43 @@ public class ZosLogExp extends TstZosConnection {
         ZosConnection connection = ZosConnectionFactory
                 .createBasicConnection(hostName, zosmfPort, userName, password);
         ZosLog zosLog = new ZosLog(connection);
+
         ZosLogInputData zosLogInputData = new ZosLogInputData.Builder()
-                .startTime("2026-04-25T15:20:39Z")
+                // example .startTime("2026-04-25T15:20:39Z")
+                .startTime("yyyy-MM-ddTHH:mm:ssZ")
                 .hardCopy(HardCopyType.SYSLOG)
                 .timeRange("24h")
                 .direction(DirectionType.BACKWARD)
                 .processResponses(true)
                 .build();
-        ZosLogResponse zosLogReply;
+
+        // Demonstrate the single-response API.
+        ZosLogResponse zosLogResponse;
         try {
-            zosLogReply = zosLog.issueCommand(zosLogInputData);
+            zosLogResponse = zosLog.issueCommand(zosLogInputData);
         } catch (ZosmfRequestException e) {
-            String errMsg = e.getMessage();
-            if (e.getResponse() != null && e.getResponse().hasTextResponsePhrase()) {
-                errMsg = e.getResponse().getResponsePhraseAsString().orElse(errMsg);
-            }
-            throw new RuntimeException(errMsg, e);
+            throw new RuntimeException(e);
         }
-        zosLogReply.getItems().forEach(i -> {
+
+        zosLogResponse.getItems().forEach(i -> {
             String msg = i.getTime() + " " + i.getMessage();
             System.out.println(msg);
         });
+
+        // Demonstrate the paginated API using the same input. This will retrieve the first
+        // batch again, then continue paging if z/OSMF returns 10,000 items.
+        List<ZosLogResponse> zosLogResponses;
+        try {
+            zosLogResponses = zosLog.issueCommand(zosLogInputData, 20000);
+        } catch (ZosmfRequestException e) {
+            throw new RuntimeException(e);
+        }
+
+        zosLogResponses.forEach(i -> i.getItems()
+                .forEach(j -> {
+                    String msg = j.getTime() + " " + j.getMessage();
+                    System.out.println(msg);
+                }));
 
         // get the last one minute of syslog from the date/time of now backwards...
         zosLogInputData = new ZosLogInputData.Builder()
@@ -71,7 +87,7 @@ public class ZosLogExp extends TstZosConnection {
                 .processResponses(true)
                 .build();
         try {
-            zosLogReply = zosLog.issueCommand(zosLogInputData);
+            zosLogResponse = zosLog.issueCommand(zosLogInputData);
         } catch (ZosmfRequestException e) {
             String errMsg = e.getMessage();
             if (e.getResponse() != null && e.getResponse().hasTextResponsePhrase()) {
@@ -79,7 +95,7 @@ public class ZosLogExp extends TstZosConnection {
             }
             throw new RuntimeException(errMsg, e);
         }
-        zosLogReply.getItems().forEach(i -> {
+        zosLogResponse.getItems().forEach(i -> {
             String msg = i.getTime() + " " + i.getMessage();
             System.out.println(msg);
         });

--- a/src/main/java/zowe/client/sdk/zoslogs/input/ZosLogInputData.java
+++ b/src/main/java/zowe/client/sdk/zoslogs/input/ZosLogInputData.java
@@ -76,11 +76,6 @@ public class ZosLogInputData {
     private final boolean processResponses;
 
     /**
-     * Internal use to count the number of query parameters specified
-     */
-    private final int queryCount;
-
-    /**
      * ZosLogInputData constructor
      *
      * @param builder Builder object
@@ -92,7 +87,6 @@ public class ZosLogInputData {
         this.direction = builder.direction;
         this.timeRange = builder.timeRange;
         this.processResponses = builder.processResponses;
-        this.queryCount = builder.queryCount;
     }
 
     /**
@@ -138,15 +132,6 @@ public class ZosLogInputData {
      */
     public boolean isProcessResponses() {
         return processResponses;
-    }
-
-    /**
-     * Retrieve queryCount value
-     *
-     * @return queryCount value
-     */
-    public int getQueryCount() {
-        return queryCount;
     }
 
     /**

--- a/src/main/java/zowe/client/sdk/zoslogs/method/ZosLog.java
+++ b/src/main/java/zowe/client/sdk/zoslogs/method/ZosLog.java
@@ -10,6 +10,7 @@
  */
 package zowe.client.sdk.zoslogs.method;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.GetJsonZosmfRequest;
 import zowe.client.sdk.rest.ZosmfRequest;
@@ -33,6 +34,8 @@ import java.util.List;
 public class ZosLog {
 
     private static final String RESOURCE = "/restconsoles/v1/log";
+    private static final String CONTEXT = "issueCommand";
+    private static final int ZOSMF_MAX_LOG_ITEMS = 10_000;
     private final ZosConnection connection;
     private ZosmfRequest request;
 
@@ -49,7 +52,7 @@ public class ZosLog {
 
     /**
      * Alternative ZosLog constructor with ZoweRequest object. This is mainly used for internal code unit testing
-     * with mockito, and it is not recommended to be used by the larger community.
+     * with Mockito, and it is not recommended to be used by the larger community.
      * <p>
      * This constructor is package-private
      *
@@ -72,12 +75,105 @@ public class ZosLog {
      * <p>
      * If the API fails, APAR PH35930 may be required for log operations.
      *
-     * @param logInputData ZosLogInputData object
+     * @param logInputData ZosLogInputData object containing optional log query parameters
      * @return ZosLogResponse object with log messages/items
      * @throws ZosmfRequestException request error state
      * @author Frank Giordano
      */
     public ZosLogResponse issueCommand(final ZosLogInputData logInputData) throws ZosmfRequestException {
+        final String url = getUrl(logInputData, 0);
+        setUrl(url);
+
+        final String responsePhrase = request.executeRequest()
+                .getResponsePhrase()
+                .orElseThrow(() -> new IllegalStateException("no zos log response phrase"))
+                .toString();
+
+        return JsonUtils.parseResponse(responsePhrase, ZosLogResponse.class, CONTEXT);
+    }
+
+    /**
+     * Retrieve z/OS log data from the z/OSMF REST API and continue requesting additional log data
+     * when z/OSMF returns the maximum number of log items.
+     * <p>
+     * z/OSMF returns a maximum of 10,000 log items per request. When that limit is reached, the
+     * returned next timestamp is used as the {@code timestamp} parameter for the next request.
+     * <p>
+     * The {@code totalMaxLimit} value is used as a pagination stop threshold. The returned number
+     * of log items may exceed this value because z/OSMF returns results in response-sized batches.
+     *
+     * @param logInputData       ZosLogInputData object containing optional log query parameters
+     * @param totalItemThreshold pagination stop threshold across requests
+     * @return list of ZosLogResponse objects returned by each z/OSMF request
+     * @throws ZosmfRequestException request error state
+     * @author Frank Giordano
+     */
+    public List<ZosLogResponse> issueCommand(final ZosLogInputData logInputData,
+                                             final int totalItemThreshold) throws ZosmfRequestException {
+        if (totalItemThreshold <= 0) {
+            throw new IllegalArgumentException("totalItemThreshold must be greater than 0");
+        }
+
+        final List<ZosLogResponse> zosLogResponses = new ArrayList<>();
+        String url = getUrl(logInputData, 0);
+        this.setUrl(url);
+
+        String responsePhrase = request.executeRequest()
+                .getResponsePhrase()
+                .orElseThrow(() -> new IllegalStateException("no zos log response phrase"))
+                .toString();
+
+        ZosLogResponse zosLogResponse = JsonUtils.parseResponse(responsePhrase, ZosLogResponse.class, CONTEXT);
+        zosLogResponses.add(zosLogResponse);
+        long totalItems = zosLogResponse.getTotalItems();
+
+        // Prevent repeated paging if z/OSMF returns the same nextTimestamp more than once.
+        long previousNextTimestamp = -1;
+        while (totalItems < totalItemThreshold
+                && zosLogResponse.getTotalItems() == ZOSMF_MAX_LOG_ITEMS
+                && zosLogResponse.getNextTimeStamp() > 0) {
+
+            final long nextTimestamp = zosLogResponse.getNextTimeStamp();
+            if (previousNextTimestamp == nextTimestamp) {
+                break;
+            }
+            previousNextTimestamp = nextTimestamp;
+
+            url = getUrl(logInputData, nextTimestamp);
+            setUrl(url);
+
+            responsePhrase = request.executeRequest()
+                    .getResponsePhrase()
+                    .orElseThrow(() -> new IllegalStateException("no zos log response phrase"))
+                    .toString();
+
+            zosLogResponse = JsonUtils.parseResponse(responsePhrase, ZosLogResponse.class, CONTEXT);
+            zosLogResponses.add(zosLogResponse);
+            totalItems += zosLogResponse.getTotalItems();
+        }
+
+        return zosLogResponses;
+    }
+
+    /**
+     * Builds the z/OSMF log REST API request URL from the provided input data.
+     * <p>
+     * When {@code nextTimestamp} is greater than zero, the value is added as the z/OSMF {@code timestamp}
+     * query parameter and the {@code time} parameter is not included. This is used for follow-up requests
+     * when paging through log responses.
+     * <p>
+     * When {@code nextTimestamp} is zero or less, the {@code time} query parameter is only included when
+     * {@code logInputData} contains an explicit start time.
+     * <p>
+     * If no start time is provided, the {@code time} parameter is omitted and z/OSMF uses its own
+     * server-side current time.
+     *
+     * @param logInputData  ZosLogInputData object containing optional log query parameters
+     * @param nextTimestamp timestamp value from a previous z/OSMF log response, or zero for the initial request
+     * @return z/OSMF log REST API request URL
+     * @author Frank Giordano
+     */
+    private @NonNull String getUrl(final ZosLogInputData logInputData, final long nextTimestamp) {
         ValidateUtils.checkNullParameter(logInputData, "logInputData");
 
         final StringBuilder url = new StringBuilder(connection.getZosmfUrl())
@@ -85,11 +181,12 @@ public class ZosLog {
 
         final List<String> queryParams = new ArrayList<>();
 
-        // IBM documents the time parameter as optional. When it is omitted, z/OSMF defaults to the
-        // current UNIX timestamp on the server. This avoids sending a client-side "now" value that
-        // could be a few seconds ahead of the z/OSMF server’s current time.
-        logInputData.getStartTime()
-                .ifPresent(startTime -> queryParams.add("time=" + startTime));
+        if (nextTimestamp > 0) {
+            queryParams.add("timestamp=" + nextTimestamp);
+        } else {
+            logInputData.getStartTime()
+                    .ifPresent(startTime -> queryParams.add("time=" + startTime));
+        }
 
         logInputData.getTimeRange()
                 .ifPresent(timeRange -> queryParams.add("timeRange=" + timeRange));
@@ -103,19 +200,20 @@ public class ZosLog {
         if (!queryParams.isEmpty()) {
             url.append("?").append(String.join("&", queryParams));
         }
+        return url.toString();
+    }
 
+    /**
+     * Sets the request URL on the z/OSMF request object.
+     *
+     * @param url z/OSMF log REST API request URL
+     * @author Frank Giordano
+     */
+    private void setUrl(final String url) {
         if (request == null) {
             request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.GET_JSON);
         }
-        request.setUrl(url.toString());
-
-        final String responsePhrase = request.executeRequest()
-                .getResponsePhrase()
-                .orElseThrow(() -> new IllegalStateException("no zos log response phrase"))
-                .toString();
-
-        final String context = "issueCommand";
-        return JsonUtils.parseResponse(responsePhrase, ZosLogResponse.class, context);
+        request.setUrl(url);
     }
 
 }

--- a/src/test/java/zowe/client/sdk/zoslogs/method/ZosLogTest.java
+++ b/src/test/java/zowe/client/sdk/zoslogs/method/ZosLogTest.java
@@ -93,7 +93,6 @@ public class ZosLogTest {
         Mockito.when(inputData.getTimeRange()).thenReturn(Optional.empty());
         Mockito.when(inputData.getDirection()).thenReturn(Optional.empty());
         Mockito.when(inputData.getHardCopy()).thenReturn(Optional.empty());
-        Mockito.when(inputData.getQueryCount()).thenReturn(1);
 
         ZosLogResponse response = zosLog.issueCommand(inputData);
 
@@ -124,7 +123,6 @@ public class ZosLogTest {
         Mockito.when(inputData.getTimeRange()).thenReturn(Optional.empty());
         Mockito.when(inputData.getDirection()).thenReturn(Optional.empty());
         Mockito.when(inputData.getHardCopy()).thenReturn(Optional.empty());
-        Mockito.when(inputData.getQueryCount()).thenReturn(1);
 
         assertThrows(ZosmfRequestException.class, () -> zosLog.issueCommand(inputData));
     }
@@ -162,7 +160,6 @@ public class ZosLogTest {
         Mockito.when(inputData.getTimeRange()).thenReturn(Optional.empty());
         Mockito.when(inputData.getDirection()).thenReturn(Optional.empty());
         Mockito.when(inputData.getHardCopy()).thenReturn(Optional.empty());
-        Mockito.when(inputData.getQueryCount()).thenReturn(1);
 
         ZosLogResponse response = zosLog.issueCommand(inputData);
 
@@ -185,8 +182,6 @@ public class ZosLogTest {
         Mockito.when(inputData.getStartTime()).thenReturn(Optional.empty());
         Mockito.when(inputData.getTimeRange()).thenReturn(Optional.empty());
         Mockito.when(inputData.getDirection()).thenReturn(Optional.empty());
-        Mockito.when(inputData.getHardCopy()).thenReturn(Optional.empty());
-        Mockito.when(inputData.getQueryCount()).thenReturn(1);
 
         ZosLogResponse response = zosLog.issueCommand(inputData);
 
@@ -228,7 +223,6 @@ public class ZosLogTest {
         Mockito.when(inputData.getTimeRange()).thenReturn(Optional.empty());
         Mockito.when(inputData.getDirection()).thenReturn(Optional.empty());
         Mockito.when(inputData.getHardCopy()).thenReturn(Optional.empty());
-        Mockito.when(inputData.getQueryCount()).thenReturn(1);
 
         ZosLogResponse response = zosLog.issueCommand(inputData);
 


### PR DESCRIPTION
**Description**

Adds a new overloaded issueCommand method to support retrieving larger z/OS log result sets across multiple z/OSMF requests.

z/OSMF returns a maximum of 10,000 log items per request. The existing issueCommand(ZosLogInputData) method returns a single response, which means larger log ranges than 10,000 are not retrieved. The new overload method introduced in this PR allows callers to continue retrieving additional responses by using the nextTimestamp value returned by z/OSMF as the timestamp parameter on follow-up requests.

    public List<ZosLogResponse> issueCommand(final ZosLogInputData logInputData,
                                             final int totalItemThreshold) throws ZosmfRequestException

**Behavior**

- Executes the initial z/OS log request using the provided ZosLogInputData.
- Adds the first ZosLogResponse to the returned list.
- If z/OSMF returns the maximum 10,000 items, the method uses the returned nextTimestamp to request the next batch.
- Continues paging until:
    - the total retrieved item count reaches the provided totalItemThreshold,
    - the previous response returned fewer than 10,000 items,
    - z/OSMF does not return a usable nextTimestamp, or
    - the same nextTimestamp is returned again.
    - Returns a list of ZosLogResponse objects, one per z/OSMF request.

**Notes**

The totalItemThreshold is a pagination stop threshold, not a strict maximum result count. The final number of returned log items may exceed the threshold because z/OSMF returns results in batches of up to 10,000 items.

The original single-response issueCommand(ZosLogInputData) method remains unchanged for callers that only need one z/OSMF response.