### PR TITLE
feat: add get properties of archived workflow API (#477)

### DIFF
--- a/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowGet.java
+++ b/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowGet.java
@@ -26,11 +26,14 @@ import zowe.client.sdk.zosmfworkflow.response.WorkflowGetDefinitionResponse;
 import zowe.client.sdk.zosmfworkflow.response.WorkflowGetPropertiesResponse;
 
 /**
- * Provides retrieve workflow definition functionality through the z/OSMF workflow REST API.
+ * Provides retrieve workflow definition and properties functionality through the z/OSMF workflow REST API.
  * <p>
  * <a href="https://www.ibm.com/docs/en/zos/3.2.0?topic=services-retrieve-workflow-definition">z/OSMF REST API</a>
+ * <p>
+ * <a href="https://www.ibm.com/docs/en/zos/3.2.0?topic=services-get-properties-archived-workflow">z/OSMF REST API (Archived)</a>
  *
  * @author Ashish Kumar Dash
+ * @author Eshaan Gupta
  * @version 7.0
  */
 public class WorkflowGet {
@@ -156,23 +159,39 @@ public class WorkflowGet {
      * @author Ashish Kumar Dash
      */
     public WorkflowGetPropertiesResponse getProperties(final String workflowKey) throws ZosmfRequestException {
-        return getPropertiesCommon(WorkflowGetPropertiesInputData.builder().workflowKey(workflowKey).build());
+        return getPropertiesCommon(WorkflowGetPropertiesInputData.builder().workflowKey(workflowKey).build(), false);
     }
 
     /**
-     * Get the properties of a z/OSMF workflow.
+     * Get the properties of an archived z/OSMF workflow by workflow key.
+     *
+     * @param workflowKey workflow key that uniquely identifies the archived workflow instance
+     * @return archived workflow properties returned by z/OSMF
+     * @throws ZosmfRequestException request error state
+     * @author Eshaan Gupta
+     */
+    public WorkflowGetPropertiesResponse getArchivedProperties(final String workflowKey) throws ZosmfRequestException {
+        return getPropertiesCommon(WorkflowGetPropertiesInputData.builder().workflowKey(workflowKey).build(), true);
+    }
+
+    /**
+     * Get the properties of a z/OSMF workflow or archived workflow.
      *
      * @param propertiesInputData workflow properties retrieval parameters
+     * @param isArchived          whether to use the archived workflows endpoint
      * @return workflow properties returned by z/OSMF
      * @throws ZosmfRequestException request error state
      * @author Ashish Kumar Dash
+     * @author Eshaan Gupta
      */
-    public WorkflowGetPropertiesResponse getPropertiesCommon(final WorkflowGetPropertiesInputData propertiesInputData)
-            throws ZosmfRequestException {
+    public WorkflowGetPropertiesResponse getPropertiesCommon(
+            final WorkflowGetPropertiesInputData propertiesInputData,
+            final boolean isArchived) throws ZosmfRequestException {
         ValidateUtils.checkNullParameter(propertiesInputData, "propertiesInputData");
 
         final StringBuilder url = new StringBuilder(connection.getZosmfUrl());
-        url.append(WorkflowConstants.WORKFLOWS_RESOURCE);
+        url.append(isArchived ? WorkflowConstants.ARCHIVED_WORKFLOWS_RESOURCE
+                : WorkflowConstants.WORKFLOWS_RESOURCE);
 
         // workflowKey is always present; WorkflowGetPropertiesInputData enforces this invariant
         propertiesInputData.getWorkflowKey()

--- a/src/test/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowGetTest.java
+++ b/src/test/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowGetTest.java
@@ -463,7 +463,7 @@ public class WorkflowGetTest {
                 .workflowKey(WORKFLOW_KEY)
                 .returnSteps(true)
                 .returnVariables(true)
-                .build());
+                .build(), false);
 
         String expectedUrl = "https://1:443/zosmf/workflow/rest/1.0/workflows/" +
                 EncodeUtils.encodeURIComponent(WORKFLOW_KEY) + "?returnData=steps,variables";
@@ -484,7 +484,7 @@ public class WorkflowGetTest {
         workflowGet.getPropertiesCommon(WorkflowGetPropertiesInputData.builder()
                 .workflowKey(WORKFLOW_KEY)
                 .returnSteps(true)
-                .build());
+                .build(), false);
 
         String expectedUrl = "https://1:443/workflow/rest/1.0/workflows/" +
                 EncodeUtils.encodeURIComponent(WORKFLOW_KEY) + "?returnData=steps";
@@ -496,7 +496,7 @@ public class WorkflowGetTest {
         ZosConnection connection = ZosConnectionFactory.createBasicConnection("1", 443, "1", "1");
         WorkflowGet workflowGet = new WorkflowGet(connection);
         NullPointerException exception = assertThrows(NullPointerException.class,
-                () -> workflowGet.getPropertiesCommon(null));
+                () -> workflowGet.getPropertiesCommon(null, false));
         assertEquals("propertiesInputData is null", exception.getMessage());
     }
 
@@ -506,6 +506,110 @@ public class WorkflowGetTest {
         WorkflowGet workflowGet = new WorkflowGet(connection);
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
                 () -> workflowGet.getProperties(null));
+        assertEquals("workflowKey is either null or empty", exception.getMessage());
+    }
+
+    private static String getArchivedWorkflowPropertiesJson() {
+        return "{\n" +
+                "  \"workflowName\": \"archivedProgramExecutionSample\",\n" +
+                "  \"workflowKey\": \"2535b19e-a8c3-4a52-9d77-e30bb920f912\",\n" +
+                "  \"workflowID\": \"programExecutionSample\",\n" +
+                "  \"owner\": \"zosmfad\",\n" +
+                "  \"system\": \"PLEX1.SY1\",\n" +
+                "  \"statusName\": \"archived\",\n" +
+                "  \"access\": \"Public\",\n" +
+                "  \"percentComplete\": 100\n" +
+                "}";
+    }
+
+    @Test
+    public void tstWorkflowGetArchivedPropertiesByKeySuccess() throws ZosmfRequestException {
+        ZosConnection connection = Mockito.mock(ZosConnection.class);
+        Mockito.when(connection.getZosmfUrl()).thenReturn("https://1:443");
+        GetJsonZosmfRequest mockGetRequest = Mockito.mock(GetJsonZosmfRequest.class);
+        Mockito.when(mockGetRequest.executeRequest()).thenReturn(
+                new Response(getArchivedWorkflowPropertiesJson(), 200, "success"));
+        doCallRealMethod().when(mockGetRequest).setUrl(any());
+        doCallRealMethod().when(mockGetRequest).getUrl();
+
+        WorkflowGet workflowGet = new WorkflowGet(connection, mockGetRequest);
+        WorkflowGetPropertiesResponse response = workflowGet.getArchivedProperties(
+                "2535b19e-a8c3-4a52-9d77-e30bb920f912");
+
+        String expectedUrl = "https://1:443/workflow/rest/1.0/archivedworkflows/" +
+                EncodeUtils.encodeURIComponent("2535b19e-a8c3-4a52-9d77-e30bb920f912");
+        assertEquals(expectedUrl, mockGetRequest.getUrl());
+        assertEquals("archivedProgramExecutionSample", response.getWorkflowName());
+        assertEquals("2535b19e-a8c3-4a52-9d77-e30bb920f912", response.getWorkflowKey());
+        assertEquals("programExecutionSample", response.getWorkflowID());
+        assertEquals("zosmfad", response.getOwner());
+        assertEquals("PLEX1.SY1", response.getSystem());
+        assertEquals("Public", response.getAccess());
+        assertEquals("archived", response.getStatusName());
+        assertEquals(100, response.getPercentComplete().intValue());
+    }
+
+    @Test
+    public void tstWorkflowGetArchivedPropertiesCommonReturnStepsAndVariablesUrlGeneration()
+            throws ZosmfRequestException {
+        ZosConnection connection = Mockito.mock(ZosConnection.class);
+        Mockito.when(connection.getZosmfUrl()).thenReturn("https://1:443/zosmf");
+        GetJsonZosmfRequest mockGetRequest = Mockito.mock(GetJsonZosmfRequest.class);
+        Mockito.when(mockGetRequest.executeRequest()).thenReturn(
+                new Response(getArchivedWorkflowPropertiesJson(), 200, "success"));
+        doCallRealMethod().when(mockGetRequest).setUrl(any());
+        doCallRealMethod().when(mockGetRequest).getUrl();
+
+        WorkflowGet workflowGet = new WorkflowGet(connection, mockGetRequest);
+        workflowGet.getPropertiesCommon(WorkflowGetPropertiesInputData.builder()
+                .workflowKey("2535b19e-a8c3-4a52-9d77-e30bb920f912")
+                .returnSteps(true)
+                .returnVariables(true)
+                .build(), true);
+
+        String expectedUrl = "https://1:443/zosmf/workflow/rest/1.0/archivedworkflows/" +
+                EncodeUtils.encodeURIComponent("2535b19e-a8c3-4a52-9d77-e30bb920f912") +
+                "?returnData=steps,variables";
+        assertEquals(expectedUrl, mockGetRequest.getUrl());
+    }
+
+    @Test
+    public void tstWorkflowGetArchivedPropertiesCommonReturnStepsOnlyUrlGeneration() throws ZosmfRequestException {
+        ZosConnection connection = Mockito.mock(ZosConnection.class);
+        Mockito.when(connection.getZosmfUrl()).thenReturn("https://1:443");
+        GetJsonZosmfRequest mockGetRequest = Mockito.mock(GetJsonZosmfRequest.class);
+        Mockito.when(mockGetRequest.executeRequest()).thenReturn(
+                new Response(getArchivedWorkflowPropertiesJson(), 200, "success"));
+        doCallRealMethod().when(mockGetRequest).setUrl(any());
+        doCallRealMethod().when(mockGetRequest).getUrl();
+
+        WorkflowGet workflowGet = new WorkflowGet(connection, mockGetRequest);
+        workflowGet.getPropertiesCommon(WorkflowGetPropertiesInputData.builder()
+                .workflowKey("2535b19e-a8c3-4a52-9d77-e30bb920f912")
+                .returnSteps(true)
+                .build(), true);
+
+        String expectedUrl = "https://1:443/workflow/rest/1.0/archivedworkflows/" +
+                EncodeUtils.encodeURIComponent("2535b19e-a8c3-4a52-9d77-e30bb920f912") +
+                "?returnData=steps";
+        assertEquals(expectedUrl, mockGetRequest.getUrl());
+    }
+
+    @Test
+    public void tstWorkflowGetArchivedPropertiesWithNullInputData() {
+        ZosConnection connection = ZosConnectionFactory.createBasicConnection("1", 443, "1", "1");
+        WorkflowGet workflowGet = new WorkflowGet(connection);
+        NullPointerException exception = assertThrows(NullPointerException.class,
+                () -> workflowGet.getPropertiesCommon(null, true));
+        assertEquals("propertiesInputData is null", exception.getMessage());
+    }
+
+    @Test
+    public void tstWorkflowGetArchivedPropertiesWithNullWorkflowKey() {
+        ZosConnection connection = ZosConnectionFactory.createBasicConnection("1", 443, "1", "1");
+        WorkflowGet workflowGet = new WorkflowGet(connection);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> workflowGet.getArchivedProperties(null));
         assertEquals("workflowKey is either null or empty", exception.getMessage());
     }
 


### PR DESCRIPTION
## Summary
- Add `getArchivedProperties` methods to `WorkflowGet` to support the z/OSMF 
  GET `/archivedworkflows/{workflowKey}` REST API (issue #477)
- Support optional `returnData` query parameter for requesting step and variable information
- Reuse existing `WorkflowGetPropertiesInputData` and `WorkflowGetPropertiesResponse` classes 
  since the archived endpoint shares the same request parameters and response structure
- Add unit tests for URL generation, response parsing, and null validation

## API Reference
- [IBM z/OSMF: Get the properties of an archived Workflow](https://www.ibm.com/docs/en/zos/3.2.0?topic=services-get-properties-archived-workflow)

## Test plan
- [x] `tstWorkflowGetArchivedPropertiesByKeySuccess` - verifies URL and response parsing
- [x] `tstWorkflowGetArchivedPropertiesWithReturnDataUrlGeneration` - verifies `?returnData=steps,variables`
- [x] `tstWorkflowGetArchivedPropertiesCommonReturnStepsOnlyUrlGeneration` - verifies `?returnData=steps`
- [x] `tstWorkflowGetArchivedPropertiesWithNullInputData` - null input validation
- [x] `tstWorkflowGetArchivedPropertiesWithNullWorkflowKey` - null key validation

Closes #477