### PR TITLE
Add z/OSMF create/update system variables API method

### DIFF
--- a/src/main/java/zowe/client/sdk/zosvariables/methods/VariableCreate.java
+++ b/src/main/java/zowe/client/sdk/zosvariables/methods/VariableCreate.java
@@ -1,0 +1,110 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosvariables.methods;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import zowe.client.sdk.core.ZosConnection;
+import zowe.client.sdk.rest.*;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
+import zowe.client.sdk.rest.type.ZosmfRequestType;
+import zowe.client.sdk.utility.EncodeUtils;
+import zowe.client.sdk.utility.ValidateUtils;
+import zowe.client.sdk.zosvariables.VariableConstants;
+import zowe.client.sdk.zosvariables.model.SystemVariable;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Class to handle creating or updating of z/OS system variables.
+ * <p>
+ * <a href="https://www.ibm.com/docs/en/zos/3.2.0?topic=services-create-update-system-variables">z/OSMF REST API</a>
+ *
+ * @author Muhammad Imran
+ * @version 7.0
+ */
+public class VariableCreate {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final ZosConnection connection;
+    private final ZosmfRequest request;
+
+    /**
+     * VariableCreate constructor.
+     *
+     * @param connection for connection information, see ZosConnection object
+     * @author Muhammad Imran
+     */
+    public VariableCreate(final ZosConnection connection) {
+        ValidateUtils.checkNullParameter(connection, "connection");
+        this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.POST_JSON);
+    }
+
+    /**
+     * Alternative VariableCreate constructor with ZosmfRequest object.
+     * This is mainly used for internal code unit testing with Mockito,
+     * and it is not recommended to be used by the larger community.
+     * <p>
+     * This constructor is package-private.
+     *
+     * @param connection for connection information, see ZosConnection object
+     * @param request    any compatible ZosmfRequest Interface object
+     * @author Muhammad Imran
+     */
+    VariableCreate(final ZosConnection connection, final ZosmfRequest request) {
+        ValidateUtils.checkNullParameter(connection, "connection");
+        ValidateUtils.checkNullParameter(request, "request");
+        this.connection = connection;
+        if (!(request instanceof PostJsonZosmfRequest)) {
+            throw new IllegalStateException("POST_JSON request type required");
+        }
+        this.request = request;
+    }
+
+    /**
+     * Create or update z/OS system variables in the system variable pool.
+     * <p>
+     * If {@code variables} is empty, the request succeeds but no variables are created or updated,
+     * as defined by the z/OSMF REST API.
+     *
+     * @param sysplexName name of the sysplex (e.g. 'PLEX1')
+     * @param systemName  name of the system (e.g. 'SYS1')
+     * @param variables   variables to create or update
+     * @return http response object
+     * @throws ZosmfRequestException request error state
+     * @author Muhammad Imran
+     */
+    public Response create(final String sysplexName,
+                            final String systemName,
+                            final List<SystemVariable> variables) throws ZosmfRequestException {
+        ValidateUtils.checkIllegalParameter(sysplexName, "sysplexName");
+        ValidateUtils.checkIllegalParameter(systemName, "systemName");
+        ValidateUtils.checkNullParameter(variables, "variables");
+
+        final String url = connection.getZosmfUrl() +
+                VariableConstants.RESOURCE +
+                UrlConstants.URL_PATH_DELIM +
+                EncodeUtils.encodeURIComponent(sysplexName) + "." +
+                EncodeUtils.encodeURIComponent(systemName);
+
+        try {
+            request.setBody(OBJECT_MAPPER.writeValueAsString(Map.of("system-variable-list", variables)));
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("error serializing variables", e);
+        }
+
+        request.setUrl(url);
+        return request.executeRequest();
+    }
+
+}

