### PR TITLE
Fix USS ZFS query delimiter when path and fsname are combined

### DIFF
--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssList.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssList.java
@@ -159,8 +159,14 @@ public class UssList {
         listZfsInputData.getPath().ifPresent(path ->
                 url.append("?path=").append(EncodeUtils.encodeURIComponent(FileUtils.validatePath(path))));
 
-        listZfsInputData.getFsname().ifPresent(fsname ->
-                url.append("?fsname=").append(EncodeUtils.encodeURIComponent(fsname)));
+        listZfsInputData.getFsname().ifPresent(fsname -> {
+            if (listZfsInputData.getPath().isPresent()) {
+                url.append("&fsname=");
+            } else {
+                url.append("?fsname=");
+            }
+            url.append(EncodeUtils.encodeURIComponent(fsname));
+        });
 
         if (request == null) {
             request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.GET_JSON);


### PR DESCRIPTION
## Summary
Fixes query string construction in `UssList.getZfsSystems` so `fsname` is appended with `&` when `path` is already present.

## Details
Previously, the URL could be formed as `...?path=... ?fsname=...`, which is invalid. This change ensures correct delimiter handling.
