### PR TITLE
test(core): add getZosmfUrl unit tests

### DIFF
--- a/src/test/java/zowe/client/sdk/core/ZosConnectionTest.java
+++ b/src/test/java/zowe/client/sdk/core/ZosConnectionTest.java
@@ -9,10 +9,13 @@
  */
 package zowe.client.sdk.core;
 
-import kong.unirest.core.Cookie;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import kong.unirest.core.Cookie;
 
 /**
  * Unit tests for the equals() and hashCode() implementations of ZosConnection.
@@ -297,6 +300,40 @@ class ZosConnectionTest {
         assertEquals(conn1, conn2, "equal objects should compare equal");
         assertNotEquals(null, conn1, "object must not equal null");
     }
+
+@Test
+void tstGetZosmfUrlWithoutBasePathSuccess() {
+    final ZosConnection conn = ZosConnectionFactory
+            .createBasicConnection("myhost", 443, "user", "pass");
+
+    assertEquals("https://myhost:443/zosmf", conn.getZosmfUrl());
+}
+
+@Test
+void tstGetZosmfUrlWithBasePathSuccess() {
+    final ZosConnection conn = ZosConnectionFactory
+            .createBasicConnection("myhost", 443, "user", "pass", "/custom/api");
+
+    assertEquals("https://myhost:443/custom/api/zosmf", conn.getZosmfUrl());
+}
+
+@Test
+void tstGetZosmfUrlBasePathNormalizationNoDoubleSlashSuccess() {
+    final ZosConnection conn = ZosConnectionFactory
+            .createBasicConnection("myhost", 443, "user", "pass", "custom/api/");
+
+    assertEquals("https://myhost:443/custom/api/zosmf", conn.getZosmfUrl());
+}
+
+@Test
+void tstGetZosmfUrlWithNonStandardPortSuccess() {
+    final ZosConnection conn = ZosConnectionFactory
+            .createBasicConnection("zos.example.com", 1443, "user", "pass");
+
+    assertEquals("https://zos.example.com:1443/zosmf", conn.getZosmfUrl());
+}
+
+
 
     @Test
     void tstInvalidPortNumbersFailure() {


### PR DESCRIPTION
## Summary

Adds dedicated unit tests for `ZosConnection.getZosmfUrl()` in `ZosConnectionTest`.

## Changes

- Tests URL construction without a basePath
- Tests URL construction with a basePath
- Tests basePath normalization to avoid double slashes
- Tests URL construction with a non-standard port

## Testing

- Ran `.\mvnw -Dtest=ZosConnectionTest test`
- Full `.\mvnw test` fails locally with Mockito inline mock errors on Java 23, unrelated to this change