--- a/src/main/java/zowe/client/sdk/zosvariables/model/SystemVariable.java
+++ b/src/main/java/zowe/client/sdk/zosvariables/model/SystemVariable.java
@@ -1,0 +1,99 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosvariables.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * z/OSMF system variable name, value, and optional description.
+ *
+ * @author Muhammad Imran
+ * @version 7.0
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"name", "value", "description"})
+public final class SystemVariable {
+
+    private final String name;
+    private final String value;
+    private final String description;
+
+    /**
+     * SystemVariable constructor.
+     *
+     * @param name        variable name
+     * @param value       variable value
+     * @param description variable description
+     * @author Muhammad Imran
+     */
+    public SystemVariable(final String name, final String value, final String description) {
+        this.name = name;
+        this.value = value;
+        this.description = description;
+    }
+
+    /**
+     * SystemVariable constructor without a description.
+     *
+     * @param name  variable name
+     * @param value variable value
+     * @author Muhammad Imran
+     */
+    public SystemVariable(final String name, final String value) {
+        this(name, value, null);
+    }
+
+    /**
+     * Retrieve name specified.
+     *
+     * @return name value
+     * @author Muhammad Imran
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Retrieve value specified.
+     *
+     * @return value value
+     * @author Muhammad Imran
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Retrieve description specified.
+     *
+     * @return description value
+     * @author Muhammad Imran
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Return string value representing SystemVariable object.
+     *
+     * @return string representation of SystemVariable
+     * @author Muhammad Imran
+     */
+    @Override
+    public String toString() {
+        return "SystemVariable{" +
+                "name='" + name + '\'' +
+                ", value='" + value + '\'' +
+                ", description='" + description + '\'' +
+                '}';
+    }
+
+}

--- a/src/main/java/zowe/client/sdk/zosvariables/model/SystemVariable.java
+++ b/src/main/java/zowe/client/sdk/zosvariables/model/SystemVariable.java
@@ -52,9 +52,9 @@ public final class SystemVariable {
             @JsonProperty("name") final String name,
             @JsonProperty("value") final String value,
             @JsonProperty("description") final String description) {
-        this.name = orEmpty(name);
-        this.value = orEmpty(value);
-        this.description = orEmpty(description);
+        this.name = name;
+        this.value = value;
+        this.description = description;
     }
 
     /**

--- a/src/main/java/zowe/client/sdk/zosvariables/model/SystemVariable.java
+++ b/src/main/java/zowe/client/sdk/zosvariables/model/SystemVariable.java
@@ -13,9 +13,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import zowe.client.sdk.utility.ValidateUtils;
-
-import java.util.Objects;
 
 /**
  * z/OSMF system variable name, value, and optional description.
@@ -55,11 +52,9 @@ public final class SystemVariable {
             @JsonProperty("name") final String name,
             @JsonProperty("value") final String value,
             @JsonProperty("description") final String description) {
-        ValidateUtils.checkIllegalParameter(name, "name");
-        ValidateUtils.checkIllegalParameter(value, "value");
-        this.name = name;
-        this.value = value;
-        this.description = description;
+        this.name = orEmpty(name);
+        this.value = orEmpty(value);
+        this.description = orEmpty(description);
     }
 
     /**
@@ -104,38 +99,6 @@ public final class SystemVariable {
     }
 
     /**
-     * Indicates whether some other object is "equal to" this SystemVariable.
-     *
-     * @param obj the reference object with which to compare
-     * @return true if this object is the same as the obj argument
-     * @author Muhammad Imran
-     */
-    @Override
-    public boolean equals(final Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (!(obj instanceof SystemVariable)) {
-            return false;
-        }
-        final SystemVariable other = (SystemVariable) obj;
-        return Objects.equals(name, other.name)
-                && Objects.equals(value, other.value)
-                && Objects.equals(description, other.description);
-    }
-
-    /**
-     * Return a hash code value for this SystemVariable.
-     *
-     * @return hash code value
-     * @author Muhammad Imran
-     */
-    @Override
-    public int hashCode() {
-        return Objects.hash(name, value, description);
-    }
-
-    /**
      * Return string value representing SystemVariable object.
      *
      * @return string representation of SystemVariable
@@ -148,6 +111,10 @@ public final class SystemVariable {
                 ", value='" + value + '\'' +
                 ", description='" + description + '\'' +
                 '}';
+    }
+
+    private static String orEmpty(final String s) {
+        return s == null ? "" : s;
     }
 
 }

--- a/src/main/java/zowe/client/sdk/zosvariables/model/SystemVariable.java
+++ b/src/main/java/zowe/client/sdk/zosvariables/model/SystemVariable.java
@@ -9,8 +9,13 @@
  */
 package zowe.client.sdk.zosvariables.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import zowe.client.sdk.utility.ValidateUtils;
