### PR TITLE
add z/OSMF create workflow API

### DIFF
--- a/src/main/java/zowe/client/sdk/zosworkflow/WorkflowConstants.java
+++ b/src/main/java/zowe/client/sdk/zosworkflow/WorkflowConstants.java
@@ -1,0 +1,42 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosworkflow;
+
+/**
+ * Constants to be used by the z/OSMF workflow API.
+ *
+ * @author Ashish Kumar Dash
+ * @version 6.0
+ */
+public final class WorkflowConstants {
+
+    /**
+     * Private constructor defined to avoid instantiation of class
+     */
+    private WorkflowConstants() {
+        throw new IllegalStateException("Constants class");
+    }
+
+    /**
+     * Indicator for the workflow REST service.
+     */
+    public static final String RESOURCE = "/workflow/rest";
+
+    /**
+     * Supported workflow service version.
+     */
+    public static final String VERSION = "/1.0";
+
+    /**
+     * Indicator for workflow collection operations.
+     */
+    public static final String WORKFLOWS = "/workflows";
+
+}

--- a/src/main/java/zowe/client/sdk/zosworkflow/WorkflowConstants.java
+++ b/src/main/java/zowe/client/sdk/zosworkflow/WorkflowConstants.java
@@ -11,32 +11,29 @@ package zowe.client.sdk.zosworkflow;
 
 /**
  * Constants to be used by the z/OSMF workflow API.
+ * <p>
+ * <a href="https://www.ibm.com/docs/en/zos/3.2.0?topic=services-zosmf-workflow-services">z/OSMF REST API</a>
  *
  * @author Ashish Kumar Dash
- * @version 6.0
+ * @version 7.0
  */
 public final class WorkflowConstants {
 
     /**
-     * Private constructor defined to avoid instantiation of class
+     * Private constructor defined to avoid instantiation of class.
      */
     private WorkflowConstants() {
         throw new IllegalStateException("Constants class");
     }
 
     /**
-     * Indicator for the workflow REST service.
+     * Version of the z/OSMF workflow service.
      */
-    public static final String RESOURCE = "/workflow/rest";
+    private static final String VERSION = "1.0";
 
     /**
-     * Supported workflow service version.
+     * z/OSMF workflow service path.
      */
-    public static final String VERSION = "/1.0";
-
-    /**
-     * Indicator for workflow collection operations.
-     */
-    public static final String WORKFLOWS = "/workflows";
+    public static final String RESOURCE = "/workflow/rest/" + VERSION + "/workflows";
 
 }

