### PR TITLE
Add delete system variables 

### DIFF
--- a/src/main/java/zowe/client/sdk/rest/DeleteJsonZosmfRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/DeleteJsonZosmfRequest.java
@@ -13,6 +13,8 @@ import kong.unirest.core.HttpResponse;
 import kong.unirest.core.JsonNode;
 import kong.unirest.core.Unirest;
 import kong.unirest.core.UnirestException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.utility.ValidateUtils;
@@ -24,6 +26,13 @@ import zowe.client.sdk.utility.ValidateUtils;
  * @version 7.0
  */
 public class DeleteJsonZosmfRequest extends ZosmfRequest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DeleteJsonZosmfRequest.class);
+
+    /**
+     * JSON String representation of an optional request body. A delete request may be issued with or without a body.
+     */
+    private String body;
 
     /**
      * DeleteJsonZosmfRequest constructor
@@ -47,8 +56,13 @@ public class DeleteJsonZosmfRequest extends ZosmfRequest {
         ValidateUtils.checkNullParameter(url, "url");
         HttpResponse<JsonNode> reply;
         try {
-            reply = token != null ? Unirest.delete(url).cookie(token).headers(headers).asJson() :
-                    Unirest.delete(url).headers(headers).asJson();
+            if (body == null) {
+                reply = token != null ? Unirest.delete(url).cookie(token).headers(headers).asJson() :
+                        Unirest.delete(url).headers(headers).asJson();
+            } else {
+                reply = token != null ? Unirest.delete(url).cookie(token).headers(headers).body(body).asJson() :
+                        Unirest.delete(url).headers(headers).body(body).asJson();
+            }
         } catch (UnirestException e) {
             throw new ZosmfRequestException(e.getMessage(), e);
         }
@@ -56,14 +70,15 @@ public class DeleteJsonZosmfRequest extends ZosmfRequest {
     }
 
     /**
-     * Method to set the body information for the http request which is not used for this request.
+     * Set the body information for the http request. The body is optional for a delete request.
      *
-     * @param body object value
+     * @param body String value
      * @author Frank Giordano
      */
     @Override
