### PR TITLE
Remove redundant getProperties boolean overload from WorkflowGet

### DIFF
--- a/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowGet.java
+++ b/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowGet.java
@@ -160,28 +160,6 @@ public class WorkflowGet {
     }
 
     /**
-     * Get the properties of a z/OSMF workflow by workflow key, optionally including step and variable information.
-     *
-     * @param workflowKey     workflow key that uniquely identifies the workflow instance
-     * @param returnSteps     whether the response includes the workflow step information
-     * @param returnVariables whether the response includes the workflow variable information
-     * @return workflow properties returned by z/OSMF
-     * @throws ZosmfRequestException request error state
-     * @author Ashish Kumar Dash
-     */
-    public WorkflowGetPropertiesResponse getProperties(final String workflowKey,
-                                                       final boolean returnSteps,
-                                                       final boolean returnVariables) throws ZosmfRequestException {
-        return getPropertiesCommon(
-                WorkflowGetPropertiesInputData.builder()
-                        .workflowKey(workflowKey)
-                        .returnSteps(returnSteps)
-                        .returnVariables(returnVariables)
-                        .build()
-        );
-    }
-
-    /**
      * Get the properties of a z/OSMF workflow.
      *
      * @param propertiesInputData workflow properties retrieval parameters

--- a/src/test/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowGetTest.java
+++ b/src/test/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowGetTest.java
@@ -449,7 +449,7 @@ public class WorkflowGetTest {
     }
 
     @Test
-    public void tstWorkflowGetPropertiesWithReturnDataUrlGeneration() throws ZosmfRequestException {
+    public void tstWorkflowGetPropertiesCommonReturnStepsAndVariablesUrlGeneration() throws ZosmfRequestException {
         ZosConnection connection = Mockito.mock(ZosConnection.class);
         Mockito.when(connection.getZosmfUrl()).thenReturn("https://1:443/zosmf");
         GetJsonZosmfRequest mockGetRequest = Mockito.mock(GetJsonZosmfRequest.class);
@@ -459,7 +459,11 @@ public class WorkflowGetTest {
         doCallRealMethod().when(mockGetRequest).getUrl();
 
         WorkflowGet workflowGet = new WorkflowGet(connection, mockGetRequest);
-        workflowGet.getProperties(WORKFLOW_KEY, true, true);
+        workflowGet.getPropertiesCommon(WorkflowGetPropertiesInputData.builder()
+                .workflowKey(WORKFLOW_KEY)
+                .returnSteps(true)
+                .returnVariables(true)
+                .build());
 
         String expectedUrl = "https://1:443/zosmf/workflow/rest/1.0/workflows/" +
                 EncodeUtils.encodeURIComponent(WORKFLOW_KEY) + "?returnData=steps,variables";


### PR DESCRIPTION
the common method handles selective return data via the self-documenting builder, and the simple getProperties(workflowKey) covers the default case.