--- a/src/main/java/zowe/client/sdk/zosworkflow/input/WorkflowCreateInputData.java
+++ b/src/main/java/zowe/client/sdk/zosworkflow/input/WorkflowCreateInputData.java
@@ -1,0 +1,317 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosworkflow.input;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import zowe.client.sdk.zosworkflow.model.WorkflowVariable;
+
+import java.util.List;
+
+/**
+ * Parameters for the z/OSMF create workflow API input data.
+ *
+ * @author Ashish Kumar Dash
+ * @version 6.0
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class WorkflowCreateInputData {
+
+    private final String workflowName;
+    private final String workflowDefinitionFile;
+    private final String workflowDefinitionFileSystem;
+    private final String variableInputFile;
+    private final List<WorkflowVariable> variables;
+    private final String resolveGlobalConflictByUsing;
+    private final String system;
+    private final String owner;
+    private final String workflowArchiveSAFID;
+    private final String comments;
+    private final Boolean assignToOwner;
+    private final String accessType;
+    private final String accountInfo;
+    private final List<String> jobStatement;
+    private final Boolean deleteCompletedJobs;
+    private final String jobsOutputDirectory;
+    private final Boolean autoDeleteOnCompletion;
+    private final String targetSystemuid;
+    private final String targetSystempwd;
+
+    /**
+     * WorkflowCreateInputData constructor.
+     *
+     * @param builder builder instance
+     */
+    private WorkflowCreateInputData(final Builder builder) {
+        this.workflowName = builder.workflowName;
+        this.workflowDefinitionFile = builder.workflowDefinitionFile;
+        this.workflowDefinitionFileSystem = builder.workflowDefinitionFileSystem;
+        this.variableInputFile = builder.variableInputFile;
+        this.variables = builder.variables;
+        this.resolveGlobalConflictByUsing = builder.resolveGlobalConflictByUsing;
+        this.system = builder.system;
+        this.owner = builder.owner;
+        this.workflowArchiveSAFID = builder.workflowArchiveSAFID;
+        this.comments = builder.comments;
+        this.assignToOwner = builder.assignToOwner;
+        this.accessType = builder.accessType;
+        this.accountInfo = builder.accountInfo;
+        this.jobStatement = builder.jobStatement;
+        this.deleteCompletedJobs = builder.deleteCompletedJobs;
+        this.jobsOutputDirectory = builder.jobsOutputDirectory;
+        this.autoDeleteOnCompletion = builder.autoDeleteOnCompletion;
+        this.targetSystemuid = builder.targetSystemuid;
+        this.targetSystempwd = builder.targetSystempwd;
+    }
+
+    /**
+     * Create a new builder for workflow create input data.
+     *
+     * @return builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for workflow create input data.
+     */
+    public static final class Builder {
+
+        private String workflowName;
+        private String workflowDefinitionFile;
+        private String workflowDefinitionFileSystem;
+        private String variableInputFile;
+        private List<WorkflowVariable> variables;
+        private String resolveGlobalConflictByUsing;
+        private String system;
+        private String owner;
+        private String workflowArchiveSAFID;
+        private String comments;
+        private Boolean assignToOwner;
+        private String accessType;
+        private String accountInfo;
+        private List<String> jobStatement;
+        private Boolean deleteCompletedJobs;
+        private String jobsOutputDirectory;
+        private Boolean autoDeleteOnCompletion;
+        private String targetSystemuid;
+        private String targetSystempwd;
+
+        private Builder() {
+        }
+
+        public Builder workflowName(final String workflowName) {
+            this.workflowName = workflowName;
+            return this;
+        }
+
+        public Builder workflowDefinitionFile(final String workflowDefinitionFile) {
+            this.workflowDefinitionFile = workflowDefinitionFile;
+            return this;
+        }
+
+        public Builder workflowDefinitionFileSystem(final String workflowDefinitionFileSystem) {
+            this.workflowDefinitionFileSystem = workflowDefinitionFileSystem;
+            return this;
+        }
+
+        public Builder variableInputFile(final String variableInputFile) {
+            this.variableInputFile = variableInputFile;
+            return this;
+        }
+
+        public Builder variables(final List<WorkflowVariable> variables) {
+            this.variables = variables;
+            return this;
+        }
+
+        public Builder resolveGlobalConflictByUsing(final String resolveGlobalConflictByUsing) {
+            this.resolveGlobalConflictByUsing = resolveGlobalConflictByUsing;
+            return this;
+        }
+
+        public Builder system(final String system) {
+            this.system = system;
+            return this;
+        }
+
+        public Builder owner(final String owner) {
+            this.owner = owner;
+            return this;
+        }
+
+        public Builder workflowArchiveSAFID(final String workflowArchiveSAFID) {
+            this.workflowArchiveSAFID = workflowArchiveSAFID;
+            return this;
+        }
+
+        public Builder comments(final String comments) {
+            this.comments = comments;
+            return this;
+        }
+
+        public Builder assignToOwner(final Boolean assignToOwner) {
+            this.assignToOwner = assignToOwner;
+            return this;
+        }
+
+        public Builder accessType(final String accessType) {
+            this.accessType = accessType;
+            return this;
+        }
+
+        public Builder accountInfo(final String accountInfo) {
+            this.accountInfo = accountInfo;
+            return this;
+        }
+
+        public Builder jobStatement(final List<String> jobStatement) {
+            this.jobStatement = jobStatement;
+            return this;
+        }
+
+        public Builder deleteCompletedJobs(final Boolean deleteCompletedJobs) {
+            this.deleteCompletedJobs = deleteCompletedJobs;
+            return this;
+        }
+
+        public Builder jobsOutputDirectory(final String jobsOutputDirectory) {
+            this.jobsOutputDirectory = jobsOutputDirectory;
+            return this;
+        }
+
+        public Builder autoDeleteOnCompletion(final Boolean autoDeleteOnCompletion) {
+            this.autoDeleteOnCompletion = autoDeleteOnCompletion;
+            return this;
+        }
+
+        public Builder targetSystemuid(final String targetSystemuid) {
+            this.targetSystemuid = targetSystemuid;
+            return this;
+        }
+
+        public Builder targetSystempwd(final String targetSystempwd) {
+            this.targetSystempwd = targetSystempwd;
+            return this;
+        }
+
+        public WorkflowCreateInputData build() {
+            return new WorkflowCreateInputData(this);
+        }
+
+    }
+
+    public String getWorkflowName() {
+        return workflowName;
+    }
+
+    public String getWorkflowDefinitionFile() {
+        return workflowDefinitionFile;
+    }
+
+    public String getWorkflowDefinitionFileSystem() {
+        return workflowDefinitionFileSystem;
+    }
+
+    public String getVariableInputFile() {
+        return variableInputFile;
+    }
+
+    public List<WorkflowVariable> getVariables() {
+        return variables;
+    }
+
+    public String getResolveGlobalConflictByUsing() {
+        return resolveGlobalConflictByUsing;
+    }
+
+    public String getSystem() {
+        return system;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public String getWorkflowArchiveSAFID() {
+        return workflowArchiveSAFID;
+    }
+
+    public String getComments() {
+        return comments;
+    }
+
+    public Boolean getAssignToOwner() {
+        return assignToOwner;
+    }
+
+    public String getAccessType() {
+        return accessType;
+    }
+
+    public String getAccountInfo() {
+        return accountInfo;
+    }
+
+    public List<String> getJobStatement() {
+        return jobStatement;
+    }
+
+    public Boolean getDeleteCompletedJobs() {
+        return deleteCompletedJobs;
+    }
+
+    public String getJobsOutputDirectory() {
+        return jobsOutputDirectory;
+    }
+
+    public Boolean getAutoDeleteOnCompletion() {
+        return autoDeleteOnCompletion;
+    }
+
+    public String getTargetSystemuid() {
+        return targetSystemuid;
+    }
+
+    public String getTargetSystempwd() {
+        return targetSystempwd;
+    }
+
+    /**
+     * Return string value representing WorkflowCreateInputData object.
+     *
+     * @return string representation of WorkflowCreateInputData
+     */
+    @Override
+    public String toString() {
+        return "WorkflowCreateInputData{" +
+                "workflowName='" + workflowName + '\'' +
+                ", workflowDefinitionFile='" + workflowDefinitionFile + '\'' +
+                ", workflowDefinitionFileSystem='" + workflowDefinitionFileSystem + '\'' +
+                ", variableInputFile='" + variableInputFile + '\'' +
+                ", variables=" + variables +
+                ", resolveGlobalConflictByUsing='" + resolveGlobalConflictByUsing + '\'' +
+                ", system='" + system + '\'' +
+                ", owner='" + owner + '\'' +
+                ", workflowArchiveSAFID='" + workflowArchiveSAFID + '\'' +
+                ", comments='" + comments + '\'' +
+                ", assignToOwner=" + assignToOwner +
+                ", accessType='" + accessType + '\'' +
+                ", accountInfo='" + accountInfo + '\'' +
+                ", jobStatement=" + jobStatement +
+                ", deleteCompletedJobs=" + deleteCompletedJobs +
+                ", jobsOutputDirectory='" + jobsOutputDirectory + '\'' +
+                ", autoDeleteOnCompletion=" + autoDeleteOnCompletion +
+                ", targetSystemuid='" + targetSystemuid + '\'' +
+                ", targetSystempwd='" + targetSystempwd + '\'' +
+                '}';
+    }
+
+}

--- a/src/main/java/zowe/client/sdk/zosworkflow/input/WorkflowCreateInputData.java
+++ b/src/main/java/zowe/client/sdk/zosworkflow/input/WorkflowCreateInputData.java
@@ -16,31 +16,108 @@ import java.util.List;
 
 /**
  * Parameters for the z/OSMF create workflow API input data.
+ * <p>
+ * <a href="https://www.ibm.com/docs/en/zos/3.2.0?topic=services-zosmf-workflow-services">z/OSMF REST API</a>
  *
  * @author Ashish Kumar Dash
- * @version 6.0
+ * @version 7.0
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class WorkflowCreateInputData {
 
+    /**
+     * Descriptive name for the workflow.
+     */
     private final String workflowName;
+
+    /**
+     * Location of the workflow definition file.
+     */
     private final String workflowDefinitionFile;
+
+    /**
+     * Nickname of the system on which the workflow definition file resides.
+     */
     private final String workflowDefinitionFileSystem;
+
+    /**
+     * Optional workflow variable input file.
+     */
     private final String variableInputFile;
+
+    /**
+     * Workflow variables supplied on the request.
+     */
     private final List<WorkflowVariable> variables;
+
+    /**
+     * Resolve conflict behavior for global variables.
+     */
     private final String resolveGlobalConflictByUsing;
+
+    /**
+     * Nickname of the system where the workflow is created.
+     */
     private final String system;
