### PR TITLE
chore: remove legacy PowerMock test dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,12 +131,7 @@
             <version>5.12.0</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-reflect</artifactId>
-            <version>2.0.9</version>
-            <scope>test</scope>
-        </dependency>
+
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>

--- a/src/test/java/zowe/client/sdk/zosjobs/methods/JobGetJsonTest.java
+++ b/src/test/java/zowe/client/sdk/zosjobs/methods/JobGetJsonTest.java
@@ -15,7 +15,6 @@ import org.json.simple.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.powermock.reflect.Whitebox;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.core.ZosConnectionFactory;
 import zowe.client.sdk.rest.GetJsonZosmfRequest;
@@ -53,8 +52,7 @@ public class JobGetJsonTest {
     @SuppressWarnings("unchecked")
     public void init() {
         mockJsonGetRequest = Mockito.mock(GetJsonZosmfRequest.class);
-        getJobs = new JobGet(connection);
-        Whitebox.setInternalState(getJobs, "request", mockJsonGetRequest);
+        getJobs = new JobGet(connection, mockJsonGetRequest);
 
         final Map<String, String> jsonMap = getJsonObject();
         jobJson = new JSONObject(jsonMap);

--- a/src/test/java/zowe/client/sdk/zosjobs/methods/JobGetTextTest.java
+++ b/src/test/java/zowe/client/sdk/zosjobs/methods/JobGetTextTest.java
@@ -13,7 +13,6 @@ import kong.unirest.core.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.powermock.reflect.Whitebox;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.core.ZosConnectionFactory;
 import zowe.client.sdk.rest.GetTextZosmfRequest;
@@ -47,10 +46,9 @@ public class JobGetTextTest {
 
     @Test
     public void tstJobGetTextSpoolContentByIdSuccess() throws ZosmfRequestException {
-        JobGet getJobs = new JobGet(connection);
+        JobGet getJobs = new JobGet(connection, mockTextGetRequest);
         Mockito.when(mockTextGetRequest.executeRequest()).thenReturn(
                 new Response("1\n2\n3\n", 200, "success"));
-        Whitebox.setInternalState(getJobs, "request", mockTextGetRequest);
 
         final String results = getJobs.getSpoolContent("jobName", "jobId", 1L);
         assertEquals("https://1:443/zosmf/restjobs/jobs/jobName/jobId/files/1/records", getJobs.getUrl());
@@ -59,10 +57,9 @@ public class JobGetTextTest {
 
     @Test
     public void tstJobGetTextSpoolContentByIdToggleTokenSuccess() throws ZosmfRequestException {
-        JobGet getJobs = new JobGet(tokenConnection);
         GetTextZosmfRequest mockTextGetRequestToken = Mockito.mock(GetTextZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
-        Whitebox.setInternalState(getJobs, "request", mockTextGetRequestToken);
+        JobGet getJobs = new JobGet(tokenConnection, mockTextGetRequestToken);
         Mockito.when(mockTextGetRequestToken.executeRequest()).thenReturn(
                 new Response("1\n2\n3\n", 200, "success"));
         doCallRealMethod().when(mockTextGetRequestToken).setHeaders(anyMap());


### PR DESCRIPTION
#### Description
This PR removes the legacy `powermock-reflect` dependency from the test suite. 

#### Changes Made
* **Refactored Tests:** Updated `JobGetJsonTest.java` and `JobGetTextTest.java` to inject Mockito mocks directly via the package-private `JobGet` constructor, eliminating the need for PowerMock's `Whitebox.setInternalState()` utility.
* **Removed Dependency:** Removed the `powermock-reflect` dependency from the `pom.xml` file.

#### Verification
* Ran `./mvnw clean test` to ensure all 786 tests execute and pass successfully.