### PR TITLE
Fix TsoReply msgData detection and add tests

### DIFF
--- a/src/main/java/zowe/client/sdk/zostso/methods/TsoReply.java
+++ b/src/main/java/zowe/client/sdk/zostso/methods/TsoReply.java
@@ -9,6 +9,9 @@
  */
 package zowe.client.sdk.zostso.methods;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.PutJsonZosmfRequest;
 import zowe.client.sdk.rest.ZosmfRequest;
@@ -29,6 +32,7 @@ public class TsoReply {
 
     private final ZosConnection connection;
     private ZosmfRequest request;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     /**
      * TsoReply constructor
@@ -83,11 +87,24 @@ public class TsoReply {
         request.setBody("");
 
         final String responseStr = TsoUtils.getResponseStr(request);
-        if (responseStr.contains("msgData")) {
-            final String errMsg = TsoUtils.getMsgDataText(responseStr);
+        if (containsMsgData(responseStr)) {
+            String errMsg = TsoUtils.getMsgDataText(responseStr);
+            if (errMsg.isBlank()) {
+                errMsg = "Response contains msgData";
+            }
             throw new ZosmfRequestException(errMsg);
         }
         return responseStr;
+    }
+
+    private boolean containsMsgData(final String responseStr) {
+        try {
+            final JsonNode rootNode = objectMapper.readTree(responseStr);
+            final JsonNode msgDataNode = rootNode.get("msgData");
+            return msgDataNode != null && !msgDataNode.isNull();
+        } catch (JsonProcessingException ignored) {
+            return false;
+        }
     }
 
 }

--- a/src/test/java/zowe/client/sdk/zostso/methods/TsoReplyTest.java
+++ b/src/test/java/zowe/client/sdk/zostso/methods/TsoReplyTest.java
@@ -133,6 +133,42 @@ public class TsoReplyTest {
     }
 
     /**
+     * Test that a response containing the text "msgData" does not fail unless a msgData field exists.
+     */
+    @Test
+    public void tstTsoReplyIgnoresMsgDataTextInMessageSuccess() {
+        String responseJson = "{\"tsoData\":[{\"TSO MESSAGE\":{\"DATA\":\"contains msgData text\"}}]}";
+
+        try (MockedStatic<TsoUtils> mockResponseUtil = mockStatic(TsoUtils.class)) {
+            mockResponseUtil.when(() -> TsoUtils.getResponseStr(any()))
+                    .thenReturn(responseJson);
+
+            final TsoReply tsoReply = new TsoReply(mockConnection, mockPutRequest);
+            assertDoesNotThrow(() -> tsoReply.reply("SESSION123"));
+        }
+    }
+
+    /**
+     * Test that a response with a msgData object triggers an exception with the message text.
+     */
+    @Test
+    public void tstTsoReplyThrowsOnMsgDataErrorPayloadFailure() {
+        String responseJson = "{\"msgData\":[{\"messageText\":\"TSO error\"}]}";
+
+        try (MockedStatic<TsoUtils> mockResponseUtil = mockStatic(TsoUtils.class)) {
+            mockResponseUtil.when(() -> TsoUtils.getResponseStr(any()))
+                    .thenReturn(responseJson);
+
+            final TsoReply tsoReply = new TsoReply(mockConnection, mockPutRequest);
+            ZosmfRequestException ex = assertThrows(
+                    ZosmfRequestException.class,
+                    () -> tsoReply.reply("SESSION123")
+            );
+            assertEquals("TSO error", ex.getMessage());
+        }
+    }
+
+    /**
      * Test that the alternative constructor throws an exception if the connection is null.
      */
     @Test

--- a/src/test/java/zowe/client/sdk/zostso/methods/TsoReplyTest.java
+++ b/src/test/java/zowe/client/sdk/zostso/methods/TsoReplyTest.java
@@ -158,6 +158,8 @@ public class TsoReplyTest {
         try (MockedStatic<TsoUtils> mockResponseUtil = mockStatic(TsoUtils.class)) {
             mockResponseUtil.when(() -> TsoUtils.getResponseStr(any()))
                     .thenReturn(responseJson);
+            mockResponseUtil.when(() -> TsoUtils.getMsgDataText(any()))
+                .thenCallRealMethod();
 
             final TsoReply tsoReply = new TsoReply(mockConnection, mockPutRequest);
             ZosmfRequestException ex = assertThrows(


### PR DESCRIPTION
## Summary
- Parse TSO reply JSON to detect structured msgData errors.
- Avoid false positives when msgData appears in message text.
- Add unit tests for structured errors and false-positive cases.
