### PR TITLE
Refactor USS setfacl input creation with controlled factory methods

### DIFF
--- a/src/main/java/zowe/client/sdk/zosfiles/uss/input/factory/SetAclInputFactory.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/input/factory/SetAclInputFactory.java
@@ -1,0 +1,237 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosfiles.uss.input.factory;
+
+import zowe.client.sdk.zosfiles.uss.types.DeleteAclType;
+import zowe.client.sdk.zosfiles.uss.types.LinkType;
+
+/**
+ * Factory class for creating UssSetAclInputData instances.
+ * <p>
+ * This factory provides controlled creation methods for the supported USS setfacl operations.
+ * The setfacl API requires at least one of the following keywords to be specified:
+ * delete-type, set, modify, or delete.
+ * <p>
+ * The modify and delete keywords may be used together. The delete-type and set keywords
+ * cannot be combined with any other ACL operation keyword.
+ *
+ * @author Frank Giordano
+ * @version 6.0
+ */
+public class SetAclInputFactory {
+
+    /**
+     * Create delete-type input data using default abort and links values.
+     *
+     * @param deleteType deleteType value
+     * @return UssSetAclInputData
+     */
+    public UssSetAclInputData createDeleteTypeInput(final DeleteAclType deleteType) {
+        return this.createDeleteTypeInput(deleteType, false, LinkType.FOLLOW);
+    }
+
+    /**
+     * Create delete-type input data using default links value.
+     *
+     * @param deleteType deleteType value
+     * @param abort abort value
+     * @return UssSetAclInputData
+     */
+    public UssSetAclInputData createDeleteTypeInput(final DeleteAclType deleteType,
+                                                    final boolean abort) {
+        return this.createDeleteTypeInput(deleteType, abort, LinkType.FOLLOW);
+    }
+
+    /**
+     * Create delete-type input data.
+     *
+     * @param deleteType deleteType value
+     * @param abort abort value
+     * @param links links value
+     * @return UssSetAclInputData
+     */
+    public UssSetAclInputData createDeleteTypeInput(final DeleteAclType deleteType,
+                                                    final boolean abort,
+                                                    final LinkType links) {
+        return new UssSetAclInputData.Builder()
+                .setDeleteType(deleteType)
+                .setAbort(abort)
+                .setLinks(links)
+                .build();
+    }
+
+    /**
+     * Create delete input data using default abort and links values.
+     *
+     * @param delete delete value
+     * @return UssSetAclInputData
+     */
+    public UssSetAclInputData createDeleteInput(final String delete) {
+        return this.createDeleteInput(delete, false, LinkType.FOLLOW);
+    }
+
+    /**
+     * Create delete input data using default links value.
+     *
+     * @param delete delete value
+     * @param abort abort value
+     * @return UssSetAclInputData
+     */
+    public UssSetAclInputData createDeleteInput(final String delete,
+                                                final boolean abort) {
+        return this.createDeleteInput(delete, abort, LinkType.FOLLOW);
+    }
+
+    /**
+     * Create delete input data.
+     *
+     * @param delete delete value
+     * @param abort abort value
+     * @param links links value
+     * @return UssSetAclInputData
+     */
+    public UssSetAclInputData createDeleteInput(final String delete,
+                                                final boolean abort,
+                                                final LinkType links) {
+        return new UssSetAclInputData.Builder()
+                .setDelete(delete)
+                .setAbort(abort)
+                .setLinks(links)
+                .build();
+    }
+
+    /**
+     * Create modify input data using default abort and links values.
+     *
+     * @param modify modify value
+     * @return UssSetAclInputData
+     */
+    public UssSetAclInputData createModifyInput(final String modify) {
+        return this.createModifyInput(modify, false, LinkType.FOLLOW);
+    }
+
+    /**
+     * Create modify input data using default links value.
+     *
+     * @param modify modify value
+     * @param abort abort value
+     * @return UssSetAclInputData
+     */
+    public UssSetAclInputData createModifyInput(final String modify,
+                                                final boolean abort) {
+        return this.createModifyInput(modify, abort, LinkType.FOLLOW);
+    }
+
+    /**
+     * Create modify input data.
+     *
+     * @param modify modify value
+     * @param abort abort value
+     * @param links links value
+     * @return UssSetAclInputData
+     */
+    public UssSetAclInputData createModifyInput(final String modify,
+                                                final boolean abort,
+                                                final LinkType links) {
+        return new UssSetAclInputData.Builder()
+                .setModify(modify)
+                .setAbort(abort)
+                .setLinks(links)
+                .build();
+    }
+
+    /**
+     * Create set input data using default abort and links values.
+     *
+     * @param set set value
+     * @return UssSetAclInputData
+     */
+    public UssSetAclInputData createSetInput(final String set) {
+        return this.createSetInput(set, false, LinkType.FOLLOW);
+    }
+
+    /**
+     * Create set input data using default links value.
+     *
+     * @param set set value
+     * @param abort abort value
+     * @return UssSetAclInputData
+     */
+    public UssSetAclInputData createSetInput(final String set,
+                                             final boolean abort) {
+        return this.createSetInput(set, abort, LinkType.FOLLOW);
+    }
+
+    /**
+     * Create set input data.
+     *
+     * @param set set value
+     * @param abort abort value
+     * @param links links value
+     * @return UssSetAclInputData
+     */
+    public UssSetAclInputData createSetInput(final String set,
+                                             final boolean abort,
+                                             final LinkType links) {
+        return new UssSetAclInputData.Builder()
+                .setSet(set)
+                .setAbort(abort)
+                .setLinks(links)
+                .build();
+    }
+
+    /**
+     * Create modify and delete input data using default abort and links values.
+     *
+     * @param modify modify value
+     * @param delete delete value
+     * @return UssSetAclInputData
+     */
+    public UssSetAclInputData createModifyDeleteInput(final String modify,
+                                                      final String delete) {
+        return this.createModifyDeleteInput(modify, delete, false, LinkType.FOLLOW);
+    }
+
+    /**
+     * Create modify and delete input data using default links value.
+     *
+     * @param modify modify value
+     * @param delete delete value
+     * @param abort abort value
+     * @return UssSetAclInputData
+     */
+    public UssSetAclInputData createModifyDeleteInput(final String modify,
+                                                      final String delete,
+                                                      final boolean abort) {
+        return this.createModifyDeleteInput(modify, delete, abort, LinkType.FOLLOW);
+    }
+
+    /**
+     * Create modify and delete input data.
+     *
+     * @param modify modify value
+     * @param delete delete value
+     * @param abort abort value
+     * @param links links value
+     * @return UssSetAclInputData
+     */
+    public UssSetAclInputData createModifyDeleteInput(final String modify,
+                                                      final String delete,
+                                                      final boolean abort,
+                                                      final LinkType links) {
+        return new UssSetAclInputData.Builder()
+                .setModify(modify)
+                .setDelete(delete)
+                .setAbort(abort)
+                .setLinks(links)
+                .build();
+    }
+
+}

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/input/factory/UssSetAclInputData.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/input/factory/UssSetAclInputData.java
@@ -7,7 +7,7 @@
  *
  * Copyright Contributors to the Zowe Project.
  */