-    public void setBody(Object body) {
-        throw new IllegalStateException("setting body for this request is invalid");
+    public void setBody(final Object body) {
+        this.body = (String) body;
+        LOG.debug(this.body);
     }
 
     /**

--- a/src/main/java/zowe/client/sdk/zosvariables/methods/VariableDelete.java
+++ b/src/main/java/zowe/client/sdk/zosvariables/methods/VariableDelete.java
@@ -78,14 +78,8 @@ public class VariableDelete {
      * @return http response object
      * @throws ZosmfRequestException request error state
      */
-    public Response delete(final String sysplexName, final String systemName) throws ZosmfRequestException {
-        ValidateUtils.checkIllegalParameter(sysplexName, "sysplexName");
-        ValidateUtils.checkIllegalParameter(systemName, "systemName");
-
-        // clear any body from a prior call so the reused request issues a true bodyless (whole-pool) delete
-        request.setBody(null);
-        request.setUrl(buildUrl(sysplexName, systemName));
-        return request.executeRequest();
+    public Response deleteAll(final String sysplexName, final String systemName) throws ZosmfRequestException {
+        return deleteCommon(sysplexName, systemName, null, true);
     }
 
     /**
@@ -101,32 +95,43 @@ public class VariableDelete {
      */
     public Response delete(final String sysplexName, final String systemName, final List<String> variableNames)
             throws ZosmfRequestException {
-        ValidateUtils.checkIllegalParameter(sysplexName, "sysplexName");
-        ValidateUtils.checkIllegalParameter(systemName, "systemName");
-        ValidateUtils.checkNullParameter(variableNames, "variableNames");
-        ValidateUtils.checkIllegalParameter(variableNames.isEmpty(), "variableNames is empty");
-
-        final JSONArray bodyArray = new JSONArray();
-        bodyArray.addAll(variableNames);
-
-        request.setUrl(buildUrl(sysplexName, systemName));
-        request.setBody(bodyArray.toJSONString());
-        return request.executeRequest();
+        return deleteCommon(sysplexName, systemName, variableNames, false);
     }
 
     /**
-     * Build the system variable pool url for the target system.
+     * Common method to handle deleting of system variables.
      *
-     * @param sysplexName name of the sysplex
-     * @param systemName  name of the system
-     * @return system variable pool url
+     * @param sysplexName   name of the sysplex (e.g. 'PLEX1')
+     * @param systemName    name of the system (e.g. 'SYS1')
+     * @param variableNames names of the system variables to delete, ignored when isAll is true
+     * @param isAll         true to delete the entire system variable pool with no request body
+     * @return http response object
+     * @throws ZosmfRequestException request error state
      */
-    private String buildUrl(final String sysplexName, final String systemName) {
-        return connection.getZosmfUrl() +
+    private Response deleteCommon(final String sysplexName, final String systemName,
+                                  final List<String> variableNames, final boolean isAll) throws ZosmfRequestException {
+        ValidateUtils.checkIllegalParameter(sysplexName, "sysplexName");
+        ValidateUtils.checkIllegalParameter(systemName, "systemName");
+
+        final String url = connection.getZosmfUrl() +
                 VariableConstants.RESOURCE +
                 UrlConstants.URL_PATH_DELIM +
                 EncodeUtils.encodeURIComponent(sysplexName) + "." +
                 EncodeUtils.encodeURIComponent(systemName);
+
+        if (isAll) {
+            // whole-pool delete: clear any prior body so the reused request issues a true bodyless request
+            request.setBody(null);
+        } else {
+            ValidateUtils.checkNullParameter(variableNames, "variableNames");
+            ValidateUtils.checkIllegalParameter(variableNames.isEmpty(), "variableNames is empty");
+            final JSONArray bodyArray = new JSONArray();
+            bodyArray.addAll(variableNames);
+            request.setBody(bodyArray.toJSONString());
+        }
+
+        request.setUrl(url);
+        return request.executeRequest();
     }
 
 }

--- a/src/main/java/zowe/client/sdk/zosvariables/methods/VariableDelete.java
+++ b/src/main/java/zowe/client/sdk/zosvariables/methods/VariableDelete.java
@@ -9,7 +9,8 @@
  */
 package zowe.client.sdk.zosvariables.methods;
 
-import org.json.simple.JSONArray;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.DeleteJsonZosmfRequest;
 import zowe.client.sdk.rest.Response;
@@ -33,6 +34,8 @@ import java.util.List;
  * @version 7.0
  */
 public class VariableDelete {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private final ZosConnection connection;
     private final ZosmfRequest request;
@@ -86,6 +89,8 @@ public class VariableDelete {
      * Delete the specified system variables from the target system's variable pool.
      * <p>
      * The request body is an array of strings, each representing the name of a system variable to delete.
+     * If {@code variableNames} is empty, the request succeeds but no variables are deleted, as defined by the
+     * z/OSMF REST API.
      *
      * @param sysplexName   name of the sysplex (e.g. 'PLEX1')
      * @param systemName    name of the system (e.g. 'SYS1')
@@ -103,13 +108,16 @@ public class VariableDelete {
      *
      * @param sysplexName   name of the sysplex (e.g. 'PLEX1')
      * @param systemName    name of the system (e.g. 'SYS1')
-     * @param variableNames names of the system variables to delete, ignored when isAll is true
-     * @param isAll         true to delete the entire system variable pool with no request body
+     * @param variableNames names of the system variables to delete, ignored when deleteAll is true
+     * @param deleteAll     true to delete the entire system variable pool with no request body
      * @return http response object
      * @throws ZosmfRequestException request error state
      */
-    private Response deleteCommon(final String sysplexName, final String systemName,
-                                  final List<String> variableNames, final boolean isAll) throws ZosmfRequestException {
+    private Response deleteCommon(final String sysplexName,
+                                  final String systemName,
+                                  final List<String> variableNames,
+                                  final boolean deleteAll)
+            throws ZosmfRequestException {
         ValidateUtils.checkIllegalParameter(sysplexName, "sysplexName");
         ValidateUtils.checkIllegalParameter(systemName, "systemName");
 
@@ -119,15 +127,16 @@ public class VariableDelete {
                 EncodeUtils.encodeURIComponent(sysplexName) + "." +
                 EncodeUtils.encodeURIComponent(systemName);
 
-        if (isAll) {
+        if (deleteAll) {
             // whole-pool delete: clear any prior body so the reused request issues a true bodyless request
             request.setBody(null);
         } else {
             ValidateUtils.checkNullParameter(variableNames, "variableNames");
-            ValidateUtils.checkIllegalParameter(variableNames.isEmpty(), "variableNames is empty");
-            final JSONArray bodyArray = new JSONArray();
-            bodyArray.addAll(variableNames);
-            request.setBody(bodyArray.toJSONString());
+            try {
+                request.setBody(OBJECT_MAPPER.writeValueAsString(variableNames));
+            } catch (JsonProcessingException e) {
+                throw new IllegalStateException("error serializing variable names", e);
+            }
         }
 
         request.setUrl(url);

--- a/src/main/java/zowe/client/sdk/zosvariables/methods/VariableDelete.java
+++ b/src/main/java/zowe/client/sdk/zosvariables/methods/VariableDelete.java
@@ -1,0 +1,132 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosvariables.methods;
+
+import org.json.simple.JSONArray;
+import zowe.client.sdk.core.ZosConnection;
+import zowe.client.sdk.rest.DeleteJsonZosmfRequest;
+import zowe.client.sdk.rest.Response;
+import zowe.client.sdk.rest.UrlConstants;
+import zowe.client.sdk.rest.ZosmfRequest;
+import zowe.client.sdk.rest.ZosmfRequestFactory;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
+import zowe.client.sdk.rest.type.ZosmfRequestType;
+import zowe.client.sdk.utility.EncodeUtils;
+import zowe.client.sdk.utility.ValidateUtils;
+import zowe.client.sdk.zosvariables.VariableConstants;
+
+import java.util.List;
+
+/**
+ * Class to handle deleting of z/OS system variables.
+ * <p>
+ * <a href="https://www.ibm.com/docs/en/zos/3.2.0?topic=services-delete-system-variables">z/OSMF REST API</a>
+ *
+ * @author Ashish Kumar Dash
+ * @version 7.0
+ */
+public class VariableDelete {
+
+    private final ZosConnection connection;
+    private final ZosmfRequest request;
+
+    /**
+     * VariableDelete constructor.
+     *
+     * @param connection for connection information, see ZosConnection object
+     */
+    public VariableDelete(final ZosConnection connection) {
+        ValidateUtils.checkNullParameter(connection, "connection");
+        this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.DELETE_JSON);
+    }
+
+    /**
+     * Alternative VariableDelete constructor with ZosmfRequest object.
+     * This is mainly used for internal code unit testing with Mockito,
+     * and it is not recommended to be used by the larger community.
+     * <p>
+     * This constructor is package-private.
+     *
+     * @param connection for connection information, see ZosConnection object
+     * @param request    any compatible ZosmfRequest Interface object
+     */
+    VariableDelete(final ZosConnection connection, final ZosmfRequest request) {
+        ValidateUtils.checkNullParameter(connection, "connection");
+        ValidateUtils.checkNullParameter(request, "request");
+        this.connection = connection;
+        if (!(request instanceof DeleteJsonZosmfRequest)) {
+            throw new IllegalStateException("DELETE_JSON request type required");
+        }
+        this.request = request;
+    }
+
+    /**
+     * Delete the entire system variable pool for the target system.
+     * <p>
+     * A delete request with no request body removes the system variable pool from the system.
+     *
+     * @param sysplexName name of the sysplex (e.g. 'PLEX1')
+     * @param systemName  name of the system (e.g. 'SYS1')
+     * @return http response object
+     * @throws ZosmfRequestException request error state
+     */
+    public Response delete(final String sysplexName, final String systemName) throws ZosmfRequestException {
+        ValidateUtils.checkIllegalParameter(sysplexName, "sysplexName");
+        ValidateUtils.checkIllegalParameter(systemName, "systemName");
+
+        // clear any body from a prior call so the reused request issues a true bodyless (whole-pool) delete
+        request.setBody(null);
+        request.setUrl(buildUrl(sysplexName, systemName));
+        return request.executeRequest();
+    }
+
+    /**
+     * Delete the specified system variables from the target system's variable pool.
+     * <p>
+     * The request body is an array of strings, each representing the name of a system variable to delete.
+     *
+     * @param sysplexName   name of the sysplex (e.g. 'PLEX1')
+     * @param systemName    name of the system (e.g. 'SYS1')
+     * @param variableNames names of the system variables to delete
+     * @return http response object
+     * @throws ZosmfRequestException request error state
+     */
+    public Response delete(final String sysplexName, final String systemName, final List<String> variableNames)
+            throws ZosmfRequestException {
+        ValidateUtils.checkIllegalParameter(sysplexName, "sysplexName");
+        ValidateUtils.checkIllegalParameter(systemName, "systemName");
+        ValidateUtils.checkNullParameter(variableNames, "variableNames");
+        ValidateUtils.checkIllegalParameter(variableNames.isEmpty(), "variableNames is empty");
+
+        final JSONArray bodyArray = new JSONArray();
+        bodyArray.addAll(variableNames);
+
+        request.setUrl(buildUrl(sysplexName, systemName));
+        request.setBody(bodyArray.toJSONString());
+        return request.executeRequest();
+    }
+
+    /**
+     * Build the system variable pool url for the target system.
+     *
+     * @param sysplexName name of the sysplex
+     * @param systemName  name of the system
+     * @return system variable pool url
+     */
+    private String buildUrl(final String sysplexName, final String systemName) {
+        return connection.getZosmfUrl() +
+                VariableConstants.RESOURCE +
+                UrlConstants.URL_PATH_DELIM +
+                EncodeUtils.encodeURIComponent(sysplexName) + "." +
+                EncodeUtils.encodeURIComponent(systemName);
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/zosvariables/methods/VariableDeleteTest.java
+++ b/src/test/java/zowe/client/sdk/zosvariables/methods/VariableDeleteTest.java
@@ -68,7 +68,7 @@ public class VariableDeleteTest {
     @Test
     public void tstVariableDeletePoolSuccess() throws ZosmfRequestException {
         final VariableDelete variableDelete = new VariableDelete(connection, mockDeleteRequest);
-        final Response response = variableDelete.delete("PLEX1", "SYS1");
+        final Response response = variableDelete.deleteAll("PLEX1", "SYS1");
 
         assertEquals(204, response.getStatusCode().orElse(-1));
         assertEquals("No Content", response.getStatusText().orElse("n\\a"));
@@ -82,7 +82,7 @@ public class VariableDeleteTest {
         final VariableDelete variableDelete = new VariableDelete(connection, mockDeleteRequest);
         // a specific-variable delete sets a body, then a whole-pool delete on the same instance must clear it
         variableDelete.delete("PLEX1", "SYS1", Collections.singletonList("var1"));
-        variableDelete.delete("PLEX1", "SYS1");
+        variableDelete.deleteAll("PLEX1", "SYS1");
 
         final ArgumentCaptor<Object> bodyCaptor = ArgumentCaptor.forClass(Object.class);
         verify(mockDeleteRequest, times(2)).setBody(bodyCaptor.capture());
@@ -117,7 +117,7 @@ public class VariableDeleteTest {
     public void tstVariableDeleteNullSysplexNameFailure() {
         final VariableDelete variableDelete = new VariableDelete(connection, mockDeleteRequest);
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-                () -> variableDelete.delete(null, "SYS1"));
+                () -> variableDelete.deleteAll(null, "SYS1"));
         assertEquals("sysplexName is either null or empty", exception.getMessage());
     }
 
@@ -125,7 +125,7 @@ public class VariableDeleteTest {
     public void tstVariableDeleteEmptySystemNameFailure() {
         final VariableDelete variableDelete = new VariableDelete(connection, mockDeleteRequest);
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-                () -> variableDelete.delete("PLEX1", ""));
+                () -> variableDelete.deleteAll("PLEX1", ""));
         assertEquals("systemName is either null or empty", exception.getMessage());
     }
 

--- a/src/test/java/zowe/client/sdk/zosvariables/methods/VariableDeleteTest.java
+++ b/src/test/java/zowe/client/sdk/zosvariables/methods/VariableDeleteTest.java
@@ -138,11 +138,15 @@ public class VariableDeleteTest {
     }
 
     @Test
-    public void tstVariableDeleteEmptyVariableNamesFailure() {
+    public void tstVariableDeleteEmptyVariableNamesSuccess() throws ZosmfRequestException {
         final VariableDelete variableDelete = new VariableDelete(connection, mockDeleteRequest);
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-                () -> variableDelete.delete("PLEX1", "SYS1", Collections.emptyList()));
-        assertEquals("variableNames is empty", exception.getMessage());
+        // the z/OSMF REST API allows an empty array; the request succeeds and no variables are deleted
+        final Response response = variableDelete.delete("PLEX1", "SYS1", Collections.emptyList());
+
+        assertEquals(204, response.getStatusCode().orElse(-1));
+        final ArgumentCaptor<Object> bodyCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(mockDeleteRequest).setBody(bodyCaptor.capture());
+        assertEquals("[]", bodyCaptor.getValue().toString());
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosvariables/methods/VariableDeleteTest.java
+++ b/src/test/java/zowe/client/sdk/zosvariables/methods/VariableDeleteTest.java
@@ -1,0 +1,192 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosvariables.methods;
+
+import kong.unirest.core.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import zowe.client.sdk.core.ZosConnection;
+import zowe.client.sdk.core.ZosConnectionFactory;
+import zowe.client.sdk.rest.DeleteJsonZosmfRequest;
+import zowe.client.sdk.rest.Response;
+import zowe.client.sdk.rest.ZosmfRequest;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.*;
+
+/**
+ * Class containing unit tests for VariableDelete.
+ *
+ * @author Ashish Kumar Dash
+ * @version 7.0
+ */
+public class VariableDeleteTest {
+
+    private final ZosConnection connection = ZosConnectionFactory
+            .createBasicConnection("1", 443, "1", "1");
+    private final ZosConnection tokenConnection = ZosConnectionFactory
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
+    private DeleteJsonZosmfRequest mockDeleteRequest;
+    private DeleteJsonZosmfRequest mockDeleteRequestToken;
+
+    @BeforeEach
+    public void init() throws ZosmfRequestException {
+        mockDeleteRequest = Mockito.mock(DeleteJsonZosmfRequest.class);
+        Mockito.when(mockDeleteRequest.executeRequest()).thenReturn(
+                new Response("No Content", 204, "No Content"));
+        doCallRealMethod().when(mockDeleteRequest).setUrl(any());
+        doCallRealMethod().when(mockDeleteRequest).getUrl();
+        doCallRealMethod().when(mockDeleteRequest).setBody(any());
+
+        mockDeleteRequestToken = Mockito.mock(DeleteJsonZosmfRequest.class,
+                withSettings().useConstructor(tokenConnection));
+        Mockito.when(mockDeleteRequestToken.executeRequest()).thenReturn(
+                new Response("No Content", 204, "No Content"));
+        doCallRealMethod().when(mockDeleteRequestToken).setHeaders(anyMap());
+        doCallRealMethod().when(mockDeleteRequestToken).setStandardHeaders();
+        doCallRealMethod().when(mockDeleteRequestToken).setUrl(any());
+        doCallRealMethod().when(mockDeleteRequestToken).getHeaders();
+        doCallRealMethod().when(mockDeleteRequestToken).getUrl();
+        doCallRealMethod().when(mockDeleteRequestToken).setBody(any());
+    }
+
+    @Test
+    public void tstVariableDeletePoolSuccess() throws ZosmfRequestException {
+        final VariableDelete variableDelete = new VariableDelete(connection, mockDeleteRequest);
+        final Response response = variableDelete.delete("PLEX1", "SYS1");
+
+        assertEquals(204, response.getStatusCode().orElse(-1));
+        assertEquals("No Content", response.getStatusText().orElse("n\\a"));
+        assertEquals("https://1:443/zosmf/variables/rest/1.0/systems/PLEX1.SYS1", mockDeleteRequest.getUrl());
+        // whole-pool delete issues a bodyless request; any prior body is cleared
+        verify(mockDeleteRequest).setBody(null);
+    }
+
+    @Test
+    public void tstVariableDeletePoolClearsPriorBodySuccess() throws ZosmfRequestException {
+        final VariableDelete variableDelete = new VariableDelete(connection, mockDeleteRequest);
+        // a specific-variable delete sets a body, then a whole-pool delete on the same instance must clear it
+        variableDelete.delete("PLEX1", "SYS1", Collections.singletonList("var1"));
+        variableDelete.delete("PLEX1", "SYS1");
+
+        final ArgumentCaptor<Object> bodyCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(mockDeleteRequest, times(2)).setBody(bodyCaptor.capture());
+        assertEquals("[\"var1\"]", bodyCaptor.getAllValues().get(0).toString());
+        assertNull(bodyCaptor.getAllValues().get(1));
+    }
+
+    @Test
+    public void tstVariableDeleteVariablesSuccess() throws ZosmfRequestException {
+        final VariableDelete variableDelete = new VariableDelete(connection, mockDeleteRequest);
+        final Response response = variableDelete.delete("PLEX1", "SYS1", Arrays.asList("var1", "var2"));
+
+        assertEquals(204, response.getStatusCode().orElse(-1));
+        assertEquals("https://1:443/zosmf/variables/rest/1.0/systems/PLEX1.SYS1", mockDeleteRequest.getUrl());
+
+        final ArgumentCaptor<Object> bodyCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(mockDeleteRequest).setBody(bodyCaptor.capture());
+        assertEquals("[\"var1\",\"var2\"]", bodyCaptor.getValue().toString());
+    }
+
+    @Test
+    public void tstVariableDeleteVariablesTokenSuccess() throws ZosmfRequestException {
+        final VariableDelete variableDelete = new VariableDelete(connection, mockDeleteRequestToken);
+        variableDelete.delete("PLEX1", "SYS1", Collections.singletonList("var1"));
+
+        assertEquals("{X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
+                mockDeleteRequestToken.getHeaders().toString());
+        assertEquals("https://1:443/zosmf/variables/rest/1.0/systems/PLEX1.SYS1", mockDeleteRequestToken.getUrl());
+    }
+
+    @Test
+    public void tstVariableDeleteNullSysplexNameFailure() {
+        final VariableDelete variableDelete = new VariableDelete(connection, mockDeleteRequest);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> variableDelete.delete(null, "SYS1"));
+        assertEquals("sysplexName is either null or empty", exception.getMessage());
+    }
+
+    @Test
+    public void tstVariableDeleteEmptySystemNameFailure() {
+        final VariableDelete variableDelete = new VariableDelete(connection, mockDeleteRequest);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> variableDelete.delete("PLEX1", ""));
+        assertEquals("systemName is either null or empty", exception.getMessage());
+    }
+
+    @Test
+    public void tstVariableDeleteNullVariableNamesFailure() {
+        final VariableDelete variableDelete = new VariableDelete(connection, mockDeleteRequest);
+        NullPointerException exception = assertThrows(NullPointerException.class,
+                () -> variableDelete.delete("PLEX1", "SYS1", null));
+        assertEquals("variableNames is null", exception.getMessage());
+    }
+
+    @Test
+    public void tstVariableDeleteEmptyVariableNamesFailure() {
+        final VariableDelete variableDelete = new VariableDelete(connection, mockDeleteRequest);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> variableDelete.delete("PLEX1", "SYS1", Collections.emptyList()));
+        assertEquals("variableNames is empty", exception.getMessage());
+    }
+
+    @Test
+    public void tstVariableDeleteSecondaryConstructorWithValidRequestTypeSuccess() {
+        ZosConnection mockConnection = Mockito.mock(ZosConnection.class);
+        ZosmfRequest mockRequest = Mockito.mock(DeleteJsonZosmfRequest.class);
+        assertNotNull(new VariableDelete(mockConnection, mockRequest));
+    }
+
+    @Test
+    public void tstVariableDeleteSecondaryConstructorWithNullConnectionFailure() {
+        ZosmfRequest mockRequest = Mockito.mock(DeleteJsonZosmfRequest.class);
+        NullPointerException exception = assertThrows(NullPointerException.class,
+                () -> new VariableDelete(null, mockRequest));
+        assertEquals("connection is null", exception.getMessage());
+    }
+
+    @Test
+    public void tstVariableDeleteSecondaryConstructorWithNullRequestFailure() {
+        ZosConnection mockConnection = Mockito.mock(ZosConnection.class);
+        NullPointerException exception = assertThrows(NullPointerException.class,
+                () -> new VariableDelete(mockConnection, null));
+        assertEquals("request is null", exception.getMessage());
+    }
+
+    @Test
+    public void tstVariableDeleteSecondaryConstructorWithInvalidRequestTypeFailure() {
+        ZosConnection mockConnection = Mockito.mock(ZosConnection.class);
+        ZosmfRequest mockRequest = Mockito.mock(ZosmfRequest.class);
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> new VariableDelete(mockConnection, mockRequest));
+        assertEquals("DELETE_JSON request type required", exception.getMessage());
+    }
+
+    @Test
+    public void tstVariableDeletePrimaryConstructorWithValidConnectionSuccess() {
+        assertNotNull(new VariableDelete(connection));
+    }
+
+    @Test
+    public void tstVariableDeletePrimaryConstructorWithNullConnectionFailure() {
+        NullPointerException exception = assertThrows(NullPointerException.class,
+                () -> new VariableDelete(null));
+        assertEquals("connection is null", exception.getMessage());
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/zosvariables/methods/VariableDeleteTest.java
+++ b/src/test/java/zowe/client/sdk/zosvariables/methods/VariableDeleteTest.java
@@ -122,10 +122,26 @@ public class VariableDeleteTest {
     }
 
     @Test
+    public void tstVariableDeleteEmptySysplexNameFailure() {
+        final VariableDelete variableDelete = new VariableDelete(connection, mockDeleteRequest);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> variableDelete.deleteAll("", "SYS1"));
+        assertEquals("sysplexName is either null or empty", exception.getMessage());
+    }
+
+    @Test
     public void tstVariableDeleteEmptySystemNameFailure() {
         final VariableDelete variableDelete = new VariableDelete(connection, mockDeleteRequest);
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
                 () -> variableDelete.deleteAll("PLEX1", ""));
+        assertEquals("systemName is either null or empty", exception.getMessage());
+    }
+
+    @Test
+    public void tstVariableDeleteNullSystemNameFailure() {
+        final VariableDelete variableDelete = new VariableDelete(connection, mockDeleteRequest);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> variableDelete.deleteAll("PLEX1", null));
         assertEquals("systemName is either null or empty", exception.getMessage());
     }
 


### PR DESCRIPTION
## Summary
Implements the z/OSMF "Delete system variables" REST API (closes #508 ): DELETE /variables/rest/1.0/systems/<sysplex>.<system>

## Changes
- VariableDelete (methods) — new API class with two operations: - delete(sysplexName, systemName) — bodyless request that deletes the entire system variable pool
  - delete(sysplexName, systemName, variableNames) — sends a JSON array body to delete specific named variables
- DeleteJsonZosmfRequest (rest) — enhanced to optionally carry a request body. setBody now stores the body (instead of throwing) and executeRequest attaches it only when present, so existing bodyless deletes are unchanged.

## Notes
- The IBM doc example path had a typo (.../variables/systems/...); used the canonical .../systems/... consistent with the existing VariableConstants.RESOURCE.
- The whole-pool delete clears any prior body so a reused request instance always issues a true bodyless request.
- Empty variableNames is rejected with IllegalArgumentException (the API treats [] as a no-op; rejecting guides correct usage).