+
+    /**
+     * User ID of the workflow owner.
+     */
     private final String owner;
+
+    /**
+     * SAF group or workflow owner user ID for archived workflow access.
+     */
     private final String workflowArchiveSAFID;
+
+    /**
+     * Workflow creation comments.
+     */
     private final String comments;
+
+    /**
+     * Indicator that workflow steps are assigned to the owner on create.
+     */
     private final Boolean assignToOwner;
+
+    /**
+     * Workflow access type.
+     */
     private final String accessType;
+
+    /**
+     * Account information for job-submitting workflows.
+     */
     private final String accountInfo;
+
+    /**
+     * JOB statement for job-submitting workflows.
+     */
     private final List<String> jobStatement;
+
+    /**
+     * Indicator that completed jobs are deleted from JES spool.
+     */
     private final Boolean deleteCompletedJobs;
+
+    /**
+     * Directory used to save job spool files.
+     */
     private final String jobsOutputDirectory;
+
+    /**
+     * Indicator that the workflow is automatically deleted on completion.
+     */
     private final Boolean autoDeleteOnCompletion;
+
+    /**
+     * User ID used for remote system basic authentication.
+     */
     private final String targetSystemuid;
+
+    /**
+     * Password used for remote system basic authentication.
+     */
     private final String targetSystempwd;
 
     /**
@@ -70,6 +147,82 @@ public class WorkflowCreateInputData {
         this.targetSystempwd = builder.targetSystempwd;
     }
 
+    public String getWorkflowName() {
+        return workflowName;
+    }
+
+    public String getWorkflowDefinitionFile() {
+        return workflowDefinitionFile;
+    }
+
+    public String getWorkflowDefinitionFileSystem() {
+        return workflowDefinitionFileSystem;
+    }
+
+    public String getVariableInputFile() {
+        return variableInputFile;
+    }
+
+    public List<WorkflowVariable> getVariables() {
+        return variables;
+    }
+
+    public String getResolveGlobalConflictByUsing() {
+        return resolveGlobalConflictByUsing;
+    }
+
+    public String getSystem() {
+        return system;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public String getWorkflowArchiveSAFID() {
+        return workflowArchiveSAFID;
+    }
+
+    public String getComments() {
+        return comments;
+    }
+
+    public Boolean getAssignToOwner() {
+        return assignToOwner;
+    }
+
+    public String getAccessType() {
+        return accessType;
+    }
+
+    public String getAccountInfo() {
+        return accountInfo;
+    }
+
+    public List<String> getJobStatement() {
+        return jobStatement;
+    }
+
+    public Boolean getDeleteCompletedJobs() {
+        return deleteCompletedJobs;
+    }
+
+    public String getJobsOutputDirectory() {
+        return jobsOutputDirectory;
+    }
+
+    public Boolean getAutoDeleteOnCompletion() {
+        return autoDeleteOnCompletion;
+    }
+
+    public String getTargetSystemuid() {
+        return targetSystemuid;
+    }
+
+    public String getTargetSystempwd() {
+        return targetSystempwd;
+    }
+
     /**
      * Create a new builder for workflow create input data.
      *
@@ -77,6 +230,36 @@ public class WorkflowCreateInputData {
      */
     public static Builder builder() {
         return new Builder();
+    }
+
+    /**
+     * Return string value representing WorkflowCreateInputData object.
+     *
+     * @return string representation of WorkflowCreateInputData
+     */
+    @Override
+    public String toString() {
+        return "WorkflowCreateInputData{" +
+                "workflowName='" + workflowName + '\'' +
+                ", workflowDefinitionFile='" + workflowDefinitionFile + '\'' +
+                ", workflowDefinitionFileSystem='" + workflowDefinitionFileSystem + '\'' +
+                ", variableInputFile='" + variableInputFile + '\'' +
+                ", variables=" + variables +
+                ", resolveGlobalConflictByUsing='" + resolveGlobalConflictByUsing + '\'' +
+                ", system='" + system + '\'' +
+                ", owner='" + owner + '\'' +
+                ", workflowArchiveSAFID='" + workflowArchiveSAFID + '\'' +
+                ", comments='" + comments + '\'' +
+                ", assignToOwner=" + assignToOwner +
+                ", accessType='" + accessType + '\'' +
+                ", accountInfo='" + accountInfo + '\'' +
+                ", jobStatement=" + jobStatement +
+                ", deleteCompletedJobs=" + deleteCompletedJobs +
+                ", jobsOutputDirectory='" + jobsOutputDirectory + '\'' +
+                ", autoDeleteOnCompletion=" + autoDeleteOnCompletion +
+                ", targetSystemuid='" + targetSystemuid + '\'' +
+                ", targetSystempwd='" + targetSystempwd + '\'' +
+                '}';
     }
 
     /**
@@ -206,112 +389,6 @@ public class WorkflowCreateInputData {
             return new WorkflowCreateInputData(this);
         }
 
-    }
-
-    public String getWorkflowName() {
-        return workflowName;
-    }
-
-    public String getWorkflowDefinitionFile() {
-        return workflowDefinitionFile;
-    }
-
-    public String getWorkflowDefinitionFileSystem() {
-        return workflowDefinitionFileSystem;
-    }
-
-    public String getVariableInputFile() {
-        return variableInputFile;
-    }
-
-    public List<WorkflowVariable> getVariables() {
-        return variables;
-    }
-
-    public String getResolveGlobalConflictByUsing() {
-        return resolveGlobalConflictByUsing;
-    }
-
-    public String getSystem() {
-        return system;
-    }
-
-    public String getOwner() {
-        return owner;
-    }
-
-    public String getWorkflowArchiveSAFID() {
-        return workflowArchiveSAFID;
-    }
-
-    public String getComments() {
-        return comments;
-    }
-
-    public Boolean getAssignToOwner() {
-        return assignToOwner;
-    }
-
-    public String getAccessType() {
-        return accessType;
-    }
-
-    public String getAccountInfo() {
-        return accountInfo;
-    }
-
-    public List<String> getJobStatement() {
-        return jobStatement;
-    }
-
-    public Boolean getDeleteCompletedJobs() {
-        return deleteCompletedJobs;
-    }
-
-    public String getJobsOutputDirectory() {
-        return jobsOutputDirectory;
-    }
-
-    public Boolean getAutoDeleteOnCompletion() {
-        return autoDeleteOnCompletion;
-    }
-
-    public String getTargetSystemuid() {
-        return targetSystemuid;
-    }
-
-    public String getTargetSystempwd() {
-        return targetSystempwd;
-    }
-
-    /**
-     * Return string value representing WorkflowCreateInputData object.
-     *
-     * @return string representation of WorkflowCreateInputData
-     */
-    @Override
-    public String toString() {
-        return "WorkflowCreateInputData{" +
-                "workflowName='" + workflowName + '\'' +
-                ", workflowDefinitionFile='" + workflowDefinitionFile + '\'' +
-                ", workflowDefinitionFileSystem='" + workflowDefinitionFileSystem + '\'' +
-                ", variableInputFile='" + variableInputFile + '\'' +
-                ", variables=" + variables +
-                ", resolveGlobalConflictByUsing='" + resolveGlobalConflictByUsing + '\'' +
-                ", system='" + system + '\'' +
-                ", owner='" + owner + '\'' +
-                ", workflowArchiveSAFID='" + workflowArchiveSAFID + '\'' +
-                ", comments='" + comments + '\'' +
-                ", assignToOwner=" + assignToOwner +
-                ", accessType='" + accessType + '\'' +
-                ", accountInfo='" + accountInfo + '\'' +
-                ", jobStatement=" + jobStatement +
-                ", deleteCompletedJobs=" + deleteCompletedJobs +
-                ", jobsOutputDirectory='" + jobsOutputDirectory + '\'' +
-                ", autoDeleteOnCompletion=" + autoDeleteOnCompletion +
-                ", targetSystemuid='" + targetSystemuid + '\'' +
-                ", targetSystempwd='" + targetSystempwd + '\'' +
-                '}';
     }
 
 }

