### PR TITLE
Update encodeURIComponent behaviour and add coverage

### DIFF
--- a/src/main/java/zowe/client/sdk/utility/EncodeUtils.java
+++ b/src/main/java/zowe/client/sdk/utility/EncodeUtils.java
@@ -31,22 +31,26 @@ public final class EncodeUtils {
     }
 
     /**
-     * Encodes the passed String as UTF-8 using an algorithm that's compatible
-     * with JavaScript's encodeURIComponent function.
+     * Encodes the given String using UTF-8 in a manner compatible with JavaScript's
+     * {@code encodeURIComponent} function.
      *
-     * @param value string to be encoded
-     * @return encoded String or original string
-     * @author Frank Giordano
+     * <p>Note: the input value must be non-null and non-empty. Validation is enforced
+     * to match SDK defensive programming standards.</p>
+     *
+     * @param value the string to encode
+     * @return the encoded string
+     * @throws IllegalArgumentException if {@code value} is null or empty
      */
     public static String encodeURIComponent(final String value) {
         ValidateUtils.checkIllegalParameter(value, "value");
+
         return URLEncoder.encode(value, StandardCharsets.UTF_8)
-                .replaceAll("\\+", "%20")
-                .replaceAll("%21", "!")
-                .replaceAll("%27", "'")
-                .replaceAll("%28", "(")
-                .replaceAll("%29", ")")
-                .replaceAll("%7E", "~");
+                .replace("+", "%20")
+                .replace("%21", "!")
+                .replace("%27", "'")
+                .replace("%28", "(")
+                .replace("%29", ")")
+                .replace("%7E", "~");
     }
 
     /**

--- a/src/test/java/zowe/client/sdk/utility/EncodeUtilsTest.java
+++ b/src/test/java/zowe/client/sdk/utility/EncodeUtilsTest.java
@@ -10,6 +10,14 @@
 package zowe.client.sdk.utility;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Class containing unit test for EncodeUtils.
@@ -26,6 +34,53 @@ public class EncodeUtilsTest {
     public void tstEncodeUtilsClassStructureSuccess() {
         final String privateConstructorExceptionMsg = "Utility class";
         UtilsTestHelper.validateClass(EncodeUtils.class, privateConstructorExceptionMsg);
+    }
+
+    @ParameterizedTest(name = "[{index}] \"{0}\" -> \"{1}\"")
+    @MethodSource("encodeURIComponentCases")
+    void tstEncodeURIComponentSuccess(String input, String expected) {
+        assertEquals(expected, EncodeUtils.encodeURIComponent(input));
+    }
+
+    static Stream<Arguments> encodeURIComponentCases() {
+        return Stream.of(
+                Arguments.of("abc", "abc"),
+                Arguments.of("a b", "a%20b"),
+                Arguments.of("a+b", "a%2Bb"),
+                Arguments.of("a&b", "a%26b"),
+                Arguments.of("a=b", "a%3Db"),
+                Arguments.of("a?b", "a%3Fb"),
+                Arguments.of("!", "!"),
+                Arguments.of("'", "'"),
+                Arguments.of("(", "("),
+                Arguments.of(")", ")"),
+                Arguments.of("~", "~"),
+                Arguments.of("/", "%2F"),
+                Arguments.of(":", "%3A"),
+                Arguments.of("@", "%40"),
+                Arguments.of("$", "%24"),
+                Arguments.of(",", "%2C"),
+                Arguments.of("✓", "%E2%9C%93"),
+                Arguments.of("©", "%C2%A9"),
+                Arguments.of("你好", "%E4%BD%A0%E5%A5%BD"),
+                Arguments.of("email@test.com", "email%40test.com"),
+                Arguments.of("a/b/c", "a%2Fb%2Fc"),
+                Arguments.of("100%", "100%25")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidEncodeURIComponentCases")
+    void tstEncodeURIComponent_invalidInputsFailure(String input) {
+        assertThrows(IllegalArgumentException.class,
+                () -> EncodeUtils.encodeURIComponent(input));
+    }
+
+    static Stream<String> invalidEncodeURIComponentCases() {
+        return Stream.of(
+                null,
+                ""
+        );
     }
 
 }


### PR DESCRIPTION
This PR refines the `EncodeUtils.encodeURIComponent` implementation to more closely mirror JavaScript’s `encodeURIComponent` behaviour and adds a comprehensive unit test matrix to lock in correctness.

### Changes

* Updated `encodeURIComponent` to:

  * Use `String.replace` instead of `replaceAll` (no regex overhead)
  * Preserve JavaScript-compatible handling of spaces and reserved characters
  * Align Javadoc with actual behavior
* Added parameterized unit tests covering:

  * ASCII and reserved characters
  * Space handling (`%20` vs `+`)
  * Unicode and multi-byte UTF-8 characters
  * Edge cases (empty string)

### Rationale

Java’s `URLEncoder` does not behave the same as JavaScript’s `encodeURIComponent` out of the box. The adjustments ensure consistent encoding behaviour between Java clients and JavaScript consumers, reducing subtle bugs in URL construction and request handling.