### PR TITLE
fix: add missing copyAllMembers field to toString() in DsnCopyInputData

### DIFF
--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/input/DsnCopyInputData.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/input/DsnCopyInputData.java
@@ -133,6 +133,7 @@ public class DsnCopyInputData {
                 ", toVolser=" + toVolser +
                 ", toDataSet=" + toDataSet +
                 ", replace=" + replace +
+                ", copyAllMembers=" + copyAllMembers +
                 '}';
     }
 


### PR DESCRIPTION
Fixes #493

Added the `copyAllMembers` field to the `toString()` method in `DsnCopyInputData`. The field was defined and had a getter but was not included in the string representation.