--- a/src/main/java/zowe/client/sdk/zosworkflow/input/package-info.java
+++ b/src/main/java/zowe/client/sdk/zosworkflow/input/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Workflow request input data.
+ */
+package zowe.client.sdk.zosworkflow.input;

--- a/src/main/java/zowe/client/sdk/zosworkflow/methods/WorkflowCreate.java
+++ b/src/main/java/zowe/client/sdk/zosworkflow/methods/WorkflowCreate.java
@@ -25,9 +25,11 @@ import zowe.client.sdk.zosworkflow.response.WorkflowCreateResponse;
 
 /**
  * Provides create workflow functionality through the z/OSMF workflow REST API.
+ * <p>
+ * <a href="https://www.ibm.com/docs/en/zos/3.2.0?topic=services-zosmf-workflow-services">z/OSMF REST API</a>
  *
  * @author Ashish Kumar Dash
- * @version 6.0
+ * @version 7.0
  */
 public class WorkflowCreate {
 
@@ -81,9 +83,7 @@ public class WorkflowCreate {
         ValidateUtils.checkIllegalParameter(createInputData.getOwner(), "owner");
 
         final String url = connection.getZosmfUrl() +
-                WorkflowConstants.RESOURCE +
-                WorkflowConstants.VERSION +
-                WorkflowConstants.WORKFLOWS;
+            WorkflowConstants.RESOURCE;
 
         if (request == null) {
             request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.POST_JSON);

--- a/src/main/java/zowe/client/sdk/zosworkflow/methods/WorkflowCreate.java
+++ b/src/main/java/zowe/client/sdk/zosworkflow/methods/WorkflowCreate.java
@@ -1,0 +1,107 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosworkflow.methods;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import zowe.client.sdk.core.ZosConnection;
+import zowe.client.sdk.rest.PostJsonZosmfRequest;
+import zowe.client.sdk.rest.ZosmfRequest;
+import zowe.client.sdk.rest.ZosmfRequestFactory;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
+import zowe.client.sdk.rest.type.ZosmfRequestType;
+import zowe.client.sdk.utility.JsonUtils;
+import zowe.client.sdk.utility.ValidateUtils;
+import zowe.client.sdk.zosworkflow.WorkflowConstants;
+import zowe.client.sdk.zosworkflow.input.WorkflowCreateInputData;
+import zowe.client.sdk.zosworkflow.response.WorkflowCreateResponse;
+
+/**
+ * Provides create workflow functionality through the z/OSMF workflow REST API.
+ *
+ * @author Ashish Kumar Dash
+ * @version 6.0
+ */
+public class WorkflowCreate {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final ZosConnection connection;
+    private ZosmfRequest request;
+
+    /**
+     * WorkflowCreate constructor.
+     *
+     * @param connection for connection information, see ZosConnection object
+     */
+    public WorkflowCreate(final ZosConnection connection) {
+        ValidateUtils.checkNullParameter(connection, "connection");
+        this.connection = connection;
+    }
+
+    /**
+     * Alternative WorkflowCreate constructor with ZosmfRequest object.
+     * This is mainly used for internal code unit testing with Mockito,
+     * and it is not recommended to be used by the larger community.
+     * <p>
+     * This constructor is package-private.
+     *
+     * @param connection for connection information, see ZosConnection object
+     * @param request    any compatible ZoweRequest Interface object
+     */
+    WorkflowCreate(final ZosConnection connection, final ZosmfRequest request) {
+        ValidateUtils.checkNullParameter(connection, "connection");
+        ValidateUtils.checkNullParameter(request, "request");
+        this.connection = connection;
+        if (!(request instanceof PostJsonZosmfRequest)) {
+            throw new IllegalStateException("POST_JSON request type required");
+        }
+        this.request = request;
+    }
+
+    /**
+     * Create a z/OSMF workflow on the target system.
+     *
+     * @param createInputData workflow creation parameters
+     * @return workflow details returned by z/OSMF
+     * @throws ZosmfRequestException request error state
+     */
+    public WorkflowCreateResponse create(final WorkflowCreateInputData createInputData) throws ZosmfRequestException {
+        ValidateUtils.checkNullParameter(createInputData, "createInputData");
+        ValidateUtils.checkIllegalParameter(createInputData.getWorkflowName(), "workflowName");
+        ValidateUtils.checkIllegalParameter(createInputData.getWorkflowDefinitionFile(), "workflowDefinitionFile");
+        ValidateUtils.checkIllegalParameter(createInputData.getSystem(), "system");
+        ValidateUtils.checkIllegalParameter(createInputData.getOwner(), "owner");
+
+        final String url = connection.getZosmfUrl() +
+                WorkflowConstants.RESOURCE +
+                WorkflowConstants.VERSION +
+                WorkflowConstants.WORKFLOWS;
+
+        if (request == null) {
+            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.POST_JSON);
+        }
+        request.setUrl(url);
+
+        try {
+            request.setBody(OBJECT_MAPPER.writeValueAsString(createInputData));
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("error serializing workflow create request", e);
+        }
+
+        final String responsePhrase = request.executeRequest()
+                .getResponsePhrase()
+                .orElseThrow(() -> new IllegalStateException("no workflow create response phrase"))
+                .toString();
+
+        return JsonUtils.parseResponse(responsePhrase, WorkflowCreateResponse.class, "create");
+    }
+
+}

--- a/src/main/java/zowe/client/sdk/zosworkflow/methods/package-info.java
+++ b/src/main/java/zowe/client/sdk/zosworkflow/methods/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Workflow API methods.
+ */
+package zowe.client.sdk.zosworkflow.methods;

--- a/src/main/java/zowe/client/sdk/zosworkflow/model/WorkflowVariable.java
+++ b/src/main/java/zowe/client/sdk/zosworkflow/model/WorkflowVariable.java
@@ -13,9 +13,11 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 /**
  * Workflow variable name/value pair.
+ * <p>
+ * <a href="https://www.ibm.com/docs/en/zos/3.2.0?topic=services-zosmf-workflow-services">z/OSMF REST API</a>
  *
  * @author Ashish Kumar Dash
- * @version 6.0
+ * @version 7.0
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class WorkflowVariable {

--- a/src/main/java/zowe/client/sdk/zosworkflow/model/WorkflowVariable.java
+++ b/src/main/java/zowe/client/sdk/zosworkflow/model/WorkflowVariable.java
@@ -1,0 +1,75 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosworkflow.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Workflow variable name/value pair.
+ *
+ * @author Ashish Kumar Dash
+ * @version 6.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class WorkflowVariable {
+
+    /**
+     * Variable name.
+     */
+    private final String name;
+
+    /**
+     * Variable value.
+     */
+    private final String value;
+
+    /**
+     * WorkflowVariable constructor.
+     *
+     * @param name  variable name
+     * @param value variable value
+     */
+    public WorkflowVariable(final String name, final String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    /**
+     * Retrieve name specified.
+     *
+     * @return name value
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Retrieve value specified.
+     *
+     * @return value value
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Return string value representing WorkflowVariable object.
+     *
+     * @return string representation of WorkflowVariable
+     */
+    @Override
+    public String toString() {
+        return "WorkflowVariable{" +
+                "name='" + name + '\'' +
+                ", value='" + value + '\'' +
+                '}';
+    }
+
+}

--- a/src/main/java/zowe/client/sdk/zosworkflow/model/package-info.java
+++ b/src/main/java/zowe/client/sdk/zosworkflow/model/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Workflow request helper models.
+ */
+package zowe.client.sdk.zosworkflow.model;

--- a/src/main/java/zowe/client/sdk/zosworkflow/package-info.java
+++ b/src/main/java/zowe/client/sdk/zosworkflow/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * APIs for interacting with z/OSMF workflow services.
+ */
+package zowe.client.sdk.zosworkflow;

--- a/src/main/java/zowe/client/sdk/zosworkflow/response/WorkflowCreateResponse.java
+++ b/src/main/java/zowe/client/sdk/zosworkflow/response/WorkflowCreateResponse.java
@@ -1,0 +1,90 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosworkflow.response;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * API response for create workflow.
+ *
+ * @author Ashish Kumar Dash
+ * @version 6.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class WorkflowCreateResponse {
+
+    private final String workflowKey;
+    private final String workflowDescription;
+    private final String workflowID;
+    private final String workflowVersion;
+    private final String vendor;
+
+    /**
+     * WorkflowCreateResponse Jackson constructor.
+     *
+     * @param workflowKey         workflow key
+     * @param workflowDescription workflow description
+     * @param workflowID          workflow id
+     * @param workflowVersion     workflow version
+     * @param vendor              vendor name
+     */
+    @JsonCreator
+    public WorkflowCreateResponse(
+            @JsonProperty("workflowKey") final String workflowKey,
+            @JsonProperty("workflowDescription") final String workflowDescription,
+            @JsonProperty("workflowID") final String workflowID,
+            @JsonProperty("workflowVersion") final String workflowVersion,
+            @JsonProperty("vendor") final String vendor) {
+        this.workflowKey = workflowKey == null ? "" : workflowKey;
+        this.workflowDescription = workflowDescription == null ? "" : workflowDescription;
+        this.workflowID = workflowID == null ? "" : workflowID;
+        this.workflowVersion = workflowVersion == null ? "" : workflowVersion;
+        this.vendor = vendor == null ? "" : vendor;
+    }
+
+    public String getWorkflowKey() {
+        return workflowKey;
+    }
+
+    public String getWorkflowDescription() {
+        return workflowDescription;
+    }
+
+    public String getWorkflowID() {
+        return workflowID;
+    }
+
+    public String getWorkflowVersion() {
+        return workflowVersion;
+    }
+
+    public String getVendor() {
+        return vendor;
+    }
+
+    /**
+     * Return string value representing WorkflowCreateResponse object.
+     *
+     * @return string representation of WorkflowCreateResponse
+     */
+    @Override
+    public String toString() {
+        return "WorkflowCreateResponse{" +
+                "workflowKey='" + workflowKey + '\'' +
+                ", workflowDescription='" + workflowDescription + '\'' +
+                ", workflowID='" + workflowID + '\'' +
+                ", workflowVersion='" + workflowVersion + '\'' +
+                ", vendor='" + vendor + '\'' +
+                '}';
+    }
+
+}

--- a/src/main/java/zowe/client/sdk/zosworkflow/response/WorkflowCreateResponse.java
+++ b/src/main/java/zowe/client/sdk/zosworkflow/response/WorkflowCreateResponse.java
@@ -15,17 +15,38 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * API response for create workflow.
+ * <p>
+ * <a href="https://www.ibm.com/docs/en/zos/3.2.0?topic=services-zosmf-workflow-services">z/OSMF REST API</a>
  *
  * @author Ashish Kumar Dash
- * @version 6.0
+ * @version 7.0
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class WorkflowCreateResponse {
 
+    /**
+     * Workflow key.
+     */
     private final String workflowKey;
+
+    /**
+     * Workflow description.
+     */
     private final String workflowDescription;
+
+    /**
+     * Workflow ID.
+     */
     private final String workflowID;
+
+    /**
+     * Workflow definition version.
+     */
     private final String workflowVersion;
+
+    /**
+     * Vendor name.
+     */
     private final String vendor;
 
     /**

--- a/src/main/java/zowe/client/sdk/zosworkflow/response/package-info.java
+++ b/src/main/java/zowe/client/sdk/zosworkflow/response/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Workflow API response models.
+ */
+package zowe.client.sdk.zosworkflow.response;

--- a/src/test/java/zowe/client/sdk/zosworkflow/WorkflowConstantsTest.java
+++ b/src/test/java/zowe/client/sdk/zosworkflow/WorkflowConstantsTest.java
@@ -1,0 +1,28 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosworkflow;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Class containing unit tests for WorkflowConstants.
+ */
+public class WorkflowConstantsTest {
+
+    @Test
+    public void tstWorkflowConstantsValuesSuccess() {
+        assertEquals("/workflow/rest", WorkflowConstants.RESOURCE);
+        assertEquals("/1.0", WorkflowConstants.VERSION);
+        assertEquals("/workflows", WorkflowConstants.WORKFLOWS);
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/zosworkflow/WorkflowConstantsTest.java
+++ b/src/test/java/zowe/client/sdk/zosworkflow/WorkflowConstantsTest.java
@@ -20,9 +20,7 @@ public class WorkflowConstantsTest {
 
     @Test
     public void tstWorkflowConstantsValuesSuccess() {
-        assertEquals("/workflow/rest", WorkflowConstants.RESOURCE);
-        assertEquals("/1.0", WorkflowConstants.VERSION);
-        assertEquals("/workflows", WorkflowConstants.WORKFLOWS);
+        assertEquals("/workflow/rest/1.0/workflows", WorkflowConstants.RESOURCE);
     }
 
 }

--- a/src/test/java/zowe/client/sdk/zosworkflow/input/WorkflowCreateInputDataTest.java
+++ b/src/test/java/zowe/client/sdk/zosworkflow/input/WorkflowCreateInputDataTest.java
@@ -1,0 +1,74 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosworkflow.input;
+
+import org.junit.jupiter.api.Test;
+import zowe.client.sdk.zosworkflow.model.WorkflowVariable;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Class containing unit tests for WorkflowCreateInputData.
+ */
+public class WorkflowCreateInputDataTest {
+
+    @Test
+    public void tstWorkflowCreateInputDataBuilderSuccess() {
+        final WorkflowCreateInputData inputData = WorkflowCreateInputData.builder()
+                .workflowName("AutomationExample")
+                .workflowDefinitionFile("/usr/lpp/zosmf/samples/workflow_sample_automation.xml")
+                .workflowDefinitionFileSystem("SY1")
+                .variableInputFile("/tmp/workflow.properties")
+                .variables(Arrays.asList(
+                        new WorkflowVariable("user_name", "IBMUSER"),
+                        new WorkflowVariable("file_name", "textfile.txt")
+                ))
+                .resolveGlobalConflictByUsing("global")
+                .system("SY1")
+                .owner("zosmfad")
+                .workflowArchiveSAFID("ZOSMFAD")
+                .comments("created for testing")
+                .assignToOwner(Boolean.TRUE)
+                .accessType("Public")
+                .accountInfo("ACCT123")
+                .jobStatement(Arrays.asList("//TEST JOB (ACCT123)", "//*"))
+                .deleteCompletedJobs(Boolean.FALSE)
+                .jobsOutputDirectory("/u/IBMUSER/jobFiles")
+                .autoDeleteOnCompletion(Boolean.FALSE)
+                .targetSystemuid("remoteuser")
+                .targetSystempwd("remotepwd")
+                .build();
+
+        assertNotNull(inputData);
+        assertEquals("AutomationExample", inputData.getWorkflowName());
+        assertEquals("/usr/lpp/zosmf/samples/workflow_sample_automation.xml", inputData.getWorkflowDefinitionFile());
+        assertEquals("SY1", inputData.getWorkflowDefinitionFileSystem());
+        assertEquals("/tmp/workflow.properties", inputData.getVariableInputFile());
+        assertEquals(2, inputData.getVariables().size());
+        assertEquals("global", inputData.getResolveGlobalConflictByUsing());
+        assertEquals("SY1", inputData.getSystem());
+        assertEquals("zosmfad", inputData.getOwner());
+        assertEquals("ZOSMFAD", inputData.getWorkflowArchiveSAFID());
+        assertEquals("created for testing", inputData.getComments());
+        assertEquals(Boolean.TRUE, inputData.getAssignToOwner());
+        assertEquals("Public", inputData.getAccessType());
+        assertEquals("ACCT123", inputData.getAccountInfo());
+        assertEquals(2, inputData.getJobStatement().size());
+        assertEquals(Boolean.FALSE, inputData.getDeleteCompletedJobs());
+        assertEquals("/u/IBMUSER/jobFiles", inputData.getJobsOutputDirectory());
+        assertEquals(Boolean.FALSE, inputData.getAutoDeleteOnCompletion());
+        assertEquals("remoteuser", inputData.getTargetSystemuid());
+        assertEquals("remotepwd", inputData.getTargetSystempwd());
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/zosworkflow/methods/WorkflowCreateTest.java
+++ b/src/test/java/zowe/client/sdk/zosworkflow/methods/WorkflowCreateTest.java
@@ -172,6 +172,28 @@ public class WorkflowCreateTest {
         assertEquals("workflow-description", response.getWorkflowDescription());
     }
 
+        @Test
+        public void tstWorkflowCreateJsonStringResponseSuccess() throws Exception {
+                final JSONObject workflowJson = getJsonObject();
+                final PostJsonZosmfRequest mockPostJsonZosmfRequestString = Mockito.mock(PostJsonZosmfRequest.class);
+                Mockito.when(mockPostJsonZosmfRequestString.executeRequest()).thenReturn(
+                                new Response(workflowJson.toString(), 201, "Created"));
+                doCallRealMethod().when(mockPostJsonZosmfRequestString).setUrl(any());
+                doCallRealMethod().when(mockPostJsonZosmfRequestString).getUrl();
+                doCallRealMethod().when(mockPostJsonZosmfRequestString).setBody(any());
+
+                final WorkflowCreate workflowCreate = new WorkflowCreate(connection, mockPostJsonZosmfRequestString);
+                final WorkflowCreateResponse response = workflowCreate.create(createInputData());
+
+                assertEquals("https://1:443/zosmf/workflow/rest/1.0/workflows",
+                                mockPostJsonZosmfRequestString.getUrl());
+                assertEquals("workflow-key", response.getWorkflowKey());
+                assertEquals("workflow-description", response.getWorkflowDescription());
+                assertEquals("workflow-id", response.getWorkflowID());
+                assertEquals("1.0", response.getWorkflowVersion());
+                assertEquals("IBM", response.getVendor());
+        }
+
     @Test
     public void tstWorkflowCreateSecondaryConstructorWithValidRequestType() {
         ZosConnection connection = Mockito.mock(ZosConnection.class);

--- a/src/test/java/zowe/client/sdk/zosworkflow/methods/WorkflowCreateTest.java
+++ b/src/test/java/zowe/client/sdk/zosworkflow/methods/WorkflowCreateTest.java
@@ -1,0 +1,230 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosworkflow.methods;
+
+import kong.unirest.core.Cookie;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import zowe.client.sdk.core.ZosConnection;
+import zowe.client.sdk.core.ZosConnectionFactory;
+import zowe.client.sdk.rest.PostJsonZosmfRequest;
+import zowe.client.sdk.rest.Response;
+import zowe.client.sdk.rest.ZosmfRequest;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
+import zowe.client.sdk.zosworkflow.input.WorkflowCreateInputData;
+import zowe.client.sdk.zosworkflow.model.WorkflowVariable;
+import zowe.client.sdk.zosworkflow.response.WorkflowCreateResponse;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
+
+/**
+ * Class containing unit tests for WorkflowCreate.
+ */
+public class WorkflowCreateTest {
+
+    private final ZosConnection connection = ZosConnectionFactory
+            .createBasicConnection("1", 443, "1", "1");
+    private final ZosConnection tokenConnection = ZosConnectionFactory
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
+    private PostJsonZosmfRequest mockPostJsonZosmfRequest;
+    private PostJsonZosmfRequest mockPostJsonZosmfRequestToken;
+
+    @BeforeEach
+    public void init() throws ZosmfRequestException {
+        JSONObject workflowJson = getJsonObject();
+
+        mockPostJsonZosmfRequest = Mockito.mock(PostJsonZosmfRequest.class);
+        Mockito.when(mockPostJsonZosmfRequest.executeRequest()).thenReturn(
+                new Response(workflowJson, 201, "Created"));
+        doCallRealMethod().when(mockPostJsonZosmfRequest).setUrl(any());
+        doCallRealMethod().when(mockPostJsonZosmfRequest).getUrl();
+        doCallRealMethod().when(mockPostJsonZosmfRequest).setBody(any());
+
+        mockPostJsonZosmfRequestToken = Mockito.mock(PostJsonZosmfRequest.class,
+                withSettings().useConstructor(tokenConnection));
+        Mockito.when(mockPostJsonZosmfRequestToken.executeRequest()).thenReturn(
+                new Response(workflowJson, 201, "Created"));
+        doCallRealMethod().when(mockPostJsonZosmfRequestToken).setHeaders(anyMap());
+        doCallRealMethod().when(mockPostJsonZosmfRequestToken).setStandardHeaders();
+        doCallRealMethod().when(mockPostJsonZosmfRequestToken).setUrl(any());
+        doCallRealMethod().when(mockPostJsonZosmfRequestToken).getHeaders();
+        doCallRealMethod().when(mockPostJsonZosmfRequestToken).getUrl();
+        doCallRealMethod().when(mockPostJsonZosmfRequestToken).setBody(any());
+    }
+
+    private static JSONObject getJsonObject() {
+        final Map<String, String> jsonMap = new HashMap<>();
+        jsonMap.put("workflowKey", "workflow-key");
+        jsonMap.put("workflowDescription", "workflow-description");
+        jsonMap.put("workflowID", "workflow-id");
+        jsonMap.put("workflowVersion", "1.0");
+        jsonMap.put("vendor", "IBM");
+        return new JSONObject(jsonMap);
+    }
+
+    private static WorkflowCreateInputData createInputData() {
+        return WorkflowCreateInputData.builder()
+                .workflowName("AutomationExample")
+                .workflowDefinitionFile("/usr/lpp/zosmf/samples/workflow_sample_automation.xml")
+                .workflowDefinitionFileSystem("SY1")
+                .variableInputFile("/tmp/workflow.properties")
+                .variables(Arrays.asList(
+                        new WorkflowVariable("user_name", "IBMUSER"),
+                        new WorkflowVariable("file_name", "textfile.txt")
+                ))
+                .resolveGlobalConflictByUsing("input")
+                .system("SY1")
+                .owner("zosmfad")
+                .workflowArchiveSAFID("ZOSMFAD")
+                .comments("This workflow was created through the z/OSMF workflow services REST interface.")
+                .assignToOwner(Boolean.FALSE)
+                .accessType("Restricted")
+                .accountInfo("ACCT123")
+                .jobStatement(Arrays.asList("//TESTJOB JOB (ACCT123)", "//*"))
+                .deleteCompletedJobs(Boolean.TRUE)
+                .jobsOutputDirectory("/u/IBMUSER/jobFiles")
+                .autoDeleteOnCompletion(Boolean.TRUE)
+                .targetSystemuid("remoteuser")
+                .targetSystempwd("remotepwd")
+                .build();
+    }
+
+    @Test
+    public void tstWorkflowCreateSuccess() throws Exception {
+        final WorkflowCreate workflowCreate = new WorkflowCreate(connection, mockPostJsonZosmfRequest);
+        final WorkflowCreateResponse response = workflowCreate.create(createInputData());
+
+        final ArgumentCaptor<Object> bodyCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(mockPostJsonZosmfRequest).setBody(bodyCaptor.capture());
+        final String body = bodyCaptor.getValue().toString();
+        final JSONObject requestBody = (JSONObject) new JSONParser().parse(body);
+
+        assertEquals("https://1:443/zosmf/workflow/rest/1.0/workflows", mockPostJsonZosmfRequest.getUrl());
+        assertEquals("AutomationExample", requestBody.get("workflowName"));
+        assertEquals("/usr/lpp/zosmf/samples/workflow_sample_automation.xml",
+                requestBody.get("workflowDefinitionFile"));
+        assertEquals("SY1", requestBody.get("workflowDefinitionFileSystem"));
+        assertEquals("/tmp/workflow.properties", requestBody.get("variableInputFile"));
+        assertEquals("input", requestBody.get("resolveGlobalConflictByUsing"));
+        assertEquals("SY1", requestBody.get("system"));
+        assertEquals("zosmfad", requestBody.get("owner"));
+        assertEquals("ZOSMFAD", requestBody.get("workflowArchiveSAFID"));
+        assertEquals("This workflow was created through the z/OSMF workflow services REST interface.",
+                requestBody.get("comments"));
+        assertEquals(Boolean.FALSE, requestBody.get("assignToOwner"));
+        assertEquals("Restricted", requestBody.get("accessType"));
+        assertEquals("ACCT123", requestBody.get("accountInfo"));
+        assertEquals(Boolean.TRUE, requestBody.get("deleteCompletedJobs"));
+        assertEquals("/u/IBMUSER/jobFiles", requestBody.get("jobsOutputDirectory"));
+        assertEquals(Boolean.TRUE, requestBody.get("autoDeleteOnCompletion"));
+        assertEquals("remoteuser", requestBody.get("targetSystemuid"));
+        assertEquals("remotepwd", requestBody.get("targetSystempwd"));
+
+        final JSONArray variables = (JSONArray) requestBody.get("variables");
+        assertEquals(2, variables.size());
+        assertEquals("user_name", ((JSONObject) variables.get(0)).get("name"));
+        assertEquals("IBMUSER", ((JSONObject) variables.get(0)).get("value"));
+        assertEquals("file_name", ((JSONObject) variables.get(1)).get("name"));
+        assertEquals("textfile.txt", ((JSONObject) variables.get(1)).get("value"));
+
+        final JSONArray jobStatement = (JSONArray) requestBody.get("jobStatement");
+        assertEquals(2, jobStatement.size());
+        assertEquals("//TESTJOB JOB (ACCT123)", jobStatement.get(0));
+        assertEquals("//*", jobStatement.get(1));
+
+        assertEquals("workflow-key", response.getWorkflowKey());
+        assertEquals("workflow-description", response.getWorkflowDescription());
+        assertEquals("workflow-id", response.getWorkflowID());
+        assertEquals("1.0", response.getWorkflowVersion());
+        assertEquals("IBM", response.getVendor());
+    }
+
+    @Test
+    public void tstWorkflowCreateTokenSuccess() throws Exception {
+        final WorkflowCreate workflowCreate = new WorkflowCreate(connection, mockPostJsonZosmfRequestToken);
+        final WorkflowCreateResponse response = workflowCreate.create(createInputData());
+
+        assertEquals("{X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
+                mockPostJsonZosmfRequestToken.getHeaders().toString());
+        assertEquals("https://1:443/zosmf/workflow/rest/1.0/workflows", mockPostJsonZosmfRequestToken.getUrl());
+        assertEquals("workflow-key", response.getWorkflowKey());
+        assertEquals("workflow-description", response.getWorkflowDescription());
+    }
+
+    @Test
+    public void tstWorkflowCreateSecondaryConstructorWithValidRequestType() {
+        ZosConnection connection = Mockito.mock(ZosConnection.class);
+        ZosmfRequest request = Mockito.mock(PostJsonZosmfRequest.class);
+        WorkflowCreate workflowCreate = new WorkflowCreate(connection, request);
+        assertNotNull(workflowCreate);
+    }
+
+    @Test
+    public void tstWorkflowCreateSecondaryConstructorWithNullConnection() {
+        ZosmfRequest request = Mockito.mock(PostJsonZosmfRequest.class);
+        NullPointerException exception = assertThrows(
+                NullPointerException.class,
+                () -> new WorkflowCreate(null, request)
+        );
+        assertEquals("connection is null", exception.getMessage());
+    }
+
+    @Test
+    public void tstWorkflowCreateSecondaryConstructorWithNullRequest() {
+        ZosConnection connection = Mockito.mock(ZosConnection.class);
+        NullPointerException exception = assertThrows(
+                NullPointerException.class,
+                () -> new WorkflowCreate(connection, null)
+        );
+        assertEquals("request is null", exception.getMessage());
+    }
+
+    @Test
+    public void tstWorkflowCreateSecondaryConstructorWithInvalidRequestType() {
+        ZosConnection connection = Mockito.mock(ZosConnection.class);
+        ZosmfRequest request = Mockito.mock(ZosmfRequest.class);
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> new WorkflowCreate(connection, request)
+        );
+        assertEquals("POST_JSON request type required", exception.getMessage());
+    }
+
+    @Test
+    public void tstWorkflowCreatePrimaryConstructorWithValidConnection() {
+        ZosConnection connection = Mockito.mock(ZosConnection.class);
+        WorkflowCreate workflowCreate = new WorkflowCreate(connection);
+        assertNotNull(workflowCreate);
+    }
+
+    @Test
+    public void tstWorkflowCreatePrimaryConstructorWithNullConnection() {
+        NullPointerException exception = assertThrows(
+                NullPointerException.class,
+                () -> new WorkflowCreate(null)
+        );
+        assertEquals("connection is null", exception.getMessage());
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/zosworkflow/model/WorkflowVariableTest.java
+++ b/src/test/java/zowe/client/sdk/zosworkflow/model/WorkflowVariableTest.java
@@ -1,0 +1,32 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosworkflow.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Class containing unit tests for WorkflowVariable.
+ */
+public class WorkflowVariableTest {
+
+    @Test
+    public void tstWorkflowVariableSuccess() {
+        final WorkflowVariable workflowVariable = new WorkflowVariable("user_name", "IBMUSER");
+
+        assertNotNull(workflowVariable);
+        assertEquals("user_name", workflowVariable.getName());
+        assertEquals("IBMUSER", workflowVariable.getValue());
+        assertEquals("WorkflowVariable{name='user_name', value='IBMUSER'}", workflowVariable.toString());
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/zosworkflow/response/WorkflowCreateResponseTest.java
+++ b/src/test/java/zowe/client/sdk/zosworkflow/response/WorkflowCreateResponseTest.java
@@ -1,0 +1,56 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosworkflow.response;
+
+import org.junit.jupiter.api.Test;
+import zowe.client.sdk.utility.JsonUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Class containing unit tests for WorkflowCreateResponse.
+ */
+public class WorkflowCreateResponseTest {
+
+    @Test
+    public void tstWorkflowCreateResponseConstructorSuccess() {
+        final WorkflowCreateResponse response = new WorkflowCreateResponse(
+                "workflow-key",
+                "workflow-description",
+                "workflow-id",
+                "1.0",
+                "IBM");
+
+        assertNotNull(response);
+        assertEquals("workflow-key", response.getWorkflowKey());
+        assertEquals("workflow-description", response.getWorkflowDescription());
+        assertEquals("workflow-id", response.getWorkflowID());
+        assertEquals("1.0", response.getWorkflowVersion());
+        assertEquals("IBM", response.getVendor());
+        assertEquals("WorkflowCreateResponse{workflowKey='workflow-key', workflowDescription='workflow-description', workflowID='workflow-id', workflowVersion='1.0', vendor='IBM'}",
+                response.toString());
+    }
+
+    @Test
+    public void tstWorkflowCreateResponseParseSuccess() throws Exception {
+        final WorkflowCreateResponse response = JsonUtils.parseResponse(
+                "{\"workflowKey\":\"workflow-key\",\"workflowDescription\":\"workflow-description\",\"workflowID\":\"workflow-id\",\"workflowVersion\":\"1.0\",\"vendor\":\"IBM\"}",
+                WorkflowCreateResponse.class,
+                "test");
+
+        assertEquals("workflow-key", response.getWorkflowKey());
+        assertEquals("workflow-description", response.getWorkflowDescription());
+        assertEquals("workflow-id", response.getWorkflowID());
+        assertEquals("1.0", response.getWorkflowVersion());
+        assertEquals("IBM", response.getVendor());
+    }
+
+}


### PR DESCRIPTION
Adds a typed SDK surface for creating workflows through POST /zosmf/workflow/rest/1.0/workflows. Includes request/response models, the WorkflowCreate method, and unit tests for payload serialization and response parsing.
closes #468 