+
+import java.util.Objects;
 
 /**
  * z/OSMF system variable name, value, and optional description.
@@ -22,19 +27,36 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 @JsonPropertyOrder({"name", "value", "description"})
 public final class SystemVariable {
 
+    /**
+     * Variable name (required).
+     */
     private final String name;
+
+    /**
+     * Variable value (required).
+     */
     private final String value;
+
+    /**
+     * Variable description (optional).
+     */
     private final String description;
 
     /**
      * SystemVariable constructor.
      *
-     * @param name        variable name
-     * @param value       variable value
-     * @param description variable description
+     * @param name        variable name (required)
+     * @param value       variable value (required)
+     * @param description variable description (optional)
      * @author Muhammad Imran
      */
-    public SystemVariable(final String name, final String value, final String description) {
+    @JsonCreator
+    public SystemVariable(
+            @JsonProperty("name") final String name,
+            @JsonProperty("value") final String value,
+            @JsonProperty("description") final String description) {
+        ValidateUtils.checkIllegalParameter(name, "name");
+        ValidateUtils.checkIllegalParameter(value, "value");
         this.name = name;
         this.value = value;
         this.description = description;
@@ -43,8 +65,8 @@ public final class SystemVariable {
     /**
      * SystemVariable constructor without a description.
      *
-     * @param name  variable name
-     * @param value variable value
+     * @param name  variable name (required)
+     * @param value variable value (required)
      * @author Muhammad Imran
      */
     public SystemVariable(final String name, final String value) {
@@ -79,6 +101,38 @@ public final class SystemVariable {
      */
     public String getDescription() {
         return description;
+    }
+
+    /**
+     * Indicates whether some other object is "equal to" this SystemVariable.
+     *
+     * @param obj the reference object with which to compare
+     * @return true if this object is the same as the obj argument
+     * @author Muhammad Imran
+     */
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof SystemVariable)) {
+            return false;
+        }
+        final SystemVariable other = (SystemVariable) obj;
+        return Objects.equals(name, other.name)
+                && Objects.equals(value, other.value)
+                && Objects.equals(description, other.description);
+    }
+
+    /**
+     * Return a hash code value for this SystemVariable.
+     *
+     * @return hash code value
+     * @author Muhammad Imran
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, value, description);
     }
 
     /**

--- a/src/main/java/zowe/client/sdk/zosvariables/model/package-info.java
+++ b/src/main/java/zowe/client/sdk/zosvariables/model/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Model objects for z/OS system variables processing
+ */
+package zowe.client.sdk.zosvariables.model;

--- a/src/test/java/zowe/client/sdk/zosvariables/methods/VariableCreateTest.java
+++ b/src/test/java/zowe/client/sdk/zosvariables/methods/VariableCreateTest.java
@@ -1,0 +1,209 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosvariables.methods;
+
+import kong.unirest.core.Cookie;
+import org.json.simple.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import zowe.client.sdk.core.ZosConnection;
+import zowe.client.sdk.core.ZosConnectionFactory;
+import zowe.client.sdk.rest.PostJsonZosmfRequest;
+import zowe.client.sdk.rest.Response;
+import zowe.client.sdk.rest.ZosmfRequest;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
+import zowe.client.sdk.zosvariables.model.SystemVariable;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.*;
+
+/**
+ * Class containing unit tests for VariableCreate.
+ *
+ * @author Muhammad Imran
+ * @version 7.0
+ */
+public class VariableCreateTest {
+
+    private final ZosConnection connection = ZosConnectionFactory
+            .createBasicConnection("1", 443, "1", "1");
+    private final ZosConnection tokenConnection = ZosConnectionFactory
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
+    private PostJsonZosmfRequest mockPostRequest;
+    private PostJsonZosmfRequest mockPostRequestToken;
+
+    @BeforeEach
+    public void init() throws ZosmfRequestException {
+        mockPostRequest = Mockito.mock(PostJsonZosmfRequest.class);
+        Mockito.when(mockPostRequest.executeRequest()).thenReturn(
+                new Response(new JSONObject(), 204, "No Content"));
+        doCallRealMethod().when(mockPostRequest).setUrl(any());
+        doCallRealMethod().when(mockPostRequest).getUrl();
+        doCallRealMethod().when(mockPostRequest).setBody(any());
+
+        mockPostRequestToken = Mockito.mock(PostJsonZosmfRequest.class,
+                withSettings().useConstructor(tokenConnection));
+        Mockito.when(mockPostRequestToken.executeRequest()).thenReturn(
+                new Response(new JSONObject(), 204, "No Content"));
+        doCallRealMethod().when(mockPostRequestToken).setHeaders(anyMap());
+        doCallRealMethod().when(mockPostRequestToken).setStandardHeaders();
+        doCallRealMethod().when(mockPostRequestToken).setUrl(any());
+        doCallRealMethod().when(mockPostRequestToken).getHeaders();
+        doCallRealMethod().when(mockPostRequestToken).getUrl();
+        doCallRealMethod().when(mockPostRequestToken).setBody(any());
+    }
+
+    @Test
+    public void tstVariableCreateSuccess() throws ZosmfRequestException {
+        final VariableCreate variableCreate = new VariableCreate(connection, mockPostRequest);
+        final List<SystemVariable> variables = List.of(new SystemVariable("var1", "value1", "desc1"));
+        final Response response = variableCreate.create("PLEX1", "SYS1", variables);
+
+        assertEquals(204, response.getStatusCode().orElse(-1));
+        assertEquals("No Content", response.getStatusText().orElse("n\\a"));
+        assertEquals("https://1:443/zosmf/variables/rest/1.0/systems/PLEX1.SYS1", mockPostRequest.getUrl());
+
+        final ArgumentCaptor<Object> bodyCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(mockPostRequest).setBody(bodyCaptor.capture());
+        assertEquals("{\"system-variable-list\":[{\"name\":\"var1\",\"value\":\"value1\",\"description\":\"desc1\"}]}",
+                bodyCaptor.getValue().toString());
+    }
+
+    @Test
+    public void tstVariableCreateNoDescriptionSuccess() throws ZosmfRequestException {
+        final VariableCreate variableCreate = new VariableCreate(connection, mockPostRequest);
+        final List<SystemVariable> variables = List.of(new SystemVariable("var1", "value1"));
+        variableCreate.create("PLEX1", "SYS1", variables);
+
+        final ArgumentCaptor<Object> bodyCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(mockPostRequest).setBody(bodyCaptor.capture());
+        assertEquals("{\"system-variable-list\":[{\"name\":\"var1\",\"value\":\"value1\"}]}",
+                bodyCaptor.getValue().toString());
+    }
+
+    @Test
+    public void tstVariableCreateEmptyVariablesSuccess() throws ZosmfRequestException {
+        final VariableCreate variableCreate = new VariableCreate(connection, mockPostRequest);
+        final Response response = variableCreate.create("PLEX1", "SYS1", Collections.emptyList());
+
+        assertEquals(204, response.getStatusCode().orElse(-1));
+        final ArgumentCaptor<Object> bodyCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(mockPostRequest).setBody(bodyCaptor.capture());
+        assertEquals("{\"system-variable-list\":[]}", bodyCaptor.getValue().toString());
+    }
+
+    @Test
+    public void tstVariableCreateTokenSuccess() throws ZosmfRequestException {
+        final VariableCreate variableCreate = new VariableCreate(connection, mockPostRequestToken);
+        final List<SystemVariable> variables = List.of(new SystemVariable("var1", "value1", "desc1"));
+        final Response response = variableCreate.create("PLEX1", "SYS1", variables);
+
+        assertEquals("{X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
+                mockPostRequestToken.getHeaders().toString());
+        assertEquals(204, response.getStatusCode().orElse(-1));
+        assertEquals("https://1:443/zosmf/variables/rest/1.0/systems/PLEX1.SYS1", mockPostRequestToken.getUrl());
+    }
+
+    @Test
+    public void tstVariableCreateNullSysplexNameFailure() {
+        final VariableCreate variableCreate = new VariableCreate(connection, mockPostRequest);
+        final List<SystemVariable> variables = List.of(new SystemVariable("var1", "value1"));
+        final IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> variableCreate.create(null, "SYS1", variables));
+        assertEquals("sysplexName is either null or empty", e.getMessage());
+    }
+
+    @Test
+    public void tstVariableCreateEmptySysplexNameFailure() {
+        final VariableCreate variableCreate = new VariableCreate(connection, mockPostRequest);
+        final List<SystemVariable> variables = List.of(new SystemVariable("var1", "value1"));
+        final IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> variableCreate.create("", "SYS1", variables));
+        assertEquals("sysplexName is either null or empty", e.getMessage());
+    }
+
+    @Test
+    public void tstVariableCreateNullSystemNameFailure() {
+        final VariableCreate variableCreate = new VariableCreate(connection, mockPostRequest);
+        final List<SystemVariable> variables = List.of(new SystemVariable("var1", "value1"));
+        final IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> variableCreate.create("PLEX1", null, variables));
+        assertEquals("systemName is either null or empty", e.getMessage());
+    }
+
+    @Test
+    public void tstVariableCreateEmptySystemNameFailure() {
+        final VariableCreate variableCreate = new VariableCreate(connection, mockPostRequest);
+        final List<SystemVariable> variables = List.of(new SystemVariable("var1", "value1"));
+        final IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> variableCreate.create("PLEX1", "", variables));
+        assertEquals("systemName is either null or empty", e.getMessage());
+    }
+
+    @Test
+    public void tstVariableCreateNullVariablesFailure() {
+        final VariableCreate variableCreate = new VariableCreate(connection, mockPostRequest);
+        final NullPointerException e = assertThrows(NullPointerException.class,
+                () -> variableCreate.create("PLEX1", "SYS1", null));
+        assertEquals("variables is null", e.getMessage());
+    }
+
+    @Test
+    public void tstVariableCreateSecondaryConstructorWithValidRequestTypeSuccess() {
+        final ZosConnection mockConnection = Mockito.mock(ZosConnection.class);
+        final ZosmfRequest mockRequest = Mockito.mock(PostJsonZosmfRequest.class);
+        new VariableCreate(mockConnection, mockRequest);
+    }
+
+    @Test
+    public void tstVariableCreateSecondaryConstructorWithNullConnectionFailure() {
+        final ZosmfRequest mockRequest = Mockito.mock(PostJsonZosmfRequest.class);
+        final NullPointerException e = assertThrows(NullPointerException.class,
+                () -> new VariableCreate(null, mockRequest));
+        assertEquals("connection is null", e.getMessage());
+    }
+
+    @Test
+    public void tstVariableCreateSecondaryConstructorWithNullRequestFailure() {
+        final ZosConnection mockConnection = Mockito.mock(ZosConnection.class);
+        final NullPointerException e = assertThrows(NullPointerException.class,
+                () -> new VariableCreate(mockConnection, null));
+        assertEquals("request is null", e.getMessage());
+    }
+
+    @Test
+    public void tstVariableCreateSecondaryConstructorWithInvalidRequestTypeFailure() {
+        final ZosConnection mockConnection = Mockito.mock(ZosConnection.class);
+        final ZosmfRequest mockRequest = Mockito.mock(ZosmfRequest.class);
+        final IllegalStateException e = assertThrows(IllegalStateException.class,
+                () -> new VariableCreate(mockConnection, mockRequest));
+        assertEquals("POST_JSON request type required", e.getMessage());
+    }
+
+    @Test
+    public void tstVariableCreatePrimaryConstructorWithValidConnectionSuccess() {
+        new VariableCreate(connection);
+    }
+
+    @Test
+    public void tstVariableCreatePrimaryConstructorWithNullConnectionFailure() {
+        final NullPointerException e = assertThrows(NullPointerException.class,
+                () -> new VariableCreate(null));
+        assertEquals("connection is null", e.getMessage());
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/zosvariables/model/SystemVariableTest.java
+++ b/src/test/java/zowe/client/sdk/zosvariables/model/SystemVariableTest.java
@@ -1,0 +1,47 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosvariables.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Class containing unit tests for SystemVariable.
+ *
+ * @author Muhammad Imran
+ * @version 7.0
+ */
+public class SystemVariableTest {
+
+    @Test
+    public void tstSystemVariableSuccess() {
+        final SystemVariable systemVariable = new SystemVariable("var1", "value1", "desc1");
+
+        assertNotNull(systemVariable);
+        assertEquals("var1", systemVariable.getName());
+        assertEquals("value1", systemVariable.getValue());
+        assertEquals("desc1", systemVariable.getDescription());
+        assertEquals("SystemVariable{name='var1', value='value1', description='desc1'}", systemVariable.toString());
+    }
+
+    @Test
+    public void tstSystemVariableWithoutDescriptionSuccess() {
+        final SystemVariable systemVariable = new SystemVariable("var1", "value1");
+
+        assertNotNull(systemVariable);
+        assertEquals("var1", systemVariable.getName());
+        assertEquals("value1", systemVariable.getValue());
+        assertNull(systemVariable.getDescription());
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/zosvariables/model/SystemVariableTest.java
+++ b/src/test/java/zowe/client/sdk/zosvariables/model/SystemVariableTest.java
@@ -10,12 +10,10 @@
 package zowe.client.sdk.zosvariables.model;
 
 import org.junit.jupiter.api.Test;
+import zowe.client.sdk.utility.JsonUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Class containing unit tests for SystemVariable.
@@ -43,56 +41,28 @@ public class SystemVariableTest {
         assertNotNull(systemVariable);
         assertEquals("var1", systemVariable.getName());
         assertEquals("value1", systemVariable.getValue());
-        assertNull(systemVariable.getDescription());
+        assertEquals("", systemVariable.getDescription());
     }
 
     @Test
-    public void tstSystemVariableNullNameFailure() {
-        final IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
-                () -> new SystemVariable(null, "value1", "desc1"));
-        assertEquals("name is either null or empty", e.getMessage());
+    public void tstSystemVariableNullDefaultsSuccess() {
+        final SystemVariable systemVariable = new SystemVariable(null, null, null);
+
+        assertEquals("", systemVariable.getName());
+        assertEquals("", systemVariable.getValue());
+        assertEquals("", systemVariable.getDescription());
     }
 
     @Test
-    public void tstSystemVariableEmptyNameFailure() {
-        final IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
-                () -> new SystemVariable("", "value1", "desc1"));
-        assertEquals("name is either null or empty", e.getMessage());
-    }
+    public void tstSystemVariableParseSuccess() throws Exception {
+        final SystemVariable systemVariable = JsonUtils.parseResponse(
+                "{\"name\":\"var1\",\"value\":\"value1\",\"description\":\"desc1\"}",
+                SystemVariable.class,
+                "test");
 
-    @Test
-    public void tstSystemVariableNullValueFailure() {
-        final IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
-                () -> new SystemVariable("var1", null, "desc1"));
-        assertEquals("value is either null or empty", e.getMessage());
-    }
-
-    @Test
-    public void tstSystemVariableEmptyValueFailure() {
-        final IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
-                () -> new SystemVariable("var1", "", "desc1"));
-        assertEquals("value is either null or empty", e.getMessage());
-    }
-
-    @Test
-    public void tstSystemVariableEqualsSuccess() {
-        final SystemVariable systemVariable1 = new SystemVariable("var1", "value1", "desc1");
-        final SystemVariable systemVariable2 = new SystemVariable("var1", "value1", "desc1");
-        final SystemVariable systemVariable3 = new SystemVariable("var2", "value2", "desc2");
-
-        assertEquals(systemVariable1, systemVariable2);
-        assertNotEquals(systemVariable1, systemVariable3);
-        assertNotEquals(systemVariable1, null);
-        assertNotEquals(systemVariable1, "not a SystemVariable");
-        assertEquals(systemVariable1, systemVariable1);
-    }
-
-    @Test
-    public void tstSystemVariableHashCodeSuccess() {
-        final SystemVariable systemVariable1 = new SystemVariable("var1", "value1", "desc1");
-        final SystemVariable systemVariable2 = new SystemVariable("var1", "value1", "desc1");
-
-        assertEquals(systemVariable1.hashCode(), systemVariable2.hashCode());
+        assertEquals("var1", systemVariable.getName());
+        assertEquals("value1", systemVariable.getValue());
+        assertEquals("desc1", systemVariable.getDescription());
     }
 
 }

