### PR TITLE
Add dedicated method tests for zosmfauth login, logout, and password flows

### DIFF
--- a/src/test/java/zowe/client/sdk/zosmfauth/methods/ZosmfLoginTest.java
+++ b/src/test/java/zowe/client/sdk/zosmfauth/methods/ZosmfLoginTest.java
@@ -1,0 +1,105 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosmfauth.methods;
+
+import kong.unirest.core.Cookies;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import zowe.client.sdk.core.ZosConnection;
+import zowe.client.sdk.core.ZosConnectionFactory;
+import zowe.client.sdk.rest.PostJsonZosmfRequest;
+import zowe.client.sdk.rest.Response;
+import zowe.client.sdk.rest.ZosmfRequest;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
+import zowe.client.sdk.zosmfauth.response.ZosmfLoginResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
+
+/**
+ * Class containing unit tests for ZosmfLogin.
+ *
+ * @author Ashish Kumar Dash
+ * @version 6.2
+ */
+public class ZosmfLoginTest {
+
+    private final ZosConnection connection = ZosConnectionFactory
+            .createBasicConnection("1", 443, "1", "1");
+    private PostJsonZosmfRequest mockPostRequest;
+
+    @BeforeEach
+    public void init() {
+        mockPostRequest = Mockito.mock(PostJsonZosmfRequest.class);
+        doCallRealMethod().when(mockPostRequest).setUrl(any());
+        doCallRealMethod().when(mockPostRequest).getUrl();
+    }
+
+    @Test
+    public void tstLoginSuccess() throws ZosmfRequestException {
+        final Cookies tokens = Mockito.mock(Cookies.class);
+        Mockito.when(mockPostRequest.executeRequest()).thenReturn(
+                new Response("{}", 200, "ok", tokens));
+
+        final ZosmfLogin login = new ZosmfLogin(connection, mockPostRequest);
+        final ZosmfLoginResponse response = login.login();
+
+        assertNotNull(response);
+        assertEquals(tokens, response.getTokens());
+        assertEquals("https://1:443/zosmf/services/authenticate", mockPostRequest.getUrl());
+        Mockito.verify(mockPostRequest).setBody("");
+    }
+
+    @Test
+    public void tstLoginPrimaryConstructorWithValidConnection() {
+        final ZosmfLogin login = new ZosmfLogin(connection);
+        assertNotNull(login);
+    }
+
+    @Test
+    public void tstLoginNullConnectionFailure() {
+        final NullPointerException exception = assertThrows(
+                NullPointerException.class,
+                () -> new ZosmfLogin(null)
+        );
+        assertEquals("connection is null", exception.getMessage());
+    }
+
+    @Test
+    public void tstLoginSecondaryConstructorWithValidRequestType() {
+        final ZosmfLogin login = new ZosmfLogin(connection, mockPostRequest);
+        assertNotNull(login);
+    }
+
+    @Test
+    public void tstLoginSecondaryConstructorWithNullRequest() {
+        final NullPointerException exception = assertThrows(
+                NullPointerException.class,
+                () -> new ZosmfLogin(connection, null)
+        );
+        assertEquals("request is null", exception.getMessage());
+    }
+
+    @Test
+    public void tstLoginSecondaryConstructorWithInvalidRequestType() {
+        final ZosmfRequest request = Mockito.mock(ZosmfRequest.class);
+
+        final IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> new ZosmfLogin(connection, request)
+        );
+        assertEquals("POST_JSON request type required", exception.getMessage());
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/zosmfauth/methods/ZosmfLogoutTest.java
+++ b/src/test/java/zowe/client/sdk/zosmfauth/methods/ZosmfLogoutTest.java
@@ -1,0 +1,113 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosmfauth.methods;
+
+import kong.unirest.core.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import zowe.client.sdk.core.ZosConnection;
+import zowe.client.sdk.core.ZosConnectionFactory;
+import zowe.client.sdk.rest.DeleteJsonZosmfRequest;
+import zowe.client.sdk.rest.Response;
+import zowe.client.sdk.rest.ZosmfRequest;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
+
+/**
+ * Class containing unit tests for ZosmfLogout.
+ *
+ * @author Ashish Kumar Dash
+ * @version 6.2
+ */
+public class ZosmfLogoutTest {
+
+    private final ZosConnection connection = ZosConnectionFactory
+            .createBasicConnection("1", 443, "1", "1");
+    private DeleteJsonZosmfRequest mockDeleteRequest;
+
+    @BeforeEach
+    public void init() {
+        mockDeleteRequest = Mockito.mock(DeleteJsonZosmfRequest.class);
+        doCallRealMethod().when(mockDeleteRequest).setUrl(any());
+        doCallRealMethod().when(mockDeleteRequest).getUrl();
+    }
+
+    @Test
+    public void tstLogoutSuccess() throws ZosmfRequestException {
+        final Cookie token = Mockito.mock(Cookie.class);
+        final Response expectedResponse = new Response("{}", 200, "ok");
+        Mockito.when(mockDeleteRequest.executeRequest()).thenReturn(expectedResponse);
+
+        final ZosmfLogout logout = new ZosmfLogout(connection, mockDeleteRequest);
+        final Response response = logout.logout(token);
+
+        assertEquals(expectedResponse, response);
+        assertEquals("https://1:443/zosmf/services/authenticate", mockDeleteRequest.getUrl());
+    }
+
+    @Test
+    public void tstLogoutPrimaryConstructorWithValidConnection() {
+        final ZosmfLogout logout = new ZosmfLogout(connection);
+        assertNotNull(logout);
+    }
+
+    @Test
+    public void tstLogoutNullConnectionFailure() {
+        final NullPointerException exception = assertThrows(
+                NullPointerException.class,
+                () -> new ZosmfLogout(null)
+        );
+        assertEquals("connection is null", exception.getMessage());
+    }
+
+    @Test
+    public void tstLogoutNullTokenFailure() {
+        final ZosmfLogout logout = new ZosmfLogout(connection, mockDeleteRequest);
+
+        final NullPointerException exception = assertThrows(
+                NullPointerException.class,
+                () -> logout.logout(null)
+        );
+        assertEquals("token is null", exception.getMessage());
+    }
+
+    @Test
+    public void tstLogoutSecondaryConstructorWithValidRequestType() {
+        final ZosmfLogout logout = new ZosmfLogout(connection, mockDeleteRequest);
+        assertNotNull(logout);
+    }
+
+    @Test
+    public void tstLogoutSecondaryConstructorWithNullRequest() {
+        final NullPointerException exception = assertThrows(
+                NullPointerException.class,
+                () -> new ZosmfLogout(connection, null)
+        );
+        assertEquals("request is null", exception.getMessage());
+    }
+
+    @Test
+    public void tstLogoutSecondaryConstructorWithInvalidRequestType() {
+        final ZosmfRequest request = Mockito.mock(ZosmfRequest.class);
+
+        final IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> new ZosmfLogout(connection, request)
+        );
+        assertEquals("DELETE_JSON request type required", exception.getMessage());
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/zosmfauth/methods/ZosmfPasswordTest.java
+++ b/src/test/java/zowe/client/sdk/zosmfauth/methods/ZosmfPasswordTest.java
@@ -1,0 +1,121 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosmfauth.methods;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import zowe.client.sdk.core.ZosConnection;
+import zowe.client.sdk.core.ZosConnectionFactory;
+import zowe.client.sdk.rest.PutJsonZosmfRequest;
+import zowe.client.sdk.rest.Response;
+import zowe.client.sdk.rest.ZosmfRequest;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
+import zowe.client.sdk.zosmfauth.input.PasswordInputData;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
+
+/**
+ * Class containing unit tests for ZosmfPassword.
+ *
+ * @author Ashish Kumar Dash
+ * @version 6.2
+ */
+public class ZosmfPasswordTest {
+
+    private final ZosConnection connection = ZosConnectionFactory
+            .createBasicConnection("1", 443, "1", "1");
+    private PutJsonZosmfRequest mockPutRequest;
+
+    @BeforeEach
+    public void init() {
+        mockPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
+        doCallRealMethod().when(mockPutRequest).setUrl(any());
+        doCallRealMethod().when(mockPutRequest).getUrl();
+    }
+
+    @Test
+    public void tstChangePasswordSuccess() throws ZosmfRequestException {
+        final PasswordInputData inputData = new PasswordInputData("USER1", "OLDPWD", "NEWPWD");
+        final Response expectedResponse = new Response("{}", 200, "ok");
+        Mockito.when(mockPutRequest.executeRequest()).thenReturn(expectedResponse);
+
+        final ZosmfPassword password = new ZosmfPassword(connection, mockPutRequest);
+        final Response response = password.changePassword(inputData);
+        final ArgumentCaptor<Object> bodyCaptor = ArgumentCaptor.forClass(Object.class);
+
+        Mockito.verify(mockPutRequest).setBody(bodyCaptor.capture());
+        final String requestBody = String.valueOf(bodyCaptor.getValue());
+
+        assertEquals(expectedResponse, response);
+        assertEquals("https://1:443/zosmf/services/authenticate", mockPutRequest.getUrl());
+        org.junit.jupiter.api.Assertions.assertTrue(requestBody.contains("\"userID\":\"USER1\""));
+        org.junit.jupiter.api.Assertions.assertTrue(requestBody.contains("\"oldPwd\":\"OLDPWD\""));
+        org.junit.jupiter.api.Assertions.assertTrue(requestBody.contains("\"newPwd\":\"NEWPWD\""));
+    }
+
+    @Test
+    public void tstPasswordPrimaryConstructorWithValidConnection() {
+        final ZosmfPassword password = new ZosmfPassword(connection);
+        assertNotNull(password);
+    }
+
+    @Test
+    public void tstPasswordNullConnectionFailure() {
+        final NullPointerException exception = assertThrows(
+                NullPointerException.class,
+                () -> new ZosmfPassword(null)
+        );
+        assertEquals("connection is null", exception.getMessage());
+    }
+
+    @Test
+    public void tstChangePasswordNullInputDataFailure() {
+        final ZosmfPassword password = new ZosmfPassword(connection, mockPutRequest);
+
+        final NullPointerException exception = assertThrows(
+                NullPointerException.class,
+                () -> password.changePassword(null)
+        );
+        assertEquals("pwdInputData is null", exception.getMessage());
+    }
+
+    @Test
+    public void tstPasswordSecondaryConstructorWithValidRequestType() {
+        final ZosmfPassword password = new ZosmfPassword(connection, mockPutRequest);
+        assertNotNull(password);
+    }
+
+    @Test
+    public void tstPasswordSecondaryConstructorWithNullRequest() {
+        final NullPointerException exception = assertThrows(
+                NullPointerException.class,
+                () -> new ZosmfPassword(connection, null)
+        );
+        assertEquals("request is null", exception.getMessage());
+    }
+
+    @Test
+    public void tstPasswordSecondaryConstructorWithInvalidRequestType() {
+        final ZosmfRequest request = Mockito.mock(ZosmfRequest.class);
+
+        final IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> new ZosmfPassword(connection, request)
+        );
+        assertEquals("PUT_JSON request type required", exception.getMessage());
+    }
+
+}


### PR DESCRIPTION
This PR adds dedicated method-level unit tests for the zosmfauth package.

Unlike most other service areas in the SDK, zosmfauth.methods did not previously have its own focused method tests. This change brings that package closer to the repo’s existing testing pattern by adding coverage for the core authentication flows:

ZosmfLogin
ZosmfLogout
ZosmfPassword
The new tests cover:
- successful request execution paths
- URL construction
- constructor null guards
- request-type validation for the package-private test constructors
- request body verification for password change

Validation:
- ran ./mvnw.cmd -q "-Dtest=ZosmfLoginTest,ZosmfLogoutTest,ZosmfPasswordTest" test
- ran ./mvnw.cmd -q test
- full test suite passed