### PR TITLE
Add system variables export API method

### DIFF
--- a/src/main/java/zowe/client/sdk/zosvariables/methods/VariableExport.java
+++ b/src/main/java/zowe/client/sdk/zosvariables/methods/VariableExport.java
@@ -1,0 +1,104 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosvariables.methods;
+
+import org.json.simple.JSONObject;
+import zowe.client.sdk.core.ZosConnection;
+import zowe.client.sdk.rest.PostJsonZosmfRequest;
+import zowe.client.sdk.rest.Response;
+import zowe.client.sdk.rest.ZosmfRequest;
+import zowe.client.sdk.rest.ZosmfRequestFactory;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
+import zowe.client.sdk.rest.type.ZosmfRequestType;
+import zowe.client.sdk.utility.EncodeUtils;
+import zowe.client.sdk.utility.ValidateUtils;
+import zowe.client.sdk.zosvariables.VariableConstants;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Class to handle exporting of z/OS system variables.
+ * <p>
+ * <a href="https://www.ibm.com/docs/en/zos/3.2.0?topic=services-export-system-variables">z/OSMF REST API</a>
+ *
+ * @author Chaitanya Katore
+ * @version 7.0
+ */
+public class VariableExport {
+
+    private final ZosConnection connection;
+    private final ZosmfRequest request;
+
+    /**
+     * VariableExport Constructor.
+     *
+     * @param connection for connection information, see ZosConnection object
+     * @author Chaitanya Katore
+     */
+    public VariableExport(final ZosConnection connection) {
+        ValidateUtils.checkNullParameter(connection, "connection");
+        this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.POST_JSON);
+    }
+
+    /**
+     * Alternative VariableExport constructor with ZosmfRequest object.
+     * This is mainly used for internal code unit testing with Mockito,
+     * and it is not recommended to be used by the larger community.
+     * <p>
+     * This constructor is package-private.
+     *
+     * @param connection for connection information, see ZosConnection object
+     * @param request    any compatible ZosmfRequest Interface object
+     * @author Chaitanya Katore
+     */
+    VariableExport(final ZosConnection connection, final ZosmfRequest request) {
+        ValidateUtils.checkNullParameter(connection, "connection");
+        ValidateUtils.checkNullParameter(request, "request");
+        this.connection = connection;
+        if (!(request instanceof PostJsonZosmfRequest)) {
+            throw new IllegalStateException("POST_JSON request type required");
+        }
+        this.request = request;
+    }
+
+    /**
+     * Export variables to a CSV data file on USS.
+     *
+     * @param sysplexName         name of the sysplex (e.g. 'PLEX1')
+     * @param systemName          name of the system (e.g. 'SYS1')
+     * @param variablesExportFile absolute path of the variables export file on USS (e.g. '/u/user1/vars.csv')
+     * @return http response object
+     * @throws ZosmfRequestException request error state
+     * @author Chaitanya Katore
+     */
+    public Response export(final String sysplexName,
+                           final String systemName,
+                           final String variablesExportFile) throws ZosmfRequestException {
+        ValidateUtils.checkIllegalParameter(sysplexName, "sysplexName");
+        ValidateUtils.checkIllegalParameter(systemName, "systemName");
+        ValidateUtils.checkIllegalParameter(variablesExportFile, "variablesExportFile");
+
+        final String url = connection.getZosmfUrl() +
+                VariableConstants.RESOURCE + "/" +
+                EncodeUtils.encodeURIComponent(sysplexName) + "." +
+                EncodeUtils.encodeURIComponent(systemName) + "/actions/export";
+
+        final Map<String, Object> bodyMap = new HashMap<>();
+        bodyMap.put("variables-export-file", variablesExportFile);
+
+        request.setUrl(url);
+        request.setBody(new JSONObject(bodyMap).toString());
+
+        return request.executeRequest();
+    }
+
+}