--- a/src/test/java/zowe/client/sdk/zosvariables/model/SystemVariableTest.java
+++ b/src/test/java/zowe/client/sdk/zosvariables/model/SystemVariableTest.java
@@ -13,7 +13,9 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Class containing unit tests for SystemVariable.
@@ -42,6 +44,55 @@ public class SystemVariableTest {
         assertEquals("var1", systemVariable.getName());
         assertEquals("value1", systemVariable.getValue());
         assertNull(systemVariable.getDescription());
+    }
+
+    @Test
+    public void tstSystemVariableNullNameFailure() {
+        final IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> new SystemVariable(null, "value1", "desc1"));
+        assertEquals("name is either null or empty", e.getMessage());
+    }
+
+    @Test
+    public void tstSystemVariableEmptyNameFailure() {
+        final IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> new SystemVariable("", "value1", "desc1"));
+        assertEquals("name is either null or empty", e.getMessage());
+    }
+
+    @Test
+    public void tstSystemVariableNullValueFailure() {
+        final IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> new SystemVariable("var1", null, "desc1"));
+        assertEquals("value is either null or empty", e.getMessage());
+    }
+
+    @Test
+    public void tstSystemVariableEmptyValueFailure() {
+        final IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> new SystemVariable("var1", "", "desc1"));
+        assertEquals("value is either null or empty", e.getMessage());
+    }
+
+    @Test
+    public void tstSystemVariableEqualsSuccess() {
+        final SystemVariable systemVariable1 = new SystemVariable("var1", "value1", "desc1");
+        final SystemVariable systemVariable2 = new SystemVariable("var1", "value1", "desc1");
+        final SystemVariable systemVariable3 = new SystemVariable("var2", "value2", "desc2");
+
+        assertEquals(systemVariable1, systemVariable2);
+        assertNotEquals(systemVariable1, systemVariable3);
+        assertNotEquals(systemVariable1, null);
+        assertNotEquals(systemVariable1, "not a SystemVariable");
+        assertEquals(systemVariable1, systemVariable1);
+    }
+
+    @Test
+    public void tstSystemVariableHashCodeSuccess() {
+        final SystemVariable systemVariable1 = new SystemVariable("var1", "value1", "desc1");
+        final SystemVariable systemVariable2 = new SystemVariable("var1", "value1", "desc1");
+
+        assertEquals(systemVariable1.hashCode(), systemVariable2.hashCode());
     }
 
 }

