### PR TITLE
test: add header verification tests for JobSubmit RECFM and LRECL

### DIFF
--- a/src/test/java/zowe/client/sdk/zosjobs/methods/JobSubmitTest.java
+++ b/src/test/java/zowe/client/sdk/zosjobs/methods/JobSubmitTest.java
@@ -228,4 +228,24 @@ public class JobSubmitTest {
                 () -> jobSubmit.submitByLocalFile(null));
     }
 
+    @Test
+    void testSubmitByJclSetsCorrectCustomRecfmAndLreclHeaders() throws ZosmfRequestException {
+        final JobSubmit jobSubmit = new JobSubmit(connection, mockPutTextZosmfRequest);
+        jobSubmit.submitByJcl("//TESTJOB JOB ...", "V", "256");
+        verify(mockPutTextZosmfRequest).setHeaders(argThat(headers ->
+                "V".equals(headers.get("X-IBM-Intrdr-Recfm")) &&
+                "256".equals(headers.get("X-IBM-Intrdr-Lrecl")) &&
+                "TEXT".equals(headers.get("X-IBM-Intrdr-Mode")) &&
+                "A".equals(headers.get("X-IBM-Intrdr-Class"))));
+    }
+
+    @Test
+    void testSubmitByJclSetsCorrectDefaultRecfmAndLreclHeaders() throws ZosmfRequestException {
+        final JobSubmit jobSubmit = new JobSubmit(connection, mockPutTextZosmfRequest);
+        jobSubmit.submitByJcl("//TESTJOB JOB ...", "F", "80");
+        verify(mockPutTextZosmfRequest).setHeaders(argThat(headers ->
+                "F".equals(headers.get("X-IBM-Intrdr-Recfm")) &&
+                "80".equals(headers.get("X-IBM-Intrdr-Lrecl"))));
+    }
+
 }


### PR DESCRIPTION
## Summary
- Adds unit tests to verify that `submitByJcl()` sets the correct `X-IBM-Intrdr-Recfm` and `X-IBM-Intrdr-Lrecl` headers, as a follow-up to #489.
- Tests custom values (RECFM=`V`, LRECL=`256`) and default values (RECFM=`F`, LRECL=`80`) using `verify` with `argThat`.

## Test plan
- [x] All 13 tests pass (`mvn test -Dtest=JobSubmitTest`)
- [x] No new imports or dependencies added