### PR TITLE
fix: use correct getter for RECFM header in JobSubmit

### DIFF
--- a/src/main/java/zowe/client/sdk/zosjobs/methods/JobSubmit.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/methods/JobSubmit.java
@@ -144,7 +144,7 @@ public class JobSubmit {
         }
         if (submitJclInputData.getInternalReaderRecfm().isPresent()) {
             key = ZosmfHeaders.HEADERS.get("X_IBM_INTRDR_RECFM").get(0);
-            headers.put(key, submitJclInputData.getInternalReaderLrecl().get());
+            headers.put(key, submitJclInputData.getInternalReaderRecfm().get());
         } else {
             key = ZosmfHeaders.HEADERS.get("X_IBM_INTRDR_RECFM_F").get(0);
             value = ZosmfHeaders.HEADERS.get("X_IBM_INTRDR_RECFM_F").get(1);


### PR DESCRIPTION
Fixes #488 
In `submitJclCommon()`, the `X-IBM-Intrdr-Recfm` header was set using
`getInternalReaderLrecl().get()` instead of `getInternalReaderRecfm().get()`,
causing the RECFM header to receive the LRECL value.

Changed to use the correct getter.