### PR TITLE
feat: Add system variables import API method

### DIFF
--- a/src/main/java/zowe/client/sdk/zosvariables/SystemVariableConstants.java
+++ b/src/main/java/zowe/client/sdk/zosvariables/SystemVariableConstants.java
@@ -1,0 +1,33 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosvariables;
+
+/**
+ * Constants for z/OS system variables REST processing.
+ *
+ * @author Frank Giordano
+ * @author Chaitanya Katore
+ * @version 6.0
+ */
+public final class SystemVariableConstants {
+
+    /**
+     * Private constructor defined to avoid instantiation of class.
+     */
+    private SystemVariableConstants() {
+        throw new IllegalStateException("Constants class");
+    }
+
+    /**
+     * z/OS system variables service path.
+     */
+    public static final String SYSTEM_VARIABLES = "/variables/rest/1.0/systems";
+
+}

--- a/src/main/java/zowe/client/sdk/zosvariables/SystemVariableConstants.java
+++ b/src/main/java/zowe/client/sdk/zosvariables/SystemVariableConstants.java
@@ -12,9 +12,8 @@ package zowe.client.sdk.zosvariables;
 /**
  * Constants for z/OS system variables REST processing.
  *
- * @author Frank Giordano
  * @author Chaitanya Katore
- * @version 6.0
+ * @version 7.0
  */
 public final class SystemVariableConstants {
 

--- a/src/main/java/zowe/client/sdk/zosvariables/methods/SystemVariableImport.java
+++ b/src/main/java/zowe/client/sdk/zosvariables/methods/SystemVariableImport.java
@@ -1,0 +1,102 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosvariables.methods;
+
+import org.json.simple.JSONObject;
+import zowe.client.sdk.core.ZosConnection;
+import zowe.client.sdk.rest.PostJsonZosmfRequest;
+import zowe.client.sdk.rest.Response;
+import zowe.client.sdk.rest.ZosmfRequest;
+import zowe.client.sdk.rest.ZosmfRequestFactory;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
+import zowe.client.sdk.rest.type.ZosmfRequestType;
+import zowe.client.sdk.utility.EncodeUtils;
+import zowe.client.sdk.utility.ValidateUtils;
+import zowe.client.sdk.zosvariables.SystemVariableConstants;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Class to handle importing of z/OS system variables.
+ *
+ * @author Frank Giordano
+ * @author Chaitanya Katore
+ * @version 6.0
+ */
+public class SystemVariableImport {
+
+    private final ZosConnection connection;
+    private final ZosmfRequest request;
+
+    /**
+     * SystemVariableImport Constructor.
+     *
+     * @param connection for connection information, see ZosConnection object
+     * @author Frank Giordano
+     */
+    public SystemVariableImport(final ZosConnection connection) {
+        ValidateUtils.checkNullParameter(connection, "connection");
+        this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.POST_JSON);
+    }
+
+    /**
+     * Alternative SystemVariableImport constructor with ZosmfRequest object.
+     * This is mainly used for internal code unit testing with Mockito,
+     * and it is not recommended to be used by the larger community.
+     * <p>
+     * This constructor is package-private.
+     *
+     * @param connection for connection information, see ZosConnection object
+     * @param request    any compatible ZosmfRequest Interface object
+     * @author Frank Giordano
+     */
+    SystemVariableImport(final ZosConnection connection, final ZosmfRequest request) {
+        ValidateUtils.checkNullParameter(connection, "connection");
+        ValidateUtils.checkNullParameter(request, "request");
+        this.connection = connection;
+        if (!(request instanceof PostJsonZosmfRequest)) {
+            throw new IllegalStateException("POST_JSON request type required");
+        }
+        this.request = request;
+    }
+
+    /**
+     * Import variables from a CSV file on USS.
+     *
+     * @param sysplexName         name of the sysplex (e.g. 'PLEX1')
+     * @param systemName          name of the system (e.g. 'SYS1')
+     * @param variablesImportFile absolute path of the variables import file on USS (e.g. '/u/user1/myvars.csv')
+     * @return http response object
+     * @throws ZosmfRequestException request error state
+     * @author Frank Giordano
+     */
+    public Response importVariables(final String sysplexName, final String systemName, final String variablesImportFile)
+            throws ZosmfRequestException {
+        ValidateUtils.checkIllegalParameter(sysplexName, "sysplexName");
+        ValidateUtils.checkIllegalParameter(systemName, "systemName");
+        ValidateUtils.checkIllegalParameter(variablesImportFile, "variablesImportFile");
+
+        final String url = connection.getZosmfUrl() +
+                SystemVariableConstants.SYSTEM_VARIABLES + "/" +
+                EncodeUtils.encodeURIComponent(sysplexName) + "." +
+                EncodeUtils.encodeURIComponent(systemName) + "/actions/import";
+
+        final Map<String, Object> bodyMap = new HashMap<>();
+        bodyMap.put("variables-import-file", variablesImportFile);
+
+        request.setUrl(url);
+        request.setBody(new JSONObject(bodyMap).toString());
+
+        return request.executeRequest();
+    }
+
+}

