### PR TITLE
Fix API doc URL and Javadoc style in z/OSMF workflow classes

### DIFF
--- a/src/main/java/zowe/client/sdk/zosworkflow/WorkflowConstants.java
+++ b/src/main/java/zowe/client/sdk/zosworkflow/WorkflowConstants.java
@@ -11,8 +11,6 @@ package zowe.client.sdk.zosworkflow;
 
 /**
  * Constants to be used by the z/OSMF workflow API.
- * <p>
- * <a href="https://www.ibm.com/docs/en/zos/3.2.0?topic=services-zosmf-workflow-services">z/OSMF REST API</a>
  *
  * @author Ashish Kumar Dash
  * @version 7.0

--- a/src/main/java/zowe/client/sdk/zosworkflow/input/WorkflowCreateInputData.java
+++ b/src/main/java/zowe/client/sdk/zosworkflow/input/WorkflowCreateInputData.java
@@ -16,8 +16,7 @@ import java.util.List;
 
 /**
  * Parameters for the z/OSMF create workflow API input data.
- * <p>
- * <a href="https://www.ibm.com/docs/en/zos/3.2.0?topic=services-zosmf-workflow-services">z/OSMF REST API</a>
+ * <p><a href="https://www.ibm.com/docs/en/zos/2.5.0?topic=services-create-workflow">z/OSMF REST API</a>
  *
  * @author Ashish Kumar Dash
  * @version 7.0

--- a/src/main/java/zowe/client/sdk/zosworkflow/methods/WorkflowCreate.java
+++ b/src/main/java/zowe/client/sdk/zosworkflow/methods/WorkflowCreate.java
@@ -25,8 +25,7 @@ import zowe.client.sdk.zosworkflow.response.WorkflowCreateResponse;
 
 /**
  * Provides create workflow functionality through the z/OSMF workflow REST API.
- * <p>
- * <a href="https://www.ibm.com/docs/en/zos/3.2.0?topic=services-zosmf-workflow-services">z/OSMF REST API</a>
+ * <p><a href="https://www.ibm.com/docs/en/zos/2.5.0?topic=services-create-workflow">z/OSMF REST API</a>
  *
  * @author Ashish Kumar Dash
  * @version 7.0

--- a/src/main/java/zowe/client/sdk/zosworkflow/model/WorkflowVariable.java
+++ b/src/main/java/zowe/client/sdk/zosworkflow/model/WorkflowVariable.java
@@ -13,8 +13,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 /**
  * Workflow variable name/value pair.
- * <p>
- * <a href="https://www.ibm.com/docs/en/zos/3.2.0?topic=services-zosmf-workflow-services">z/OSMF REST API</a>
+ * <p><a href="https://www.ibm.com/docs/en/zos/2.5.0?topic=services-create-workflow">z/OSMF REST API</a>
  *
  * @author Ashish Kumar Dash
  * @version 7.0

--- a/src/main/java/zowe/client/sdk/zosworkflow/response/WorkflowCreateResponse.java
+++ b/src/main/java/zowe/client/sdk/zosworkflow/response/WorkflowCreateResponse.java
@@ -15,8 +15,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * API response for create workflow.
- * <p>
- * <a href="https://www.ibm.com/docs/en/zos/3.2.0?topic=services-zosmf-workflow-services">z/OSMF REST API</a>
+ * <p><a href="https://www.ibm.com/docs/en/zos/2.5.0?topic=services-create-workflow">z/OSMF REST API</a>
  *
  * @author Ashish Kumar Dash
  * @version 7.0


### PR DESCRIPTION
Replaced incorrect generic workflow services URL with the specific create-workflow API link (https://www.ibm.com/docs/en/zos/2.5.0?topic=services-create-workflow) across all workflow classes
Merged <p> and <a href> onto a single line per project style preference
Removed URL from WorkflowConstants as it is shared across workflow operations