### PR TITLE
Fix inconsistent HTTP request type validation in ZosmfLogin

### DIFF
--- a/src/main/java/zowe/client/sdk/zosmfauth/methods/ZosmfLogin.java
+++ b/src/main/java/zowe/client/sdk/zosmfauth/methods/ZosmfLogin.java
@@ -10,7 +10,7 @@
 package zowe.client.sdk.zosmfauth.methods;
 
 import zowe.client.sdk.core.ZosConnection;
-import zowe.client.sdk.rest.PutJsonZosmfRequest;
+import zowe.client.sdk.rest.PostJsonZosmfRequest;
 import zowe.client.sdk.rest.Response;
 import zowe.client.sdk.rest.ZosmfRequest;
 import zowe.client.sdk.rest.ZosmfRequestFactory;
@@ -59,8 +59,8 @@ public class ZosmfLogin {
         ValidateUtils.checkNullParameter(connection, "connection");
         ValidateUtils.checkNullParameter(request, "request");
         this.connection = connection;
-        if (!(request instanceof PutJsonZosmfRequest)) {
-            throw new IllegalStateException("PUT_JSON request type required");
+        if (!(request instanceof PostJsonZosmfRequest)) {
+            throw new IllegalStateException("POST_JSON request type required");
         }
         this.request = request;
     }


### PR DESCRIPTION
This PR fixes an internal inconsistency in ZosmfLogin.

The package-private constructor used for testing was validating against PutJsonZosmfRequest, while the actual login() implementation builds and executes a POST_JSON request. This meant the constructor contract did not match the real runtime behavior of the class.

This change aligns the constructor validation with the actual request type used by login() by checking for PostJsonZosmfRequest instead.

Validation:

- ran ./mvnw.cmd -q test
- full test suite passed