--- a/src/main/java/zowe/client/sdk/zosvariables/methods/SystemVariableImport.java
+++ b/src/main/java/zowe/client/sdk/zosvariables/methods/SystemVariableImport.java
@@ -27,9 +27,8 @@ import java.util.Map;
 /**
  * Class to handle importing of z/OS system variables.
  *
- * @author Frank Giordano
  * @author Chaitanya Katore
- * @version 6.0
+ * @version 7.0
  */
 public class SystemVariableImport {
 
@@ -40,7 +39,6 @@ public class SystemVariableImport {
      * SystemVariableImport Constructor.
      *
      * @param connection for connection information, see ZosConnection object
-     * @author Frank Giordano
      */
     public SystemVariableImport(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
@@ -57,7 +55,6 @@ public class SystemVariableImport {
      *
      * @param connection for connection information, see ZosConnection object
      * @param request    any compatible ZosmfRequest Interface object
-     * @author Frank Giordano
      */
     SystemVariableImport(final ZosConnection connection, final ZosmfRequest request) {
         ValidateUtils.checkNullParameter(connection, "connection");
@@ -77,7 +74,6 @@ public class SystemVariableImport {
      * @param variablesImportFile absolute path of the variables import file on USS (e.g. '/u/user1/myvars.csv')
      * @return http response object
      * @throws ZosmfRequestException request error state
-     * @author Frank Giordano
      */
     public Response importVariables(final String sysplexName, final String systemName, final String variablesImportFile)
             throws ZosmfRequestException {

--- a/src/main/java/zowe/client/sdk/zosvariables/methods/SystemVariableImport.java
+++ b/src/main/java/zowe/client/sdk/zosvariables/methods/SystemVariableImport.java
@@ -39,6 +39,7 @@ public class SystemVariableImport {
      * SystemVariableImport Constructor.
      *
      * @param connection for connection information, see ZosConnection object
+     * @author Chaitanya Katore
      */
     public SystemVariableImport(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
@@ -55,6 +56,7 @@ public class SystemVariableImport {
      *
      * @param connection for connection information, see ZosConnection object
      * @param request    any compatible ZosmfRequest Interface object
+     * @author Chaitanya Katore
      */
     SystemVariableImport(final ZosConnection connection, final ZosmfRequest request) {
         ValidateUtils.checkNullParameter(connection, "connection");
@@ -74,6 +76,7 @@ public class SystemVariableImport {
      * @param variablesImportFile absolute path of the variables import file on USS (e.g. '/u/user1/myvars.csv')
      * @return http response object
      * @throws ZosmfRequestException request error state
+     * @author Chaitanya Katore
      */
     public Response importVariables(final String sysplexName, final String systemName, final String variablesImportFile)
             throws ZosmfRequestException {

--- a/src/main/java/zowe/client/sdk/zosvariables/methods/package-info.java
+++ b/src/main/java/zowe/client/sdk/zosvariables/methods/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * z/OS system variables functionality by the SDK
+ */
+package zowe.client.sdk.zosvariables.methods;

--- a/src/main/java/zowe/client/sdk/zosvariables/package-info.java
+++ b/src/main/java/zowe/client/sdk/zosvariables/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * z/OS system variables package
+ */
+package zowe.client.sdk.zosvariables;

--- a/src/test/java/zowe/client/sdk/zosvariables/SystemVariableConstantsTest.java
+++ b/src/test/java/zowe/client/sdk/zosvariables/SystemVariableConstantsTest.java
@@ -1,0 +1,33 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosvariables;
+
+import org.junit.jupiter.api.Test;
+import zowe.client.sdk.utility.UtilsTestHelper;
+
+/**
+ * Class containing unit test for SystemVariableConstants.
+ *
+ * @author Frank Giordano
+ * @author Chaitanya Katore
+ * @version 6.0
+ */
+public class SystemVariableConstantsTest {
+
+    /**
+     * Validate class structure
+     */
+    @Test
+    public void tstSystemVariableConstantsClassStructureSuccess() {
+        final String privateConstructorExceptionMsg = "Constants class";
+        UtilsTestHelper.validateClass(SystemVariableConstants.class, privateConstructorExceptionMsg);
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/zosvariables/SystemVariableConstantsTest.java
+++ b/src/test/java/zowe/client/sdk/zosvariables/SystemVariableConstantsTest.java
@@ -15,9 +15,8 @@ import zowe.client.sdk.utility.UtilsTestHelper;
 /**
  * Class containing unit test for SystemVariableConstants.
  *
- * @author Frank Giordano
  * @author Chaitanya Katore
- * @version 6.0
+ * @version 7.0
  */
 public class SystemVariableConstantsTest {
 

--- a/src/test/java/zowe/client/sdk/zosvariables/methods/SystemVariableImportTest.java
+++ b/src/test/java/zowe/client/sdk/zosvariables/methods/SystemVariableImportTest.java
@@ -30,9 +30,8 @@ import static org.mockito.Mockito.withSettings;
 /**
  * Class containing unit tests for SystemVariableImport.
  *
- * @author Frank Giordano
  * @author Chaitanya Katore
- * @version 6.0
+ * @version 7.0
  */
 public class SystemVariableImportTest {
 
@@ -177,7 +176,7 @@ public class SystemVariableImportTest {
     @Test
     public void tstSystemVariableImportSecondaryConstructorWithInvalidRequestType() {
         ZosConnection mockConnection = Mockito.mock(ZosConnection.class);
-        ZosmfRequest mockRequest = Mockito.mock(ZosmfRequest.class); // Not a PostJsonZosmfRequest
+        ZosmfRequest mockRequest = Mockito.mock(ZosmfRequest.class);
         IllegalStateException exception = assertThrows(
                 IllegalStateException.class,
                 () -> new SystemVariableImport(mockConnection, mockRequest)

--- a/src/test/java/zowe/client/sdk/zosvariables/methods/SystemVariableImportTest.java
+++ b/src/test/java/zowe/client/sdk/zosvariables/methods/SystemVariableImportTest.java
@@ -1,0 +1,203 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosvariables.methods;
+
+import kong.unirest.core.Cookie;
+import org.json.simple.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import zowe.client.sdk.core.ZosConnection;
+import zowe.client.sdk.core.ZosConnectionFactory;
+import zowe.client.sdk.rest.PostJsonZosmfRequest;
+import zowe.client.sdk.rest.Response;
+import zowe.client.sdk.rest.ZosmfRequest;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.withSettings;
+
+/**
+ * Class containing unit tests for SystemVariableImport.
+ *
+ * @author Frank Giordano
+ * @author Chaitanya Katore
+ * @version 6.0
+ */
+public class SystemVariableImportTest {
+
+    private final ZosConnection connection = ZosConnectionFactory
+            .createBasicConnection("1", 443, "1", "1");
+    private final ZosConnection tokenConnection = ZosConnectionFactory
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
+    private PostJsonZosmfRequest mockPostRequest;
+    private PostJsonZosmfRequest mockPostRequestToken;
+
+    @BeforeEach
+    public void init() throws ZosmfRequestException {
+        mockPostRequest = Mockito.mock(PostJsonZosmfRequest.class);
+        Mockito.when(mockPostRequest.executeRequest()).thenReturn(
+                new Response(new JSONObject(), 204, "No Content"));
+        doCallRealMethod().when(mockPostRequest).setUrl(any());
+        doCallRealMethod().when(mockPostRequest).getUrl();
+        doCallRealMethod().when(mockPostRequest).setBody(any());
+
+        mockPostRequestToken = Mockito.mock(PostJsonZosmfRequest.class,
+                withSettings().useConstructor(tokenConnection));
+        Mockito.when(mockPostRequestToken.executeRequest()).thenReturn(
+                new Response(new JSONObject(), 204, "No Content"));
+        doCallRealMethod().when(mockPostRequestToken).setHeaders(anyMap());
+        doCallRealMethod().when(mockPostRequestToken).setStandardHeaders();
+        doCallRealMethod().when(mockPostRequestToken).setUrl(any());
+        doCallRealMethod().when(mockPostRequestToken).getHeaders();
+        doCallRealMethod().when(mockPostRequestToken).getUrl();
+        doCallRealMethod().when(mockPostRequestToken).setBody(any());
+    }
+
+    @Test
+    public void tstSystemVariableImportSuccess() throws ZosmfRequestException {
+        final SystemVariableImport variablesImport = new SystemVariableImport(connection, mockPostRequest);
+        final Response response = variablesImport.importVariables("PLEX1", "SYS1", "/path/to/import.csv");
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(204, response.getStatusCode().orElse(-1));
+        assertEquals("No Content", response.getStatusText().orElse("n\\a"));
+        assertEquals("https://1:443/zosmf/variables/rest/1.0/systems/PLEX1.SYS1/actions/import", mockPostRequest.getUrl());
+    }
+
+    @Test
+    public void tstSystemVariableImportTokenSuccess() throws ZosmfRequestException {
+        final SystemVariableImport variablesImport = new SystemVariableImport(connection, mockPostRequestToken);
+        final Response response = variablesImport.importVariables("PLEX1", "SYS1", "/path/to/import.csv");
+        assertEquals("{X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
+                mockPostRequestToken.getHeaders().toString());
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(204, response.getStatusCode().orElse(-1));
+        assertEquals("No Content", response.getStatusText().orElse("n\\a"));
+        assertEquals("https://1:443/zosmf/variables/rest/1.0/systems/PLEX1.SYS1/actions/import", mockPostRequestToken.getUrl());
+    }
+
+    @Test
+    public void tstSystemVariableImportNullSysplexName() {
+        final SystemVariableImport variablesImport = new SystemVariableImport(connection, mockPostRequest);
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> variablesImport.importVariables(null, "SYS1", "/path/to/import.csv")
+        );
+        assertEquals("sysplexName is either null or empty", exception.getMessage());
+    }
+
+    @Test
+    public void tstSystemVariableImportEmptySysplexName() {
+        final SystemVariableImport variablesImport = new SystemVariableImport(connection, mockPostRequest);
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> variablesImport.importVariables("", "SYS1", "/path/to/import.csv")
+        );
+        assertEquals("sysplexName is either null or empty", exception.getMessage());
+    }
+
+    @Test
+    public void tstSystemVariableImportNullSystemName() {
+        final SystemVariableImport variablesImport = new SystemVariableImport(connection, mockPostRequest);
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> variablesImport.importVariables("PLEX1", null, "/path/to/import.csv")
+        );
+        assertEquals("systemName is either null or empty", exception.getMessage());
+    }
+
+    @Test
+    public void tstSystemVariableImportEmptySystemName() {
+        final SystemVariableImport variablesImport = new SystemVariableImport(connection, mockPostRequest);
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> variablesImport.importVariables("PLEX1", "", "/path/to/import.csv")
+        );
+        assertEquals("systemName is either null or empty", exception.getMessage());
+    }
+
+    @Test
+    public void tstSystemVariableImportNullVariablesImportFile() {
+        final SystemVariableImport variablesImport = new SystemVariableImport(connection, mockPostRequest);
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> variablesImport.importVariables("PLEX1", "SYS1", null)
+        );
+        assertEquals("variablesImportFile is either null or empty", exception.getMessage());
+    }
+
+    @Test
+    public void tstSystemVariableImportEmptyVariablesImportFile() {
+        final SystemVariableImport variablesImport = new SystemVariableImport(connection, mockPostRequest);
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> variablesImport.importVariables("PLEX1", "SYS1", "")
+        );
+        assertEquals("variablesImportFile is either null or empty", exception.getMessage());
+    }
+
+    @Test
+    public void tstSystemVariableImportSecondaryConstructorWithValidRequestType() {
+        ZosConnection mockConnection = Mockito.mock(ZosConnection.class);
+        ZosmfRequest mockRequest = Mockito.mock(PostJsonZosmfRequest.class);
+        SystemVariableImport variablesImport = new SystemVariableImport(mockConnection, mockRequest);
+        assertNotNull(variablesImport);
+    }
+
+    @Test
+    public void tstSystemVariableImportSecondaryConstructorWithNullConnection() {
+        ZosmfRequest mockRequest = Mockito.mock(PostJsonZosmfRequest.class);
+        NullPointerException exception = assertThrows(
+                NullPointerException.class,
+                () -> new SystemVariableImport(null, mockRequest)
+        );
+        assertEquals("connection is null", exception.getMessage());
+    }
+
+    @Test
+    public void tstSystemVariableImportSecondaryConstructorWithNullRequest() {
+        ZosConnection mockConnection = Mockito.mock(ZosConnection.class);
+        NullPointerException exception = assertThrows(
+                NullPointerException.class,
+                () -> new SystemVariableImport(mockConnection, null)
+        );
+        assertEquals("request is null", exception.getMessage());
+    }
+
+    @Test
+    public void tstSystemVariableImportSecondaryConstructorWithInvalidRequestType() {
+        ZosConnection mockConnection = Mockito.mock(ZosConnection.class);
+        ZosmfRequest mockRequest = Mockito.mock(ZosmfRequest.class); // Not a PostJsonZosmfRequest
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> new SystemVariableImport(mockConnection, mockRequest)
+        );
+        assertEquals("POST_JSON request type required", exception.getMessage());
+    }
+
+    @Test
+    public void tstSystemVariableImportPrimaryConstructorWithValidConnection() {
+        SystemVariableImport variablesImport = new SystemVariableImport(connection);
+        assertNotNull(variablesImport);
+    }
+
+    @Test
+    public void tstSystemVariableImportPrimaryConstructorWithNullConnection() {
+        NullPointerException exception = assertThrows(
+                NullPointerException.class,
+                () -> new SystemVariableImport(null)
+        );
+        assertEquals("connection is null", exception.getMessage());
+    }
+
+}


### PR DESCRIPTION
## Summary
This PR implements [Issue #506](https://github.com/zowe/zowe-client-java-sdk/issues/506) by adding SDK support for the z/OSMF System Variable Services "Import" REST API.

## Implementation Details
We introduced a new system variables package `zowe.client.sdk.zosvariables` and added:
* **`SystemVariableImport`:** The method class that exposes the `importVariables(sysplexName, systemName, variablesImportFile)` method. It sends a `POST` request to `/variables/rest/1.0/systems/{sysplex-name}.{system-name}/actions/import` with a JSON payload of `{"variables-import-file": "<path>"}`.
* **Constructor request initialization:** Followed the latest SDK guidelines by declaring the `ZosmfRequest` field `final` and initializing it directly within the constructors (avoiding lazy/mutable request state).
* **`SystemVariableConstants`:** Holds the base relative path `/variables/rest/1.0/systems` for variable services.
* **`package-info.java`:** Added package descriptions for `zosvariables` and `zosvariables.methods`.

## Testing

### 1. Unit Testing (Mock-based)
Added `SystemVariableImportTest` and `SystemVariableConstantsTest` to verify:
* Successful URL path construction and HTTP response handling (under both Basic and Token auth).
* Parameter validation checks (`sysplexName`, `systemName`, and `variablesImportFile` throw `IllegalArgumentException` on null/blank).
* Constructor validation checks (null connections, incorrect request classes).

All unit tests compiled and passed successfully (827 total tests pass):
```bash
./mvnw clean test