### PR TITLE
Harden USS ACL validation and add ACL method tests

### DIFF
--- a/src/main/java/zowe/client/sdk/zosfiles/uss/input/UssSetAclInputData.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/input/UssSetAclInputData.java
@@ -313,6 +313,17 @@ public class UssSetAclInputData {
          * @return UssSetAclInputData
          */
         public UssSetAclInputData build() {
+            final boolean hasSet = set != null;
+            final boolean hasModify = modify != null;
+            final boolean hasDelete = delete != null;
+            final boolean hasDeleteType = deleteType != null;
+
+            ValidateUtils.checkIllegalParameter(!hasSet && !hasModify && !hasDelete && !hasDeleteType,
+                "set, modify, delete, and delete type are all empty");
+            ValidateUtils.checkIllegalParameter(hasDeleteType && (hasSet || hasModify || hasDelete),
+                "delete-type cannot be combined with set, modify, or delete");
+            ValidateUtils.checkIllegalParameter(hasSet && (hasModify || hasDelete),
+                "set cannot be combined with modify or delete");
             return new UssSetAclInputData(this);
         }
 

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssSetAcl.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssSetAcl.java
@@ -132,7 +132,7 @@ public class UssSetAcl {
      */
     public Response setAclCommon(final String targetPath, final UssSetAclInputData setAclInputData)
             throws ZosmfRequestException {
-        ValidateUtils.checkIllegalParameter(targetPath, "fromPath");
+        ValidateUtils.checkIllegalParameter(targetPath, "targetPath");
         ValidateUtils.checkNullParameter(setAclInputData, "setAclInputData");
         ValidateUtils.checkIllegalParameter(setAclInputData.getSet().isEmpty() &&
                 setAclInputData.getModify().isEmpty() && setAclInputData.getDelete().isEmpty() &&

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssSetAcl.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssSetAcl.java
@@ -72,67 +72,68 @@ public class UssSetAcl {
     /**
      * Sets the ACL for a USS file or directory
      *
-     * @param targetPath UNIX path to the target file or directory
+    * @param filePathName UNIX path to the target file or directory
      * @param value      sets the extended ACL entries that are specified by 'entries'
      * @return Response object
      * @throws ZosmfRequestException request error state
      * @author James Kostrewski
      */
-    public Response set(final String targetPath, final String value) throws ZosmfRequestException {
-        return setAclCommon(targetPath, new UssSetAclInputData.Builder().setSet(value).build());
+    public Response set(final String filePathName, final String value) throws ZosmfRequestException {
+        return setAclCommon(filePathName, new UssSetAclInputData.Builder().setSet(value).build());
     }
 
     /**
      * Modifies the specified ACL entry for the file or directory
      *
-     * @param targetPath UNIX path to the target file or directory
+    * @param filePathName UNIX path to the target file or directory
      * @param value      modifies the extended ACL entries that are specified by 'entries'
      * @return Response object
      * @throws ZosmfRequestException request error state
      * @author James Kostrewski
      */
-    public Response modify(final String targetPath, final String value) throws ZosmfRequestException {
-        return setAclCommon(targetPath, new UssSetAclInputData.Builder().setModify(value).build());
+    public Response modify(final String filePathName, final String value) throws ZosmfRequestException {
+        return setAclCommon(filePathName, new UssSetAclInputData.Builder().setModify(value).build());
     }
 
     /**
      * Deletes the specified ACL entry from the file or directory
      *
-     * @param targetPath UNIX path to the target file or directory
+    * @param filePathName UNIX path to the target file or directory
      * @param value      deletes the extended ACL entries that are specified by 'entries'
      * @return Response object
      * @throws ZosmfRequestException request error state
      * @author James Kostrewski
      */
-    public Response delete(final String targetPath, final String value) throws ZosmfRequestException {
-        return setAclCommon(targetPath, new UssSetAclInputData.Builder().setDelete(value).build());
+    public Response delete(final String filePathName, final String value) throws ZosmfRequestException {
+        return setAclCommon(filePathName, new UssSetAclInputData.Builder().setDelete(value).build());
     }
 
     /**
      * Delete all extended ACL entries by type (setfacl -D type):
      *
-     * @param targetPath UNIX path to the target file or directory
+    * @param filePathName UNIX path to the target file or directory
      * @param deleteType deletes the extended ACL entries that are specified by type
      * @return Response object
      * @throws ZosmfRequestException request error state
      * @author James Kostrewski
      */
-    public Response deleteByType(final String targetPath, final DeleteAclType deleteType) throws ZosmfRequestException {
-        return setAclCommon(targetPath, new UssSetAclInputData.Builder().setDeleteType(deleteType).build());
+    public Response deleteByType(final String filePathName, final DeleteAclType deleteType)
+            throws ZosmfRequestException {
+        return setAclCommon(filePathName, new UssSetAclInputData.Builder().setDeleteType(deleteType).build());
     }
 
     /**
      * Sets the ACL for a USS file or directory request driven by UssSetAclInputData object settings
      *
-     * @param targetPath      UNIX path to the target file or directory
+    * @param filePathName    UNIX path to the target file or directory
      * @param setAclInputData UssSetAclInputData object to drive the request
      * @return Response object
      * @throws ZosmfRequestException request error state
      * @author James Kostrewski
      */
-    public Response setAclCommon(final String targetPath, final UssSetAclInputData setAclInputData)
+    public Response setAclCommon(final String filePathName, final UssSetAclInputData setAclInputData)
             throws ZosmfRequestException {
-        ValidateUtils.checkIllegalParameter(targetPath, "targetPath");
+        ValidateUtils.checkIllegalParameter(filePathName, "filePathName");
         ValidateUtils.checkNullParameter(setAclInputData, "setAclInputData");
         ValidateUtils.checkIllegalParameter(setAclInputData.getSet().isEmpty() &&
                 setAclInputData.getModify().isEmpty() && setAclInputData.getDelete().isEmpty() &&
@@ -141,7 +142,7 @@ public class UssSetAcl {
         final String url = connection.getZosmfUrl() +
                 ZosFilesConstants.RESOURCE +
                 ZosFilesConstants.RES_USS_FILES +
-                EncodeUtils.encodeURIComponent(FileUtils.validatePath(targetPath));
+                EncodeUtils.encodeURIComponent(FileUtils.validatePath(filePathName));
 
         final Map<String, Object> setAclMap = new HashMap<>();
         setAclMap.put("request", "setfacl");

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssGetAclTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssGetAclTest.java
@@ -1,0 +1,136 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosfiles.uss.methods;
+
+import kong.unirest.core.Cookie;
+import org.json.simple.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import zowe.client.sdk.core.ZosConnection;
+import zowe.client.sdk.core.ZosConnectionFactory;
+import zowe.client.sdk.rest.PutJsonZosmfRequest;
+import zowe.client.sdk.rest.Response;
+import zowe.client.sdk.rest.ZosmfRequest;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
+import zowe.client.sdk.zosfiles.uss.input.UssGetAclInputData;
+import zowe.client.sdk.zosfiles.uss.types.GetAclType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
+
+/**
+ * Class containing unit tests for UssGetAcl.
+ *
+ * @author Ashish Kumar Dash
+ * @version 6.0
+ */
+public class UssGetAclTest {
+
+    private final ZosConnection connection = ZosConnectionFactory
+            .createBasicConnection("1", 443, "1", "1");
+    private final ZosConnection tokenConnection = ZosConnectionFactory
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
+    private PutJsonZosmfRequest mockJsonPutRequest;
+    private PutJsonZosmfRequest mockJsonPutRequestToken;
+    private UssGetAcl ussGetAcl;
+
+    @BeforeEach
+    public void init() throws ZosmfRequestException {
+        mockJsonPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
+        Mockito.when(mockJsonPutRequest.executeRequest()).thenReturn(
+                new Response(new JSONObject(), 200, "success"));
+        doCallRealMethod().when(mockJsonPutRequest).setUrl(any());
+        doCallRealMethod().when(mockJsonPutRequest).getUrl();
+
+        mockJsonPutRequestToken = Mockito.mock(PutJsonZosmfRequest.class,
+                withSettings().useConstructor(tokenConnection));
+        Mockito.when(mockJsonPutRequestToken.executeRequest()).thenReturn(
+                new Response(new JSONObject(), 200, "success"));
+        doCallRealMethod().when(mockJsonPutRequestToken).setHeaders(anyMap());
+        doCallRealMethod().when(mockJsonPutRequestToken).setStandardHeaders();
+        doCallRealMethod().when(mockJsonPutRequestToken).setUrl(any());
+        doCallRealMethod().when(mockJsonPutRequestToken).getHeaders();
+        doCallRealMethod().when(mockJsonPutRequestToken).getUrl();
+
+        ussGetAcl=new UssGetAcl(connection);
+    }
+
+    @Test
+    public void tstUssGetAclCommonSuccess() throws ZosmfRequestException {
+        final UssGetAcl ussGetAcl = new UssGetAcl(connection, mockJsonPutRequest);
+        final Response response = ussGetAcl.getAclCommon("/test",
+                new UssGetAclInputData.Builder().build());
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Ftest", mockJsonPutRequest.getUrl());
+
+        final Map<String, Object> getAclMap = new HashMap<>();
+        getAclMap.put("request", "getfacl");
+        verify(mockJsonPutRequest).setBody(new JSONObject(getAclMap).toString());
+    }
+
+    @Test
+    public void tstUssGetAclCommonWithParamsSuccess() throws ZosmfRequestException {
+        final UssGetAcl ussGetAcl = new UssGetAcl(connection, mockJsonPutRequest);
+        final UssGetAclInputData inputData = new UssGetAclInputData.Builder()
+                .type(GetAclType.DIR)
+                .user("IBMUSER")
+                .usecommas(true)
+                .suppressheader(true)
+                .suppressbaseacl(true)
+                .build();
+        final Response response = ussGetAcl.getAclCommon("/test", inputData);
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Ftest", mockJsonPutRequest.getUrl());
+
+        final Map<String, Object> getAclMap = new HashMap<>();
+        getAclMap.put("request", "getfacl");
+        getAclMap.put("type", GetAclType.DIR.getValue());
+        getAclMap.put("user", "IBMUSER");
+        getAclMap.put("use-commas", true);
+        getAclMap.put("suppress-header", true);
+        getAclMap.put("suppress-baseacl", true);
+        verify(mockJsonPutRequest).setBody(new JSONObject(getAclMap).toString());
+    }
+
+    @Test
+    public void tstUssGetAclToggleTokenSuccess() throws ZosmfRequestException {
+        final UssGetAcl ussGetAcl = new UssGetAcl(tokenConnection, mockJsonPutRequestToken);
+        final Response response = ussGetAcl.getAclCommon("/test",
+                new UssGetAclInputData.Builder().build());
+        assertEquals("{X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
+                mockJsonPutRequestToken.getHeaders().toString());
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Ftest", mockJsonPutRequestToken.getUrl());
+    }
+
+    @Test
+    public void tstUssGetAclSecondaryConstructorWithValidRequestType() {
+        ZosConnection connection=Mockito.mock(ZosConnection.class);
+        ZosmfRequest request=Mockito.mock(PutJsonZosmfRequest.class);
+        UssGetAcl ussGetAcl=new UssGetAcl(connection, request);
+        assertNotNull(ussGetAcl);
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssSetAclTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssSetAclTest.java
@@ -1,0 +1,158 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosfiles.uss.methods;
+
+import kong.unirest.core.Cookie;
+import org.json.simple.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import zowe.client.sdk.core.ZosConnection;
+import zowe.client.sdk.core.ZosConnectionFactory;
+import zowe.client.sdk.rest.PutJsonZosmfRequest;
+import zowe.client.sdk.rest.Response;
+import zowe.client.sdk.rest.ZosmfRequest;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
+import zowe.client.sdk.zosfiles.uss.types.DeleteAclType;
+import zowe.client.sdk.zosfiles.uss.types.LinkType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
+
+/**
+ * Class containing unit tests for UssSetAcl.
+ *
+ * @author Ashish Kumar Dash
+ * @version 6.0
+ */
+public class UssSetAclTest {
+
+    private final ZosConnection connection = ZosConnectionFactory
+            .createBasicConnection("1", 443, "1", "1");
+    private final ZosConnection tokenConnection = ZosConnectionFactory
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
+    private PutJsonZosmfRequest mockJsonPutRequest;
+    private PutJsonZosmfRequest mockJsonPutRequestToken;
+    private UssSetAcl ussSetAcl;
+
+    @BeforeEach
+    public void init() throws ZosmfRequestException {
+        mockJsonPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
+        Mockito.when(mockJsonPutRequest.executeRequest()).thenReturn(
+                new Response(new JSONObject(), 200, "success"));
+        doCallRealMethod().when(mockJsonPutRequest).setUrl(any());
+        doCallRealMethod().when(mockJsonPutRequest).getUrl();
+
+        mockJsonPutRequestToken = Mockito.mock(PutJsonZosmfRequest.class,
+                withSettings().useConstructor(tokenConnection));
+        Mockito.when(mockJsonPutRequestToken.executeRequest()).thenReturn(
+                new Response(new JSONObject(), 200, "success"));
+        doCallRealMethod().when(mockJsonPutRequestToken).setHeaders(anyMap());
+        doCallRealMethod().when(mockJsonPutRequestToken).setStandardHeaders();
+        doCallRealMethod().when(mockJsonPutRequestToken).setUrl(any());
+        doCallRealMethod().when(mockJsonPutRequestToken).getHeaders();
+        doCallRealMethod().when(mockJsonPutRequestToken).getUrl();
+
+        ussSetAcl = new UssSetAcl(connection);
+    }
+
+    @Test
+    public void tstUssSetAclSetSuccess() throws ZosmfRequestException {
+        final UssSetAcl ussSetAcl = new UssSetAcl(connection, mockJsonPutRequest);
+        final Response response = ussSetAcl.set("/xxx/xx", "u::rwx");
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxxx%2Fxx", mockJsonPutRequest.getUrl());
+
+        final Map<String, Object> setAclMap = new HashMap<>();
+        setAclMap.put("request", "setfacl");
+        setAclMap.put("links", LinkType.FOLLOW.getValue());
+        setAclMap.put("set", "u::rwx");
+        verify(mockJsonPutRequest).setBody(new JSONObject(setAclMap).toString());
+    }
+
+    @Test
+    public void tstUssSetAclToggleTokenSuccess() throws ZosmfRequestException {
+        final UssSetAcl ussSetAcl = new UssSetAcl(tokenConnection, mockJsonPutRequestToken);
+        final Response response = ussSetAcl.set("/xxx/xx", "u::rwx");
+        assertEquals("{X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
+                mockJsonPutRequestToken.getHeaders().toString());
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxxx%2Fxx", mockJsonPutRequestToken.getUrl());
+    }
+
+    @Test
+    public void tstUssSetAclModifySuccess() throws ZosmfRequestException {
+        final UssSetAcl ussSetAcl = new UssSetAcl(connection, mockJsonPutRequest);
+        final Response response = ussSetAcl.modify("/xxx/xx", "g::r-x");
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxxx%2Fxx", mockJsonPutRequest.getUrl());
+
+        final Map<String, Object> setAclMap = new HashMap<>();
+        setAclMap.put("request", "setfacl");
+        setAclMap.put("links", LinkType.FOLLOW.getValue());
+        setAclMap.put("modify", "g::r-x");
+        verify(mockJsonPutRequest).setBody(new JSONObject(setAclMap).toString());
+    }
+
+    @Test
+    public void tstUssSetAclDeleteSuccess() throws ZosmfRequestException {
+        final UssSetAcl ussSetAcl = new UssSetAcl(connection, mockJsonPutRequest);
+        final Response response = ussSetAcl.delete("/xxx/xx", "u:ibmuser:rwx");
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxxx%2Fxx", mockJsonPutRequest.getUrl());
+
+        final Map<String, Object> setAclMap = new HashMap<>();
+        setAclMap.put("request", "setfacl");
+        setAclMap.put("links", LinkType.FOLLOW.getValue());
+        setAclMap.put("delete", "u:ibmuser:rwx");
+        verify(mockJsonPutRequest).setBody(new JSONObject(setAclMap).toString());
+    }
+
+    @Test
+    public void tstUssSetAclDeleteTypeSuccess() throws ZosmfRequestException {
+        final UssSetAcl ussSetAcl = new UssSetAcl(connection, mockJsonPutRequest);
+        final Response response = ussSetAcl.deleteByType("/xxx/xx", DeleteAclType.ACCESS);
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
+        assertEquals("https://1:443/zosmf/restfiles/fs%2Fxxx%2Fxx", mockJsonPutRequest.getUrl());
+
+        final Map<String, Object> setAclMap = new HashMap<>();
+        setAclMap.put("request", "setfacl");
+        setAclMap.put("links", LinkType.FOLLOW.getValue());
+        setAclMap.put("delete-type", DeleteAclType.ACCESS.getValue());
+        verify(mockJsonPutRequest).setBody(new JSONObject(setAclMap).toString());
+    }
+
+    @Test
+    public void tstUssSetAclSecondaryConstructorWithValidRequestType() {
+        ZosConnection connection = Mockito.mock(ZosConnection.class);
+        ZosmfRequest request = Mockito.mock(PutJsonZosmfRequest.class);
+        UssSetAcl ussSetAcl = new UssSetAcl(connection, request);
+        assertNotNull(ussSetAcl);
+    }
+
+}


### PR DESCRIPTION
## Summary
- Enforce documented mutual-exclusion rules for USS setfacl builder inputs.
- Fix target path validation label in UssSetAcl.
- Add focused UssSetAcl/UssGetAcl method tests for URL/body construction and token headers.
