### PR TITLE
fix: resolve JDK 11+ compiler and deprecation warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,8 +165,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <source>${maven.compiler.source}</source>
-                    <target>${maven.compiler.target}</target>
+                    <release>11</release>
                     <compilerArgs>
                         <arg>-Xlint:unchecked</arg>
                         <arg>-Xlint:deprecation</arg>

--- a/src/main/java/zowe/client/sdk/rest/ZosmfRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/ZosmfRequest.java
@@ -24,6 +24,7 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import java.io.*;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -332,7 +333,7 @@ public abstract class ZosmfRequest {
         ValidateUtils.checkIllegalParameter(url, "url");
 
         try {
-            new URL(url).toURI();
+            new URI(url).toURL();
         } catch (MalformedURLException | URISyntaxException e) {
             throw new IllegalArgumentException("invalid url: " + url, e);
         }


### PR DESCRIPTION
### Resolved Deprecated URL Constructor

- Location: src/main/java/zowe/client/sdk/rest/ZosmfRequest.java
- Details: In Java 20+, the new URL(String) constructor is deprecated due to potential parsing issues and lack of URL validation.
- Fix: Replaced new URL(url).toURI() with the recommended new URI(url).toURL(). This approach is fully compatible with Java 11 through Java 22+ and compiles warning-free.

### Resolved Compiler System Modules Warning

- Location: pom.xml
- Details: Compiling with <source>11</source> and <target>11</target> on newer JDK versions raises a warning regarding -system module location settings.
- Fix: Configured the maven-compiler-plugin to use <release>11</release>. This properly informs the compiler to verify compatibility against JDK 11 APIs and resolves the system modules warning.