--- a/src/main/java/zowe/client/sdk/zosvariables/methods/VariableExport.java
+++ b/src/main/java/zowe/client/sdk/zosvariables/methods/VariableExport.java
@@ -83,7 +83,7 @@ public class VariableExport {
     public Response export(final String sysplexName,
                            final String systemName,
                            final String variablesExportFile) throws ZosmfRequestException {
-        return exportCommon(sysplexName, systemName, variablesExportFile, null);
+        return exportCommon(sysplexName, systemName, variablesExportFile, false);
     }
 
     /**
@@ -110,7 +110,7 @@ public class VariableExport {
      * @param sysplexName         name of the sysplex (e.g. 'PLEX1')
      * @param systemName          name of the system (e.g. 'SYS1')
      * @param variablesExportFile absolute path of the variables export file on USS (e.g. '/u/user1/vars.csv')
-     * @param overwrite           boolean value or null to indicate if file should be overwritten
+     * @param overwrite           boolean value to indicate if file should be overwritten
      * @return http response object
      * @throws ZosmfRequestException request error state
      */

--- a/src/main/java/zowe/client/sdk/zosvariables/methods/VariableExport.java
+++ b/src/main/java/zowe/client/sdk/zosvariables/methods/VariableExport.java
@@ -83,6 +83,41 @@ public class VariableExport {
     public Response export(final String sysplexName,
                            final String systemName,
                            final String variablesExportFile) throws ZosmfRequestException {
+        return exportCommon(sysplexName, systemName, variablesExportFile, null);
+    }
+
+    /**
+     * Export variables to a CSV data file on USS with overwrite option.
+     *
+     * @param sysplexName         name of the sysplex (e.g. 'PLEX1')
+     * @param systemName          name of the system (e.g. 'SYS1')
+     * @param variablesExportFile absolute path of the variables export file on USS (e.g. '/u/user1/vars.csv')
+     * @param overwrite           boolean to indicate if file should be overwritten if it already exists
+     * @return http response object
+     * @throws ZosmfRequestException request error state
+     * @author Chaitanya Katore
+     */
+    public Response export(final String sysplexName,
+                           final String systemName,
+                           final String variablesExportFile,
+                           final boolean overwrite) throws ZosmfRequestException {
+        return exportCommon(sysplexName, systemName, variablesExportFile, overwrite);
+    }
+
+    /**
+     * Common method to handle exporting of variables.
+     *
+     * @param sysplexName         name of the sysplex (e.g. 'PLEX1')
+     * @param systemName          name of the system (e.g. 'SYS1')
+     * @param variablesExportFile absolute path of the variables export file on USS (e.g. '/u/user1/vars.csv')
+     * @param overwrite           boolean value or null to indicate if file should be overwritten
+     * @return http response object
+     * @throws ZosmfRequestException request error state
+     */
+    private Response exportCommon(final String sysplexName,
+                                  final String systemName,
+                                  final String variablesExportFile,
+                                  final Boolean overwrite) throws ZosmfRequestException {
         ValidateUtils.checkIllegalParameter(sysplexName, "sysplexName");
         ValidateUtils.checkIllegalParameter(systemName, "systemName");
         ValidateUtils.checkIllegalParameter(variablesExportFile, "variablesExportFile");
@@ -94,6 +129,9 @@ public class VariableExport {
 
         final Map<String, Object> bodyMap = new HashMap<>();
         bodyMap.put("variables-export-file", variablesExportFile);
+        if (overwrite != null) {
+            bodyMap.put("overwrite", overwrite);
+        }
 
         request.setUrl(url);
         request.setBody(new JSONObject(bodyMap).toString());

--- a/src/main/java/zowe/client/sdk/zosvariables/methods/VariableExport.java
+++ b/src/main/java/zowe/client/sdk/zosvariables/methods/VariableExport.java
@@ -117,7 +117,7 @@ public class VariableExport {
     private Response exportCommon(final String sysplexName,
                                   final String systemName,
                                   final String variablesExportFile,
-                                  final Boolean overwrite) throws ZosmfRequestException {
+                                  final boolean overwrite) throws ZosmfRequestException {
         ValidateUtils.checkIllegalParameter(sysplexName, "sysplexName");
         ValidateUtils.checkIllegalParameter(systemName, "systemName");
         ValidateUtils.checkIllegalParameter(variablesExportFile, "variablesExportFile");
@@ -129,9 +129,7 @@ public class VariableExport {
 
         final Map<String, Object> bodyMap = new HashMap<>();
         bodyMap.put("variables-export-file", variablesExportFile);
-        if (overwrite != null) {
-            bodyMap.put("overwrite", overwrite);
-        }
+        bodyMap.put("overwrite", overwrite);
 
         request.setUrl(url);
         request.setBody(new JSONObject(bodyMap).toString());

--- a/src/test/java/zowe/client/sdk/zosvariables/methods/VariableExportTest.java
+++ b/src/test/java/zowe/client/sdk/zosvariables/methods/VariableExportTest.java
@@ -71,7 +71,7 @@ public class VariableExportTest {
         assertEquals(204, response.getStatusCode().orElse(-1));
         assertEquals("No Content", response.getStatusText().orElse("n\\a"));
         assertEquals("https://1:443/zosmf/variables/rest/1.0/systems/PLEX1.SYS1/actions/export", mockPostRequest.getUrl());
-        Mockito.verify(mockPostRequest).setBody("{\"variables-export-file\":\"\\/path\\/to\\/export.csv\"}");
+        Mockito.verify(mockPostRequest).setBody("{\"overwrite\":false,\"variables-export-file\":\"\\/path\\/to\\/export.csv\"}");
     }
 
     @Test
@@ -106,7 +106,7 @@ public class VariableExportTest {
         assertEquals(204, response.getStatusCode().orElse(-1));
         assertEquals("No Content", response.getStatusText().orElse("n\\a"));
         assertEquals("https://1:443/zosmf/variables/rest/1.0/systems/PLEX1.SYS1/actions/export", mockPostRequestToken.getUrl());
-        Mockito.verify(mockPostRequestToken).setBody("{\"variables-export-file\":\"\\/path\\/to\\/export.csv\"}");
+        Mockito.verify(mockPostRequestToken).setBody("{\"overwrite\":false,\"variables-export-file\":\"\\/path\\/to\\/export.csv\"}");
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosvariables/methods/VariableExportTest.java
+++ b/src/test/java/zowe/client/sdk/zosvariables/methods/VariableExportTest.java
@@ -1,0 +1,202 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosvariables.methods;
+
+import kong.unirest.core.Cookie;
+import org.json.simple.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import zowe.client.sdk.core.ZosConnection;
+import zowe.client.sdk.core.ZosConnectionFactory;
+import zowe.client.sdk.rest.PostJsonZosmfRequest;
+import zowe.client.sdk.rest.Response;
+import zowe.client.sdk.rest.ZosmfRequest;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.withSettings;
+
+/**
+ * Class containing unit tests for VariableExport.
+ *
+ * @author Chaitanya Katore
+ * @version 7.0
+ */
+public class VariableExportTest {
+
+    private final ZosConnection connection = ZosConnectionFactory
+            .createBasicConnection("1", 443, "1", "1");
+    private final ZosConnection tokenConnection = ZosConnectionFactory
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
+    private PostJsonZosmfRequest mockPostRequest;
+    private PostJsonZosmfRequest mockPostRequestToken;
+
+    @BeforeEach
+    public void init() throws ZosmfRequestException {
+        mockPostRequest = Mockito.mock(PostJsonZosmfRequest.class);
+        Mockito.when(mockPostRequest.executeRequest()).thenReturn(
+                new Response(new JSONObject(), 204, "No Content"));
+        doCallRealMethod().when(mockPostRequest).setUrl(any());
+        doCallRealMethod().when(mockPostRequest).getUrl();
+        doCallRealMethod().when(mockPostRequest).setBody(any());
+
+        mockPostRequestToken = Mockito.mock(PostJsonZosmfRequest.class,
+                withSettings().useConstructor(tokenConnection));
+        Mockito.when(mockPostRequestToken.executeRequest()).thenReturn(
+                new Response(new JSONObject(), 204, "No Content"));
+        doCallRealMethod().when(mockPostRequestToken).setHeaders(anyMap());
+        doCallRealMethod().when(mockPostRequestToken).setStandardHeaders();
+        doCallRealMethod().when(mockPostRequestToken).setUrl(any());
+        doCallRealMethod().when(mockPostRequestToken).getHeaders();
+        doCallRealMethod().when(mockPostRequestToken).getUrl();
+        doCallRealMethod().when(mockPostRequestToken).setBody(any());
+    }
+
+    @Test
+    public void tstVariableExportSuccess() throws ZosmfRequestException {
+        final VariableExport variablesExport = new VariableExport(connection, mockPostRequest);
+        final Response response = variablesExport.export("PLEX1", "SYS1", "/path/to/export.csv");
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(204, response.getStatusCode().orElse(-1));
+        assertEquals("No Content", response.getStatusText().orElse("n\\a"));
+        assertEquals("https://1:443/zosmf/variables/rest/1.0/systems/PLEX1.SYS1/actions/export", mockPostRequest.getUrl());
+    }
+
+    @Test
+    public void tstVariableExportTokenSuccess() throws ZosmfRequestException {
+        final VariableExport variablesExport = new VariableExport(connection, mockPostRequestToken);
+        final Response response = variablesExport.export("PLEX1", "SYS1", "/path/to/export.csv");
+        assertEquals("{X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
+                mockPostRequestToken.getHeaders().toString());
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(204, response.getStatusCode().orElse(-1));
+        assertEquals("No Content", response.getStatusText().orElse("n\\a"));
+        assertEquals("https://1:443/zosmf/variables/rest/1.0/systems/PLEX1.SYS1/actions/export", mockPostRequestToken.getUrl());
+    }
+
+    @Test
+    public void tstVariableExportNullSysplexNameFailure() {
+        final VariableExport variablesExport = new VariableExport(connection, mockPostRequest);
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> variablesExport.export(null, "SYS1", "/path/to/export.csv")
+        );
+        assertEquals("sysplexName is either null or empty", exception.getMessage());
+    }
+
+    @Test
+    public void tstVariableExportEmptySysplexNameFailure() {
+        final VariableExport variablesExport = new VariableExport(connection, mockPostRequest);
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> variablesExport.export("", "SYS1", "/path/to/export.csv")
+        );
+        assertEquals("sysplexName is either null or empty", exception.getMessage());
+    }
+
+    @Test
+    public void tstVariableExportNullSystemNameFailure() {
+        final VariableExport variablesExport = new VariableExport(connection, mockPostRequest);
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> variablesExport.export("PLEX1", null, "/path/to/export.csv")
+        );
+        assertEquals("systemName is either null or empty", exception.getMessage());
+    }
+
+    @Test
+    public void tstVariableExportEmptySystemNameFailure() {
+        final VariableExport variablesExport = new VariableExport(connection, mockPostRequest);
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> variablesExport.export("PLEX1", "", "/path/to/export.csv")
+        );
+        assertEquals("systemName is either null or empty", exception.getMessage());
+    }
+
+    @Test
+    public void tstVariableExportNullVariablesDataFileFailure() {
+        final VariableExport variablesExport = new VariableExport(connection, mockPostRequest);
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> variablesExport.export("PLEX1", "SYS1", null)
+        );
+        assertEquals("variablesExportFile is either null or empty", exception.getMessage());
+    }
+
+    @Test
+    public void tstVariableExportEmptyVariablesDataFileFailure() {
+        final VariableExport variablesExport = new VariableExport(connection, mockPostRequest);
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> variablesExport.export("PLEX1", "SYS1", "")
+        );
+        assertEquals("variablesExportFile is either null or empty", exception.getMessage());
+    }
+
+    @Test
+    public void tstVariableExportSecondaryConstructorWithValidRequestTypeSuccess() {
+        ZosConnection mockConnection = Mockito.mock(ZosConnection.class);
+        ZosmfRequest mockRequest = Mockito.mock(PostJsonZosmfRequest.class);
+        VariableExport variablesExport = new VariableExport(mockConnection, mockRequest);
+        assertNotNull(variablesExport);
+    }
+
+    @Test
+    public void tstVariableExportSecondaryConstructorWithNullConnectionFailure() {
+        ZosmfRequest mockRequest = Mockito.mock(PostJsonZosmfRequest.class);
+        NullPointerException exception = assertThrows(
+                NullPointerException.class,
+                () -> new VariableExport(null, mockRequest)
+        );
+        assertEquals("connection is null", exception.getMessage());
+    }
+
+    @Test
+    public void tstVariableExportSecondaryConstructorWithNullRequestFailure() {
+        ZosConnection mockConnection = Mockito.mock(ZosConnection.class);
+        NullPointerException exception = assertThrows(
+                NullPointerException.class,
+                () -> new VariableExport(mockConnection, null)
+        );
+        assertEquals("request is null", exception.getMessage());
+    }
+
+    @Test
+    public void tstVariableExportSecondaryConstructorWithInvalidRequestTypeFailure() {
+        ZosConnection mockConnection = Mockito.mock(ZosConnection.class);
+        ZosmfRequest mockRequest = Mockito.mock(ZosmfRequest.class);
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> new VariableExport(mockConnection, mockRequest)
+        );
+        assertEquals("POST_JSON request type required", exception.getMessage());
+    }
+
+    @Test
+    public void tstVariableExportPrimaryConstructorWithValidConnectionSuccess() {
+        VariableExport variablesExport = new VariableExport(connection);
+        assertNotNull(variablesExport);
+    }
+
+    @Test
+    public void tstVariableExportPrimaryConstructorWithNullConnectionFailure() {
+        NullPointerException exception = assertThrows(
+                NullPointerException.class,
+                () -> new VariableExport(null)
+        );
+        assertEquals("connection is null", exception.getMessage());
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/zosvariables/methods/VariableExportTest.java
+++ b/src/test/java/zowe/client/sdk/zosvariables/methods/VariableExportTest.java
@@ -71,6 +71,29 @@ public class VariableExportTest {
         assertEquals(204, response.getStatusCode().orElse(-1));
         assertEquals("No Content", response.getStatusText().orElse("n\\a"));
         assertEquals("https://1:443/zosmf/variables/rest/1.0/systems/PLEX1.SYS1/actions/export", mockPostRequest.getUrl());
+        Mockito.verify(mockPostRequest).setBody("{\"variables-export-file\":\"\\/path\\/to\\/export.csv\"}");
+    }
+
+    @Test
+    public void tstVariableExportWithOverwriteTrueSuccess() throws ZosmfRequestException {
+        final VariableExport variablesExport = new VariableExport(connection, mockPostRequest);
+        final Response response = variablesExport.export("PLEX1", "SYS1", "/path/to/export.csv", true);
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(204, response.getStatusCode().orElse(-1));
+        assertEquals("No Content", response.getStatusText().orElse("n\\a"));
+        assertEquals("https://1:443/zosmf/variables/rest/1.0/systems/PLEX1.SYS1/actions/export", mockPostRequest.getUrl());
+        Mockito.verify(mockPostRequest).setBody("{\"overwrite\":true,\"variables-export-file\":\"\\/path\\/to\\/export.csv\"}");
+    }
+
+    @Test
+    public void tstVariableExportWithOverwriteFalseSuccess() throws ZosmfRequestException {
+        final VariableExport variablesExport = new VariableExport(connection, mockPostRequest);
+        final Response response = variablesExport.export("PLEX1", "SYS1", "/path/to/export.csv", false);
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(204, response.getStatusCode().orElse(-1));
+        assertEquals("No Content", response.getStatusText().orElse("n\\a"));
+        assertEquals("https://1:443/zosmf/variables/rest/1.0/systems/PLEX1.SYS1/actions/export", mockPostRequest.getUrl());
+        Mockito.verify(mockPostRequest).setBody("{\"overwrite\":false,\"variables-export-file\":\"\\/path\\/to\\/export.csv\"}");
     }
 
     @Test
@@ -83,6 +106,7 @@ public class VariableExportTest {
         assertEquals(204, response.getStatusCode().orElse(-1));
         assertEquals("No Content", response.getStatusText().orElse("n\\a"));
         assertEquals("https://1:443/zosmf/variables/rest/1.0/systems/PLEX1.SYS1/actions/export", mockPostRequestToken.getUrl());
+        Mockito.verify(mockPostRequestToken).setBody("{\"variables-export-file\":\"\\/path\\/to\\/export.csv\"}");
     }
 
     @Test


### PR DESCRIPTION
## Overview
This PR implements [Issue #507](https://github.com/zowe/zowe-client-java-sdk/issues/507) by adding the z/OSMF System Variable Services export API method to the Java SDK. This enables developers to export system variables to a CSV file on USS.

## Proposed Changes
1. **Added `VariableExport` Class**:
   - Implements the `export(sysplexName, systemName, variablesExportFile)` method.
   - Follows the SDK design guideline of using a `final` `ZosmfRequest` object initialized via constructors.
   - Leverages `VariableConstants.RESOURCE` to construct the target endpoint.
2. **Added Unit Tests (`VariableExportTest`)**:
   - Covers successful export operations under both basic and token authentication.
   - Tests parameter validations (null/empty values for sysplex name, system name, and file path).
   - Validates constructor constraints (null connections, invalid request types).

## Verification
- Ran the full test suite via `./mvnw clean test`.
- All 855 unit tests passed successfully.