-package zowe.client.sdk.zosfiles.uss.input;
+package zowe.client.sdk.zosfiles.uss.input.factory;
 
 import zowe.client.sdk.utility.ValidateUtils;
 import zowe.client.sdk.zosfiles.uss.types.DeleteAclType;
@@ -86,7 +86,7 @@ public class UssSetAclInputData {
      *
      * @param builder UssSetAclInputData.Builder builder
      */
-    public UssSetAclInputData(final UssSetAclInputData.Builder builder) {
+    UssSetAclInputData(final UssSetAclInputData.Builder builder) {
         this.abort = builder.abort;
         this.links = builder.links;
         this.deleteType = builder.deleteType;
@@ -169,112 +169,93 @@ public class UssSetAclInputData {
     /**
      * Builder class for UssSetAclInputData
      */
-    public static class Builder {
+    static class Builder {
 
         /**
          * The default is false. When true, aborts processing if an error or warning occurs.
          * See the setfacl command documentation for complete documentation on the errors and warnings (setfacl -a).
          */
-        private boolean abort = false;
+        private boolean abort;
 
         /**
          * The default is 'follow'. 'suppress' does not follow symbolic links.
          * Because ACLs are not associated with symbolic links,
          * nothing happens if a symbolic link is encountered (setfacl -h).
          * <p>
-         * Note:  At least one of the following four keywords must be specified.
+         * Note: At least one of the following four keywords must be specified.
          * 'modify' and 'delete' may both be specified, but not with 'delete-type' and 'set'.
          */
-        private LinkType links = LinkType.FOLLOW;
+        private LinkType links;
 
         /**
-         * Delete all extended ACL entries by type (setfacl -D type):
-         * <p>
-         * access - Access ACL
-         * dir    - Directory default ACL
-         * file   - File default ACL
-         * every  - Every extended ACL for all ACL types that are applicable for the current path name.
-         * <p>
-         * Note: The 'delete-type' keyword cannot be specified with 'set', 'modify' or 'delete'.
+         * Delete all extended ACL entries by type (setfacl -D type).
          */
         private DeleteAclType deleteType;
 
         /**
-         * sets (replaces) all ACLs with 'entries'.
-         * 'entries' represents a string of ACL entries.
-         * Refer to the setfacl command reference for the string format (setfacl -s entries).
-         * <p>
-         * Note: The 'set' keyword cannot be specified with 'delete-type', 'modify' or 'delete'.
+         * Sets, or replaces, all ACLs with entries.
          */
         private String set;
 
         /**
-         * Modifies the ACL entries. 'entries' represents a string of ACL entries.
-         * Refer to the setfacl command reference for the string format.
-         * If an ACL entry does not exist for a user or group specified in 'entries', it is created.
-         * If an ACL entry exists for a user or group specified in 'entries', it is replaced.
-         * <p>
-         * Note: The 'modify' keyword cannot be specified with 'delete-type' or 'set'.
+         * Modifies ACL entries.
          */
         private String modify;
 
         /**
-         * Deletes the extended ACL entries that are specified by 'entries'. 'entries' is a string of ACL entries.
-         * Refer to the setfacl command reference for the string format.
-         * If an ACL entry does not exist for the user or group specified, no error is issued.
-         * <p>
-         * Note: The 'delete' keyword cannot be specified with 'delete-type' or 'set'.
+         * Deletes the specified extended ACL entries.
          */
         private String delete;
 
         /**
          * Create a new Builder instance.
          */
-        public Builder() {
+        Builder() {
             // intentionally empty
         }
 
         /**
-         * Set abort value
+         * Set abort value.
          *
          * @param abort abort value
          * @return UssSetAclInputData.Builder
          */
-        public UssSetAclInputData.Builder setAbort(final boolean abort) {
+        Builder setAbort(final boolean abort) {
             this.abort = abort;
             return this;
         }
 
         /**
-         * Set links value
+         * Set links value.
          *
          * @param links links value
          * @return UssSetAclInputData.Builder
          */
-        public UssSetAclInputData.Builder setLinks(final LinkType links) {
+        Builder setLinks(final LinkType links) {
+            ValidateUtils.checkNullParameter(links, "links");
             this.links = links;
             return this;
         }
 
         /**
-         * Set deleteType value
+         * Set deleteType value.
          *
          * @param deleteType deleteType value
          * @return UssSetAclInputData.Builder
          */
-        public UssSetAclInputData.Builder setDeleteType(final DeleteAclType deleteType) {
+        Builder setDeleteType(final DeleteAclType deleteType) {
             ValidateUtils.checkNullParameter(deleteType, "deleteType");
             this.deleteType = deleteType;
             return this;
         }
 
         /**
-         * Set the SET value
+         * Set the set value.
          *
          * @param set set value
          * @return UssSetAclInputData.Builder
          */
-        public UssSetAclInputData.Builder setSet(final String set) {
+        Builder setSet(final String set) {
             ValidateUtils.checkNullParameter(set, "set");
             ValidateUtils.checkIllegalParameter(set.isBlank(), "set not specified");
             this.set = set;
@@ -282,12 +263,12 @@ public class UssSetAclInputData {
         }
 
         /**
-         * Set modify value
+         * Set modify value.
          *
          * @param modify modify value
          * @return UssSetAclInputData.Builder
          */
-        public UssSetAclInputData.Builder setModify(final String modify) {
+        Builder setModify(final String modify) {
             ValidateUtils.checkNullParameter(modify, "modify");
             ValidateUtils.checkIllegalParameter(modify.isBlank(), "modify not specified");
             this.modify = modify;
@@ -295,12 +276,12 @@ public class UssSetAclInputData {
         }
 
         /**
-         * Set delete value
+         * Set delete value.
          *
          * @param delete delete value
          * @return UssSetAclInputData.Builder
          */
-        public UssSetAclInputData.Builder setDelete(final String delete) {
+        Builder setDelete(final String delete) {
             ValidateUtils.checkNullParameter(delete, "delete");
             ValidateUtils.checkIllegalParameter(delete.isBlank(), "delete not specified");
             this.delete = delete;
@@ -308,11 +289,11 @@ public class UssSetAclInputData {
         }
 
         /**
-         * Build UssSetAclInputData object
+         * Build UssSetAclInputData object.
          *
          * @return UssSetAclInputData
          */
-        public UssSetAclInputData build() {
+        UssSetAclInputData build() {
             return new UssSetAclInputData(this);
         }
 

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/input/factory/package-info.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/input/factory/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Request input factory object(s) for z/OS Unix System Services (USS) files processing
+ */
+package zowe.client.sdk.zosfiles.uss.input.factory;

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssSetAcl.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssSetAcl.java
@@ -150,7 +150,7 @@ public class UssSetAcl {
      */
     public Response setAclCommon(final String targetPath, final UssSetAclInputData setAclInputData)
             throws ZosmfRequestException {
-        ValidateUtils.checkIllegalParameter(targetPath, "filePathName");
+        ValidateUtils.checkIllegalParameter(targetPath, "targetPath");
         ValidateUtils.checkNullParameter(setAclInputData, "setAclInputData");
         ValidateUtils.checkIllegalParameter(setAclInputData.getSet().isEmpty() &&
                 setAclInputData.getModify().isEmpty() && setAclInputData.getDelete().isEmpty() &&

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssSetAcl.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssSetAcl.java
@@ -21,7 +21,8 @@ import zowe.client.sdk.utility.EncodeUtils;
 import zowe.client.sdk.utility.FileUtils;
 import zowe.client.sdk.utility.ValidateUtils;
 import zowe.client.sdk.zosfiles.ZosFilesConstants;
-import zowe.client.sdk.zosfiles.uss.input.UssSetAclInputData;
+import zowe.client.sdk.zosfiles.uss.input.factory.SetAclInputFactory;
+import zowe.client.sdk.zosfiles.uss.input.factory.UssSetAclInputData;
 import zowe.client.sdk.zosfiles.uss.types.DeleteAclType;
 
 import java.util.HashMap;
@@ -73,39 +74,39 @@ public class UssSetAcl {
      * Sets the ACL for a USS file or directory
      *
      * @param targetPath UNIX path to the target file or directory
-     * @param value      sets the extended ACL entries that are specified by 'entries'
+     * @param setValue sets the extended ACL entries that are specified by 'entries'
      * @return Response object
      * @throws ZosmfRequestException request error state
      * @author James Kostrewski
      */
-    public Response set(final String targetPath, final String value) throws ZosmfRequestException {
-        return setAclCommon(targetPath, new UssSetAclInputData.Builder().setSet(value).build());
+    public Response set(final String targetPath, final String setValue) throws ZosmfRequestException {
+        return setAclCommon(targetPath, new SetAclInputFactory().createSetInput(setValue));
     }
 
     /**
      * Modifies the specified ACL entry for the file or directory
      *
      * @param targetPath UNIX path to the target file or directory
-     * @param value      modifies the extended ACL entries that are specified by 'entries'
+     * @param modifyValue modifies the extended ACL entries that are specified by 'entries'
      * @return Response object
      * @throws ZosmfRequestException request error state
      * @author James Kostrewski
      */
-    public Response modify(final String targetPath, final String value) throws ZosmfRequestException {
-        return setAclCommon(targetPath, new UssSetAclInputData.Builder().setModify(value).build());
+    public Response modify(final String targetPath, final String modifyValue) throws ZosmfRequestException {
+        return setAclCommon(targetPath, new SetAclInputFactory().createModifyInput(modifyValue));
     }
 
     /**
      * Deletes the specified ACL entry from the file or directory
      *
      * @param targetPath UNIX path to the target file or directory
-     * @param value      deletes the extended ACL entries that are specified by 'entries'
+     * @param deleteValue deletes the extended ACL entries that are specified by 'entries'
      * @return Response object
      * @throws ZosmfRequestException request error state
      * @author James Kostrewski
      */
-    public Response delete(final String targetPath, final String value) throws ZosmfRequestException {
-        return setAclCommon(targetPath, new UssSetAclInputData.Builder().setDelete(value).build());
+    public Response delete(final String targetPath, final String deleteValue) throws ZosmfRequestException {
+        return setAclCommon(targetPath, new SetAclInputFactory().createDeleteInput(deleteValue));
     }
 
     /**
@@ -119,7 +120,23 @@ public class UssSetAcl {
      */
     public Response deleteByType(final String targetPath, final DeleteAclType deleteType)
             throws ZosmfRequestException {
-        return setAclCommon(targetPath, new UssSetAclInputData.Builder().setDeleteType(deleteType).build());
+        return setAclCommon(targetPath, new SetAclInputFactory().createDeleteTypeInput(deleteType));
+    }
+
+    /**
+     * Modifies the specified ACL entry for the file or directory and deletes the specified ACL
+     * entry from the file or directory
+     *
+     * @param targetPath UNIX path to the target file or directory
+     * @param modifyValue modifies the extended ACL entries that are specified by 'entries'
+     * @param deleteValue deletes the extended ACL entries that are specified by 'entries' type
+     * @return Response object
+     * @throws ZosmfRequestException request error state
+     * @author Frank Giordano
+     */
+    public Response modifyAndDelete(final String targetPath, final String modifyValue, final String deleteValue)
+            throws ZosmfRequestException {
+        return setAclCommon(targetPath, new SetAclInputFactory().createModifyDeleteInput(modifyValue, deleteValue));
     }
 
     /**

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/input/factory/SetAclInputFactoryTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/input/factory/SetAclInputFactoryTest.java
@@ -330,7 +330,7 @@ class SetAclInputFactoryTest {
                 new UssSetAclInputData.Builder().setDelete("")
         );
     }
-    
+
     @Test
     void tstBuilderRejectsNullLinksValueFailure() {
         assertThrows(NullPointerException.class, () ->

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/input/factory/SetAclInputFactoryTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/input/factory/SetAclInputFactoryTest.java
@@ -1,0 +1,413 @@
+
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosfiles.uss.input.factory;
+
+import org.junit.jupiter.api.Test;
+import zowe.client.sdk.zosfiles.uss.types.DeleteAclType;
+import zowe.client.sdk.zosfiles.uss.types.LinkType;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for SetAclInputFactory and UssSetAclInputData.Builder.
+ */
+class SetAclInputFactoryTest {
+
+    /**
+     * Verify createDeleteTypeInput creates input data with default values.
+     */
+    @Test
+    void tstCreateDeleteTypeInputWithDefaultValuesSuccess() {
+        final SetAclInputFactory factory = new SetAclInputFactory();
+
+        final UssSetAclInputData inputData = factory.createDeleteTypeInput(DeleteAclType.ACCESS);
+
+        assertFalse(inputData.isAbort());
+        assertEquals(Optional.of(LinkType.FOLLOW), inputData.getLinks());
+        assertEquals(Optional.of(DeleteAclType.ACCESS), inputData.getDeleteType());
+        assertEquals(Optional.empty(), inputData.getSet());
+        assertEquals(Optional.empty(), inputData.getModify());
+        assertEquals(Optional.empty(), inputData.getDelete());
+    }
+
+    /**
+     * Verify createDeleteTypeInput creates input data with abort value.
+     */
+    @Test
+    void tstCreateDeleteTypeInputWithAbortValueSuccess() {
+        final SetAclInputFactory factory = new SetAclInputFactory();
+
+        final UssSetAclInputData inputData = factory.createDeleteTypeInput(DeleteAclType.ACCESS, true);
+
+        assertTrue(inputData.isAbort());
+        assertEquals(Optional.of(LinkType.FOLLOW), inputData.getLinks());
+        assertEquals(Optional.of(DeleteAclType.ACCESS), inputData.getDeleteType());
+        assertEquals(Optional.empty(), inputData.getSet());
+        assertEquals(Optional.empty(), inputData.getModify());
+        assertEquals(Optional.empty(), inputData.getDelete());
+    }
+
+    /**
+     * Verify createDeleteTypeInput creates input data with abort and links values.
+     */
+    @Test
+    void tstCreateDeleteTypeInputWithAbortAndLinksValuesSuccess() {
+        final SetAclInputFactory factory = new SetAclInputFactory();
+
+        final UssSetAclInputData inputData = factory.createDeleteTypeInput(
+                DeleteAclType.ACCESS,
+                true,
+                LinkType.SUPPRESS
+        );
+
+        assertTrue(inputData.isAbort());
+        assertEquals(Optional.of(LinkType.SUPPRESS), inputData.getLinks());
+        assertEquals(Optional.of(DeleteAclType.ACCESS), inputData.getDeleteType());
+        assertEquals(Optional.empty(), inputData.getSet());
+        assertEquals(Optional.empty(), inputData.getModify());
+        assertEquals(Optional.empty(), inputData.getDelete());
+    }
+
+    /**
+     * Verify createDeleteInput creates input data with default values.
+     */
+    @Test
+    void tstCreateDeleteInputWithDefaultValuesSuccess() {
+        final SetAclInputFactory factory = new SetAclInputFactory();
+
+        final UssSetAclInputData inputData = factory.createDeleteInput("user:test:rwx");
+
+        assertFalse(inputData.isAbort());
+        assertEquals(Optional.of(LinkType.FOLLOW), inputData.getLinks());
+        assertEquals(Optional.empty(), inputData.getDeleteType());
+        assertEquals(Optional.empty(), inputData.getSet());
+        assertEquals(Optional.empty(), inputData.getModify());
+        assertEquals(Optional.of("user:test:rwx"), inputData.getDelete());
+    }
+
+    /**
+     * Verify createDeleteInput creates input data with abort and links values.
+     */
+    @Test
+    void tstCreateDeleteInputWithAbortAndLinksValuesSuccess() {
+        final SetAclInputFactory factory = new SetAclInputFactory();
+
+        final UssSetAclInputData inputData = factory.createDeleteInput(
+                "user:test:rwx",
+                true,
+                LinkType.SUPPRESS
+        );
+
+        assertTrue(inputData.isAbort());
+        assertEquals(Optional.of(LinkType.SUPPRESS), inputData.getLinks());
+        assertEquals(Optional.empty(), inputData.getDeleteType());
+        assertEquals(Optional.empty(), inputData.getSet());
+        assertEquals(Optional.empty(), inputData.getModify());
+        assertEquals(Optional.of("user:test:rwx"), inputData.getDelete());
+    }
+
+    /**
+     * Verify createModifyInput creates input data with default values.
+     */
+    @Test
+    void tstCreateModifyInputWithDefaultValuesSuccess() {
+        final SetAclInputFactory factory = new SetAclInputFactory();
+
+        final UssSetAclInputData inputData = factory.createModifyInput("user:test:rwx");
+
+        assertFalse(inputData.isAbort());
+        assertEquals(Optional.of(LinkType.FOLLOW), inputData.getLinks());
+        assertEquals(Optional.empty(), inputData.getDeleteType());
+        assertEquals(Optional.empty(), inputData.getSet());
+        assertEquals(Optional.of("user:test:rwx"), inputData.getModify());
+        assertEquals(Optional.empty(), inputData.getDelete());
+    }
+
+    /**
+     * Verify createModifyInput creates input data with abort and links values.
+     */
+    @Test
+    void tstCreateModifyInputWithAbortAndLinksValuesSuccess() {
+        final SetAclInputFactory factory = new SetAclInputFactory();
+
+        final UssSetAclInputData inputData = factory.createModifyInput(
+                "user:test:rwx",
+                true,
+                LinkType.SUPPRESS
+        );
+
+        assertTrue(inputData.isAbort());
+        assertEquals(Optional.of(LinkType.SUPPRESS), inputData.getLinks());
+        assertEquals(Optional.empty(), inputData.getDeleteType());
+        assertEquals(Optional.empty(), inputData.getSet());
+        assertEquals(Optional.of("user:test:rwx"), inputData.getModify());
+        assertEquals(Optional.empty(), inputData.getDelete());
+    }
+
+    /**
+     * Verify createSetInput creates input data with default values.
+     */
+    @Test
+    void tstCreateSetInputWithDefaultValuesSuccess() {
+        final SetAclInputFactory factory = new SetAclInputFactory();
+
+        final UssSetAclInputData inputData = factory.createSetInput("user:test:rwx");
+
+        assertFalse(inputData.isAbort());
+        assertEquals(Optional.of(LinkType.FOLLOW), inputData.getLinks());
+        assertEquals(Optional.empty(), inputData.getDeleteType());
+        assertEquals(Optional.of("user:test:rwx"), inputData.getSet());
+        assertEquals(Optional.empty(), inputData.getModify());
+        assertEquals(Optional.empty(), inputData.getDelete());
+    }
+
+    /**
+     * Verify createSetInput creates input data with abort and links values.
+     */
+    @Test
+    void tstCreateSetInputWithAbortAndLinksValuesSuccess() {
+        final SetAclInputFactory factory = new SetAclInputFactory();
+
+        final UssSetAclInputData inputData = factory.createSetInput(
+                "user:test:rwx",
+                true,
+                LinkType.SUPPRESS
+        );
+
+        assertTrue(inputData.isAbort());
+        assertEquals(Optional.of(LinkType.SUPPRESS), inputData.getLinks());
+        assertEquals(Optional.empty(), inputData.getDeleteType());
+        assertEquals(Optional.of("user:test:rwx"), inputData.getSet());
+        assertEquals(Optional.empty(), inputData.getModify());
+        assertEquals(Optional.empty(), inputData.getDelete());
+    }
+
+    /**
+     * Verify createModifyDeleteInput creates input data with default values.
+     */
+    @Test
+    void tstCreateModifyDeleteInputWithDefaultValuesSuccess() {
+        final SetAclInputFactory factory = new SetAclInputFactory();
+
+        final UssSetAclInputData inputData = factory.createModifyDeleteInput(
+                "user:test:rwx",
+                "group:test:r-x"
+        );
+
+        assertFalse(inputData.isAbort());
+        assertEquals(Optional.of(LinkType.FOLLOW), inputData.getLinks());
+        assertEquals(Optional.empty(), inputData.getDeleteType());
+        assertEquals(Optional.empty(), inputData.getSet());
+        assertEquals(Optional.of("user:test:rwx"), inputData.getModify());
+        assertEquals(Optional.of("group:test:r-x"), inputData.getDelete());
+    }
+
+    /**
+     * Verify createModifyDeleteInput creates input data with abort and links values.
+     */
+    @Test
+    void tstCreateModifyDeleteInputWithAbortAndLinksValuesSuccess() {
+        final SetAclInputFactory factory = new SetAclInputFactory();
+
+        final UssSetAclInputData inputData = factory.createModifyDeleteInput(
+                "user:test:rwx",
+                "group:test:r-x",
+                true,
+                LinkType.SUPPRESS
+        );
+
+        assertTrue(inputData.isAbort());
+        assertEquals(Optional.of(LinkType.SUPPRESS), inputData.getLinks());
+        assertEquals(Optional.empty(), inputData.getDeleteType());
+        assertEquals(Optional.empty(), inputData.getSet());
+        assertEquals(Optional.of("user:test:rwx"), inputData.getModify());
+        assertEquals(Optional.of("group:test:r-x"), inputData.getDelete());
+    }
+
+    /**
+     * Verify builder creates delete-type input data.
+     */
+    @Test
+    void tstBuilderCreatesDeleteTypeInputDataSuccess() {
+        final UssSetAclInputData inputData = new UssSetAclInputData.Builder()
+                .setDeleteType(DeleteAclType.ACCESS)
+                .setAbort(true)
+                .setLinks(LinkType.SUPPRESS)
+                .build();
+
+        assertTrue(inputData.isAbort());
+        assertEquals(Optional.of(LinkType.SUPPRESS), inputData.getLinks());
+        assertEquals(Optional.of(DeleteAclType.ACCESS), inputData.getDeleteType());
+        assertEquals(Optional.empty(), inputData.getSet());
+        assertEquals(Optional.empty(), inputData.getModify());
+        assertEquals(Optional.empty(), inputData.getDelete());
+    }
+
+    /**
+     * Verify builder creates set input data.
+     */
+    @Test
+    void tstBuilderCreatesSetInputDataSuccess() {
+        final UssSetAclInputData inputData = new UssSetAclInputData.Builder()
+                .setSet("user:test:rwx")
+                .setAbort(true)
+                .setLinks(LinkType.SUPPRESS)
+                .build();
+
+        assertTrue(inputData.isAbort());
+        assertEquals(Optional.of(LinkType.SUPPRESS), inputData.getLinks());
+        assertEquals(Optional.empty(), inputData.getDeleteType());
+        assertEquals(Optional.of("user:test:rwx"), inputData.getSet());
+        assertEquals(Optional.empty(), inputData.getModify());
+        assertEquals(Optional.empty(), inputData.getDelete());
+    }
+
+    /**
+     * Verify builder creates modify input data.
+     */
+    @Test
+    void tstBuilderCreatesModifyInputDataSuccess() {
+        final UssSetAclInputData inputData = new UssSetAclInputData.Builder()
+                .setModify("user:test:rwx")
+                .setAbort(true)
+                .setLinks(LinkType.SUPPRESS)
+                .build();
+
+        assertTrue(inputData.isAbort());
+        assertEquals(Optional.of(LinkType.SUPPRESS), inputData.getLinks());
+        assertEquals(Optional.empty(), inputData.getDeleteType());
+        assertEquals(Optional.empty(), inputData.getSet());
+        assertEquals(Optional.of("user:test:rwx"), inputData.getModify());
+        assertEquals(Optional.empty(), inputData.getDelete());
+    }
+
+    /**
+     * Verify builder creates delete input data.
+     */
+    @Test
+    void tstBuilderCreatesDeleteInputDataSuccess() {
+        final UssSetAclInputData inputData = new UssSetAclInputData.Builder()
+                .setDelete("user:test:rwx")
+                .setAbort(true)
+                .setLinks(LinkType.SUPPRESS)
+                .build();
+
+        assertTrue(inputData.isAbort());
+        assertEquals(Optional.of(LinkType.SUPPRESS), inputData.getLinks());
+        assertEquals(Optional.empty(), inputData.getDeleteType());
+        assertEquals(Optional.empty(), inputData.getSet());
+        assertEquals(Optional.empty(), inputData.getModify());
+        assertEquals(Optional.of("user:test:rwx"), inputData.getDelete());
+    }
+
+    /**
+     * Verify builder creates modify and delete input data.
+     */
+    @Test
+    void tstBuilderCreatesModifyDeleteInputDataSuccess() {
+        final UssSetAclInputData inputData = new UssSetAclInputData.Builder()
+                .setModify("user:test:rwx")
+                .setDelete("group:test:r-x")
+                .setAbort(true)
+                .setLinks(LinkType.SUPPRESS)
+                .build();
+
+        assertTrue(inputData.isAbort());
+        assertEquals(Optional.of(LinkType.SUPPRESS), inputData.getLinks());
+        assertEquals(Optional.empty(), inputData.getDeleteType());
+        assertEquals(Optional.empty(), inputData.getSet());
+        assertEquals(Optional.of("user:test:rwx"), inputData.getModify());
+        assertEquals(Optional.of("group:test:r-x"), inputData.getDelete());
+    }
+
+    /**
+     * Verify builder rejects null deleteType value.
+     */
+    @Test
+    void tstBuilderRejectsNullDeleteTypeValueFailure() {
+        assertThrows(NullPointerException.class, () ->
+                new UssSetAclInputData.Builder().setDeleteType(null)
+        );
+    }
+
+    /**
+     * Verify builder rejects null set value.
+     */
+    @Test
+    void tstBuilderRejectsNullSetValueFailure() {
+        assertThrows(NullPointerException.class, () ->
+                new UssSetAclInputData.Builder().setSet(null)
+        );
+    }
+
+    /**
+     * Verify builder rejects blank set value.
+     */
+    @Test
+    void tstBuilderRejectsBlankSetValueFailure() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new UssSetAclInputData.Builder().setSet("")
+        );
+    }
+
+    /**
+     * Verify builder rejects null modify value.
+     */
+    @Test
+    void tstBuilderRejectsNullModifyValueFailure() {
+        assertThrows(NullPointerException.class, () ->
+                new UssSetAclInputData.Builder().setModify(null)
+        );
+    }
+
+    /**
+     * Verify builder rejects blank modify value.
+     */
+    @Test
+    void tstBuilderRejectsBlankModifyValueFailure() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new UssSetAclInputData.Builder().setModify("")
+        );
+    }
+
+    /**
+     * Verify builder rejects null delete value.
+     */
+    @Test
+    void tstBuilderRejectsNullDeleteValueFailure() {
+        assertThrows(NullPointerException.class, () ->
+                new UssSetAclInputData.Builder().setDelete(null)
+        );
+    }
+
+    /**
+     * Verify builder rejects blank delete value.
+     */
+    @Test
+    void tstBuilderRejectsBlankDeleteValueFailure() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new UssSetAclInputData.Builder().setDelete("")
+        );
+    }
+
+    /**
+     * Verify builder rejects null links value.
+     */
+    @Test
+    void tstBuilderRejectsNullLinksValueFailure() {
+        assertThrows(NullPointerException.class, () ->
+                new UssSetAclInputData.Builder().setLinks(null)
+        );
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/input/factory/SetAclInputFactoryTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/input/factory/SetAclInputFactoryTest.java
@@ -23,9 +23,6 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class SetAclInputFactoryTest {
 
-    /**
-     * Verify createDeleteTypeInput creates input data with default values.
-     */
     @Test
     void tstCreateDeleteTypeInputWithDefaultValuesSuccess() {
         final SetAclInputFactory factory = new SetAclInputFactory();
@@ -40,9 +37,6 @@ class SetAclInputFactoryTest {
         assertEquals(Optional.empty(), inputData.getDelete());
     }
 
-    /**
-     * Verify createDeleteTypeInput creates input data with abort value.
-     */
     @Test
     void tstCreateDeleteTypeInputWithAbortValueSuccess() {
         final SetAclInputFactory factory = new SetAclInputFactory();
@@ -57,9 +51,6 @@ class SetAclInputFactoryTest {
         assertEquals(Optional.empty(), inputData.getDelete());
     }
 
-    /**
-     * Verify createDeleteTypeInput creates input data with abort and links values.
-     */
     @Test
     void tstCreateDeleteTypeInputWithAbortAndLinksValuesSuccess() {
         final SetAclInputFactory factory = new SetAclInputFactory();
@@ -78,9 +69,6 @@ class SetAclInputFactoryTest {
         assertEquals(Optional.empty(), inputData.getDelete());
     }
 
-    /**
-     * Verify createDeleteInput creates input data with default values.
-     */
     @Test
     void tstCreateDeleteInputWithDefaultValuesSuccess() {
         final SetAclInputFactory factory = new SetAclInputFactory();
@@ -95,9 +83,6 @@ class SetAclInputFactoryTest {
         assertEquals(Optional.of("user:test:rwx"), inputData.getDelete());
     }
 
-    /**
-     * Verify createDeleteInput creates input data with abort and links values.
-     */
     @Test
     void tstCreateDeleteInputWithAbortAndLinksValuesSuccess() {
         final SetAclInputFactory factory = new SetAclInputFactory();
@@ -116,9 +101,6 @@ class SetAclInputFactoryTest {
         assertEquals(Optional.of("user:test:rwx"), inputData.getDelete());
     }
 
-    /**
-     * Verify createModifyInput creates input data with default values.
-     */
     @Test
     void tstCreateModifyInputWithDefaultValuesSuccess() {
         final SetAclInputFactory factory = new SetAclInputFactory();
@@ -133,9 +115,6 @@ class SetAclInputFactoryTest {
         assertEquals(Optional.empty(), inputData.getDelete());
     }
 
-    /**
-     * Verify createModifyInput creates input data with abort and links values.
-     */
     @Test
     void tstCreateModifyInputWithAbortAndLinksValuesSuccess() {
         final SetAclInputFactory factory = new SetAclInputFactory();
@@ -154,9 +133,6 @@ class SetAclInputFactoryTest {
         assertEquals(Optional.empty(), inputData.getDelete());
     }
 
-    /**
-     * Verify createSetInput creates input data with default values.
-     */
     @Test
     void tstCreateSetInputWithDefaultValuesSuccess() {
         final SetAclInputFactory factory = new SetAclInputFactory();
@@ -171,9 +147,6 @@ class SetAclInputFactoryTest {
         assertEquals(Optional.empty(), inputData.getDelete());
     }
 
-    /**
-     * Verify createSetInput creates input data with abort and links values.
-     */
     @Test
     void tstCreateSetInputWithAbortAndLinksValuesSuccess() {
         final SetAclInputFactory factory = new SetAclInputFactory();
@@ -192,9 +165,6 @@ class SetAclInputFactoryTest {
         assertEquals(Optional.empty(), inputData.getDelete());
     }
 
-    /**
-     * Verify createModifyDeleteInput creates input data with default values.
-     */
     @Test
     void tstCreateModifyDeleteInputWithDefaultValuesSuccess() {
         final SetAclInputFactory factory = new SetAclInputFactory();
@@ -212,9 +182,6 @@ class SetAclInputFactoryTest {
         assertEquals(Optional.of("group:test:r-x"), inputData.getDelete());
     }
 
-    /**
-     * Verify createModifyDeleteInput creates input data with abort and links values.
-     */
     @Test
     void tstCreateModifyDeleteInputWithAbortAndLinksValuesSuccess() {
         final SetAclInputFactory factory = new SetAclInputFactory();
@@ -234,9 +201,6 @@ class SetAclInputFactoryTest {
         assertEquals(Optional.of("group:test:r-x"), inputData.getDelete());
     }
 
-    /**
-     * Verify builder creates delete-type input data.
-     */
     @Test
     void tstBuilderCreatesDeleteTypeInputDataSuccess() {
         final UssSetAclInputData inputData = new UssSetAclInputData.Builder()
@@ -253,9 +217,6 @@ class SetAclInputFactoryTest {
         assertEquals(Optional.empty(), inputData.getDelete());
     }
 
-    /**
-     * Verify builder creates set input data.
-     */
     @Test
     void tstBuilderCreatesSetInputDataSuccess() {
         final UssSetAclInputData inputData = new UssSetAclInputData.Builder()
@@ -272,9 +233,6 @@ class SetAclInputFactoryTest {
         assertEquals(Optional.empty(), inputData.getDelete());
     }
 
-    /**
-     * Verify builder creates modify input data.
-     */
     @Test
     void tstBuilderCreatesModifyInputDataSuccess() {
         final UssSetAclInputData inputData = new UssSetAclInputData.Builder()
@@ -291,9 +249,6 @@ class SetAclInputFactoryTest {
         assertEquals(Optional.empty(), inputData.getDelete());
     }
 
-    /**
-     * Verify builder creates delete input data.
-     */
     @Test
     void tstBuilderCreatesDeleteInputDataSuccess() {
         final UssSetAclInputData inputData = new UssSetAclInputData.Builder()
@@ -310,9 +265,6 @@ class SetAclInputFactoryTest {
         assertEquals(Optional.of("user:test:rwx"), inputData.getDelete());
     }
 
-    /**
-     * Verify builder creates modify and delete input data.
-     */
     @Test
     void tstBuilderCreatesModifyDeleteInputDataSuccess() {
         final UssSetAclInputData inputData = new UssSetAclInputData.Builder()
@@ -330,9 +282,6 @@ class SetAclInputFactoryTest {
         assertEquals(Optional.of("group:test:r-x"), inputData.getDelete());
     }
 
-    /**
-     * Verify builder rejects null deleteType value.
-     */
     @Test
     void tstBuilderRejectsNullDeleteTypeValueFailure() {
         assertThrows(NullPointerException.class, () ->
@@ -340,9 +289,6 @@ class SetAclInputFactoryTest {
         );
     }
 
-    /**
-     * Verify builder rejects null set value.
-     */
     @Test
     void tstBuilderRejectsNullSetValueFailure() {
         assertThrows(NullPointerException.class, () ->
@@ -350,9 +296,6 @@ class SetAclInputFactoryTest {
         );
     }
 
-    /**
-     * Verify builder rejects blank set value.
-     */
     @Test
     void tstBuilderRejectsBlankSetValueFailure() {
         assertThrows(IllegalArgumentException.class, () ->
@@ -360,9 +303,6 @@ class SetAclInputFactoryTest {
         );
     }
 
-    /**
-     * Verify builder rejects null modify value.
-     */
     @Test
     void tstBuilderRejectsNullModifyValueFailure() {
         assertThrows(NullPointerException.class, () ->
@@ -370,9 +310,6 @@ class SetAclInputFactoryTest {
         );
     }
 
-    /**
-     * Verify builder rejects blank modify value.
-     */
     @Test
     void tstBuilderRejectsBlankModifyValueFailure() {
         assertThrows(IllegalArgumentException.class, () ->
@@ -380,9 +317,6 @@ class SetAclInputFactoryTest {
         );
     }
 
-    /**
-     * Verify builder rejects null delete value.
-     */
     @Test
     void tstBuilderRejectsNullDeleteValueFailure() {
         assertThrows(NullPointerException.class, () ->
@@ -390,19 +324,13 @@ class SetAclInputFactoryTest {
         );
     }
 
-    /**
-     * Verify builder rejects blank delete value.
-     */
     @Test
     void tstBuilderRejectsBlankDeleteValueFailure() {
         assertThrows(IllegalArgumentException.class, () ->
                 new UssSetAclInputData.Builder().setDelete("")
         );
     }
-
-    /**
-     * Verify builder rejects null links value.
-     */
+    
     @Test
     void tstBuilderRejectsNullLinksValueFailure() {
         assertThrows(NullPointerException.class, () ->

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssSetAclTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssSetAclTest.java
@@ -216,7 +216,7 @@ class UssSetAclTest {
                 ZosFilesConstants.RES_USS_FILES +
                 EncodeUtils.encodeURIComponent(FileUtils.validatePath(TARGET_PATH));
     }
-    
+
     private JSONObject getRequestBody() throws Exception {
         final ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
         verify(request).setBody(bodyCaptor.capture());

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssSetAclTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssSetAclTest.java
@@ -1,0 +1,227 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosfiles.uss.methods;
+
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import zowe.client.sdk.core.ZosConnection;
+import zowe.client.sdk.rest.PutJsonZosmfRequest;
+import zowe.client.sdk.rest.Response;
+import zowe.client.sdk.rest.ZosmfRequest;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
+import zowe.client.sdk.utility.EncodeUtils;
+import zowe.client.sdk.utility.FileUtils;
+import zowe.client.sdk.zosfiles.ZosFilesConstants;
+import zowe.client.sdk.zosfiles.uss.input.factory.SetAclInputFactory;
+import zowe.client.sdk.zosfiles.uss.input.factory.UssSetAclInputData;
+import zowe.client.sdk.zosfiles.uss.types.DeleteAclType;
+import zowe.client.sdk.zosfiles.uss.types.LinkType;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for UssSetAcl.
+ */
+class UssSetAclTest {
+
+    private static final String ZOSMF_URL = "https://example.com/zosmf";
+    private static final String TARGET_PATH = "/u/test/file.txt";
+
+    private ZosConnection connection;
+    private PutJsonZosmfRequest request;
+    private Response response;
+    private UssSetAcl ussSetAcl;
+
+    @BeforeEach
+    void setUp() throws ZosmfRequestException {
+        connection = mock(ZosConnection.class);
+        request = mock(PutJsonZosmfRequest.class);
+        response = mock(Response.class);
+
+        when(connection.getZosmfUrl()).thenReturn(ZOSMF_URL);
+        when(request.executeRequest()).thenReturn(response);
+
+        ussSetAcl = new UssSetAcl(connection, request);
+    }
+
+    @Test
+    void tstDefaultConstructorRejectsNullConnectionFailure() {
+        assertThrows(NullPointerException.class, () -> new UssSetAcl(null));
+    }
+
+    @Test
+    void tstConstructorRejectsNullConnectionFailure() {
+        assertThrows(NullPointerException.class, () -> new UssSetAcl(null, request));
+    }
+
+    @Test
+    void tstConstructorRejectsNullRequestFailure() {
+        assertThrows(NullPointerException.class, () -> new UssSetAcl(connection, null));
+    }
+
+    @Test
+    void tstConstructorRejectsNonPutJsonRequestFailure() {
+        final ZosmfRequest invalidRequest = mock(ZosmfRequest.class);
+
+        assertThrows(IllegalStateException.class, () -> new UssSetAcl(connection, invalidRequest));
+    }
+
+    @Test
+    void tstSetCreatesSetAclRequestBodyWithSetValueSuccess() throws Exception {
+        final Response actualResponse = ussSetAcl.set(TARGET_PATH, "user:test:rwx");
+
+        assertSame(response, actualResponse);
+        verify(request).setUrl(getExpectedUrl());
+        final JSONObject body = getRequestBody();
+
+        assertEquals("setfacl", body.get("request"));
+        assertEquals(LinkType.FOLLOW.getValue(), body.get("links"));
+        assertEquals("user:test:rwx", body.get("set"));
+        assertFalse(body.containsKey("abort"));
+        assertFalse(body.containsKey("modify"));
+        assertFalse(body.containsKey("delete"));
+        assertFalse(body.containsKey("delete-type"));
+    }
+
+    @Test
+    void tstModifyCreatesSetAclRequestBodyWithModifyValueSuccess() throws Exception {
+        final Response actualResponse = ussSetAcl.modify(TARGET_PATH, "user:test:rwx");
+
+        assertSame(response, actualResponse);
+        verify(request).setUrl(getExpectedUrl());
+        final JSONObject body = getRequestBody();
+
+        assertEquals("setfacl", body.get("request"));
+        assertEquals(LinkType.FOLLOW.getValue(), body.get("links"));
+        assertEquals("user:test:rwx", body.get("modify"));
+        assertFalse(body.containsKey("abort"));
+        assertFalse(body.containsKey("set"));
+        assertFalse(body.containsKey("delete"));
+        assertFalse(body.containsKey("delete-type"));
+    }
+
+    @Test
+    void tstDeleteCreatesSetAclRequestBodyWithDeleteValueSuccess() throws Exception {
+        final Response actualResponse = ussSetAcl.delete(TARGET_PATH, "user:test:rwx");
+
+        assertSame(response, actualResponse);
+        verify(request).setUrl(getExpectedUrl());
+        final JSONObject body = getRequestBody();
+
+        assertEquals("setfacl", body.get("request"));
+        assertEquals(LinkType.FOLLOW.getValue(), body.get("links"));
+        assertEquals("user:test:rwx", body.get("delete"));
+        assertFalse(body.containsKey("abort"));
+        assertFalse(body.containsKey("set"));
+        assertFalse(body.containsKey("modify"));
+        assertFalse(body.containsKey("delete-type"));
+    }
+
+    @Test
+    void tstDeleteByTypeCreatesSetAclRequestBodyWithDeleteTypeValueSuccess() throws Exception {
+        final Response actualResponse = ussSetAcl.deleteByType(TARGET_PATH, DeleteAclType.ACCESS);
+
+        assertSame(response, actualResponse);
+        verify(request).setUrl(getExpectedUrl());
+        final JSONObject body = getRequestBody();
+
+        assertEquals("setfacl", body.get("request"));
+        assertEquals(LinkType.FOLLOW.getValue(), body.get("links"));
+        assertEquals(DeleteAclType.ACCESS.getValue(), body.get("delete-type"));
+        assertFalse(body.containsKey("abort"));
+        assertFalse(body.containsKey("set"));
+        assertFalse(body.containsKey("modify"));
+        assertFalse(body.containsKey("delete"));
+    }
+
+    @Test
+    void tstModifyAndDeleteCreatesSetAclRequestBodyWithModifyAndDeleteValuesSuccess() throws Exception {
+        final Response actualResponse = ussSetAcl.modifyAndDelete(
+                TARGET_PATH,
+                "user:test:rwx",
+                "group:test:r-x"
+        );
+
+        assertSame(response, actualResponse);
+        verify(request).setUrl(getExpectedUrl());
+        final JSONObject body = getRequestBody();
+
+        assertEquals("setfacl", body.get("request"));
+        assertEquals(LinkType.FOLLOW.getValue(), body.get("links"));
+        assertEquals("user:test:rwx", body.get("modify"));
+        assertEquals("group:test:r-x", body.get("delete"));
+        assertFalse(body.containsKey("abort"));
+        assertFalse(body.containsKey("set"));
+        assertFalse(body.containsKey("delete-type"));
+    }
+
+    @Test
+    void tstSetAclCommonCreatesRequestBodyWithAbortAndSuppressLinksValuesSuccess() throws Exception {
+        final UssSetAclInputData inputData = new SetAclInputFactory().createSetInput(
+                "user:test:rwx",
+                true,
+                LinkType.SUPPRESS
+        );
+
+        final Response actualResponse = ussSetAcl.setAclCommon(TARGET_PATH, inputData);
+
+        assertSame(response, actualResponse);
+        verify(request).setUrl(getExpectedUrl());
+        final JSONObject body = getRequestBody();
+
+        assertEquals("setfacl", body.get("request"));
+        assertEquals(true, body.get("abort"));
+        assertEquals(LinkType.SUPPRESS.getValue(), body.get("links"));
+        assertEquals("user:test:rwx", body.get("set"));
+        assertFalse(body.containsKey("modify"));
+        assertFalse(body.containsKey("delete"));
+        assertFalse(body.containsKey("delete-type"));
+    }
+
+    @Test
+    void tstSetAclCommonRejectsNullInputDataFailure() {
+        assertThrows(NullPointerException.class, () -> ussSetAcl.setAclCommon(TARGET_PATH, null));
+    }
+
+    @Test
+    void tstSetAclCommonRejectsBlankTargetPathFailure() {
+        final UssSetAclInputData inputData = new SetAclInputFactory().createSetInput("user:test:rwx");
+
+        assertThrows(IllegalArgumentException.class, () -> ussSetAcl.setAclCommon("", inputData));
+    }
+
+    @Test
+    void tstSetAclCommonExecutesRequestSuccess() throws Exception {
+        final UssSetAclInputData inputData = new SetAclInputFactory().createSetInput("user:test:rwx");
+
+        ussSetAcl.setAclCommon(TARGET_PATH, inputData);
+
+        verify(request).executeRequest();
+    }
+
+    private String getExpectedUrl() {
+        return ZOSMF_URL +
+                ZosFilesConstants.RESOURCE +
+                ZosFilesConstants.RES_USS_FILES +
+                EncodeUtils.encodeURIComponent(FileUtils.validatePath(TARGET_PATH));
+    }
+    
+    private JSONObject getRequestBody() throws Exception {
+        final ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(request).setBody(bodyCaptor.capture());
+
+        return (JSONObject) new JSONParser().parse(bodyCaptor.getValue());
+    }
+
+}


### PR DESCRIPTION
## Summary

Refactored USS `setfacl` input creation to use a controlled factory pattern instead of exposing direct builder usage.

This change introduces `SetAclInputFactory` as the public creation path for `UssSetAclInputData`, ensuring only valid `setfacl` keyword combinations are created.

## Changes

- Added `SetAclInputFactory` for creating `UssSetAclInputData` instances.
- Added factory methods for supported `setfacl` operations:
  - `createSetInput(...)`
  - `createModifyInput(...)`
  - `createDeleteInput(...)`
  - `createDeleteTypeInput(...)`
  - `createModifyDeleteInput(...)`
- Updated `UssSetAcl` methods to use `SetAclInputFactory` instead of directly using `UssSetAclInputData.Builder`.
- Changed `UssSetAclInputData.Builder` to package-private so external users cannot create invalid ACL input combinations directly.
- Kept factory defaults aligned with the z/OSMF API behavior:
  - `abort = false`
  - `links = LinkType.FOLLOW`
- Added validation for required ACL operation values.
- Added validation for `links` to prevent null values.
- Added Javadocs for the new factory class and methods.
- Added unit test coverage for:
  - Factory-created `set`, `modify`, `delete`, `delete-type`, and `modify/delete` inputs.
  - Builder behavior from within the same package.
  - `UssSetAcl` request body generation.
  - URL/body setup and request execution.
  - Constructor and invalid parameter scenarios.

## Reason for Change

The previous builder pattern allowed callers to create invalid `setfacl` input combinations, such as combining `set` with `modify`, or `delete-type` with other ACL operation keywords.

The z/OSMF `setfacl` API only allows certain combinations:

- `modify` and `delete` may be used together.
- `set` cannot be combined with `modify`, `delete`, or `delete-type`.
- `delete-type` cannot be combined with `set`, `modify`, or `delete`.

The new factory methods make those valid combinations explicit and prevent misuse by keeping the builder internal to the package.

## Testing

Added unit tests to verify:

- Correct default values are applied.
- Correct request JSON is generated for each supported `setfacl` operation.
- Invalid null or blank values are rejected.
- `UssSetAcl` correctly delegates input creation through the factory.
- The request URL, request body, and request execution are handled as expected.