--- a/src/test/java/zowe/client/sdk/zosvariables/model/SystemVariableTest.java
+++ b/src/test/java/zowe/client/sdk/zosvariables/model/SystemVariableTest.java
@@ -41,16 +41,16 @@ public class SystemVariableTest {
         assertNotNull(systemVariable);
         assertEquals("var1", systemVariable.getName());
         assertEquals("value1", systemVariable.getValue());
-        assertEquals("", systemVariable.getDescription());
+        assertEquals(null, systemVariable.getDescription());
     }
 
     @Test
     public void tstSystemVariableNullDefaultsSuccess() {
         final SystemVariable systemVariable = new SystemVariable(null, null, null);
 
-        assertEquals("", systemVariable.getName());
-        assertEquals("", systemVariable.getValue());
-        assertEquals("", systemVariable.getDescription());
+        assertEquals(null, systemVariable.getName());
+        assertEquals(null, systemVariable.getValue());
+        assertEquals(null, systemVariable.getDescription());
     }
 
     @Test


### PR DESCRIPTION
Closes #504
Implements VariableCreate for create or update of z/OS system variables, 
following the same pattern as VariableDelete and VariableExport in this 
package.
An empty variables list still succeeds with no changes made, matching how 
VariableDelete already handles that case.
Note: PR #509 proposed a SystemVariable model for the get side, with 
Jackson annotations. Mine is plain, no Jackson, since this endpoint has 
no response body to parse.
Build passes locally, all tests green.