### PR TITLE
Add WorkflowCancel implementation (#472)

### DIFF
--- a/src/main/java/zowe/client/sdk/zosmfworkflow/WorkflowConstants.java
+++ b/src/main/java/zowe/client/sdk/zosmfworkflow/WorkflowConstants.java
@@ -70,5 +70,9 @@ public final class WorkflowConstants {
      * Operations start path segment for workflow start operation.
      */
     public static final String OPERATIONS_START = URL_PATH_DELIM + "operations" + URL_PATH_DELIM + "start";
+    /**
+     * Operations cancel path segment for workflow cancel operation.
+     */
+    public static final String OPERATIONS_CANCEL = URL_PATH_DELIM + "operations" + URL_PATH_DELIM + "cancel";
 
 }

--- a/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCancel.java
+++ b/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCancel.java
@@ -14,8 +14,10 @@ import zowe.client.sdk.rest.*;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.rest.type.ZosmfRequestType;
 import zowe.client.sdk.utility.EncodeUtils;
+import zowe.client.sdk.utility.JsonUtils;
 import zowe.client.sdk.utility.ValidateUtils;
 import zowe.client.sdk.zosmfworkflow.WorkflowConstants;
+import zowe.client.sdk.zosmfworkflow.response.WorkflowCancelResponse;
 
 /**
  * Provides cancel workflow functionality through the z/OSMF workflow REST API.
@@ -26,6 +28,8 @@ import zowe.client.sdk.zosmfworkflow.WorkflowConstants;
  * @version 7.0
  */
 public class WorkflowCancel {
+
+    private static final String CANCEL_CONTEXT = "cancel";
 
     private final ZosConnection connection;
     private ZosmfRequest request;
@@ -67,10 +71,10 @@ public class WorkflowCancel {
      * A canceled workflow cannot be resumed.
      *
      * @param workflowKey workflow key identifying the workflow to cancel
-     * @return http response object
+     * @return WorkflowCancelResponse object containing the canceled workflow name
      * @throws ZosmfRequestException request error state
      */
-    public Response cancel(final String workflowKey) throws ZosmfRequestException {
+    public WorkflowCancelResponse cancel(final String workflowKey) throws ZosmfRequestException {
         ValidateUtils.checkIllegalParameter(workflowKey, "workflowKey");
 
         final String url = connection.getZosmfUrl() +
@@ -83,9 +87,13 @@ public class WorkflowCancel {
             request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
         }
         request.setUrl(url);
-        request.setBody("{}");
 
-        return request.executeRequest();
+        final String responsePhrase = request.executeRequest()
+                .getResponsePhrase()
+                .orElseThrow(() -> new IllegalStateException("no workflow cancel response phrase"))
+                .toString();
+
+        return JsonUtils.parseResponse(responsePhrase, WorkflowCancelResponse.class, CANCEL_CONTEXT);
     }
 
 }

--- a/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCancel.java
+++ b/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCancel.java
@@ -1,0 +1,91 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosmfworkflow.methods;
+
+import zowe.client.sdk.core.ZosConnection;
+import zowe.client.sdk.rest.*;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
+import zowe.client.sdk.rest.type.ZosmfRequestType;
+import zowe.client.sdk.utility.EncodeUtils;
+import zowe.client.sdk.utility.ValidateUtils;
+import zowe.client.sdk.zosmfworkflow.WorkflowConstants;
+
+/**
+ * Provides cancel workflow functionality through the z/OSMF workflow REST API.
+ * <p>
+ * <a href="https://www.ibm.com/docs/en/zos/3.2.0?topic=services-cancel-workflow">z/OSMF REST API</a>
+ *
+ * @author Jorge Samaniego
+ * @version 7.0
+ */
+public class WorkflowCancel {
+
+    private final ZosConnection connection;
+    private ZosmfRequest request;
+
+    /**
+     * WorkflowCancel constructor.
+     *
+     * @param connection for connection information, see ZosConnection object
+     */
+    public WorkflowCancel(final ZosConnection connection) {
+        ValidateUtils.checkNullParameter(connection, "connection");
+        this.connection = connection;
+    }
+
+    /**
+     * Alternative WorkflowCancel constructor with ZosmfRequest object.
+     * This is mainly used for internal code unit testing with Mockito,
+     * and it is not recommended to be used by the larger community.
+     * <p>
+     * This constructor is package-private.
+     *
+     * @param connection for connection information, see ZosConnection object
+     * @param request    compatible ZosmfRequest interface object
+     */
+    WorkflowCancel(final ZosConnection connection, final ZosmfRequest request) {
+        ValidateUtils.checkNullParameter(connection, "connection");
+        ValidateUtils.checkNullParameter(request, "request");
+        this.connection = connection;
+        if (!(request instanceof PutJsonZosmfRequest)) {
+            throw new IllegalStateException("PUT_JSON request type required");
+        }
+        this.request = request;
+    }
+
+    /**
+     * Cancel a z/OSMF workflow on a z/OS system.
+     * <p>
+     * Canceling a workflow does not undo any actions already performed.
+     * A canceled workflow cannot be resumed.
+     *
+     * @param workflowKey workflow key identifying the workflow to cancel
+     * @return http response object
+     * @throws ZosmfRequestException request error state
+     */
+    public Response cancel(final String workflowKey) throws ZosmfRequestException {
+        ValidateUtils.checkIllegalParameter(workflowKey, "workflowKey");
+
+        final String url = connection.getZosmfUrl() +
+                WorkflowConstants.WORKFLOWS_RESOURCE +
+                UrlConstants.URL_PATH_DELIM +
+                EncodeUtils.encodeURIComponent(workflowKey) +
+                WorkflowConstants.OPERATIONS_CANCEL;
+
+        if (request == null) {
+            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
+        }
+        request.setUrl(url);
+        request.setBody("{}");
+
+        return request.executeRequest();
+    }
+
+}

--- a/src/main/java/zowe/client/sdk/zosmfworkflow/response/WorkflowCancelResponse.java
+++ b/src/main/java/zowe/client/sdk/zosmfworkflow/response/WorkflowCancelResponse.java
@@ -1,0 +1,65 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosmfworkflow.response;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * API response for cancel workflow.
+ * <p>
+ * <a href="https://www.ibm.com/docs/en/zos/3.2.0?topic=services-cancel-workflow">z/OSMF REST API</a>
+ *
+ * @author Jorge Samaniego
+ * @version 7.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class WorkflowCancelResponse {
+
+    /**
+     * Descriptive name of the canceled workflow. The name is appended with the
+     * canceled state and a timestamp, for example:
+     * "AutomationExample|Canceled|1423679433714".
+     */
+    private final String workflowName;
+
+    /**
+     * WorkflowCancelResponse Jackson constructor.
+     *
+     * @param workflowName canceled workflow name
+     */
+    @JsonCreator
+    public WorkflowCancelResponse(@JsonProperty("workflowName") final String workflowName) {
+        this.workflowName = workflowName == null ? "" : workflowName;
+    }
+
+    /**
+     * Retrieve workflowName value.
+     *
+     * @return workflowName value
+     */
+    public String getWorkflowName() {
+        return workflowName;
+    }
+
+    /**
+     * Return a string value representing a WorkflowCancelResponse object.
+     *
+     * @return string representation of WorkflowCancelResponse
+     */
+    @Override
+    public String toString() {
+        return "WorkflowCancelResponse{" +
+                "workflowName='" + workflowName + '\'' +
+                '}';
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCancelTest.java
+++ b/src/test/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCancelTest.java
@@ -111,7 +111,7 @@ public class WorkflowCancelTest {
         Mockito.verify(mockPutRequest, Mockito.never()).setBody(any());
 
         assertEquals(
-                "https://1:443/zosmf/workflow/rest/1.0/workflows/TESTKEY/operations/cancel",
+                "https://1:443/workflow/rest/1.0/workflows/TESTKEY/operations/cancel",
                 mockPutRequest.getUrl()
         );
     }
@@ -169,7 +169,7 @@ public class WorkflowCancelTest {
         assertEquals("{X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
                 mockPutRequestToken.getHeaders().toString());
         assertEquals("AutomationExample|Canceled|1423679433714", response.getWorkflowName());
-        assertEquals("https://1:443/zosmf/workflow/rest/1.0/workflows/test-key/operations/cancel",
+        assertEquals("https://1:443/workflow/rest/1.0/workflows/test-key/operations/cancel",
                 mockPutRequestToken.getUrl());
     }
 

--- a/src/test/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCancelTest.java
+++ b/src/test/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCancelTest.java
@@ -10,7 +10,7 @@
 package zowe.client.sdk.zosmfworkflow.methods;
 
 import kong.unirest.core.Cookie;
-import org.json.simple.JSONObject;
+import kong.unirest.core.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
@@ -19,6 +19,7 @@ import zowe.client.sdk.rest.PutJsonZosmfRequest;
 import zowe.client.sdk.rest.Response;
 import zowe.client.sdk.rest.ZosmfRequest;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
+import zowe.client.sdk.zosmfworkflow.response.WorkflowCancelResponse;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -33,6 +34,9 @@ import static org.mockito.Mockito.withSettings;
  * @version 7.0
  */
 public class WorkflowCancelTest {
+
+    private static final String CANCEL_JSON =
+            "{\"workflowName\":\"AutomationExample|Canceled|1423679433714\"}";
 
     private final ZosConnection connection = ZosConnectionFactory
             .createBasicConnection("1", 443, "1", "1");
@@ -95,17 +99,17 @@ public class WorkflowCancelTest {
         ZosConnection mockConnection = Mockito.mock(ZosConnection.class);
         Mockito.when(mockConnection.getZosmfUrl()).thenReturn("https://1:443");
         PutJsonZosmfRequest mockPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
-        Mockito.when(mockPutRequest.executeRequest()).thenReturn(new Response(new JSONObject(), 200, "success"));
+        Mockito.when(mockPutRequest.executeRequest())
+                .thenReturn(new Response(new JSONObject(CANCEL_JSON), 200, "success"));
 
         doCallRealMethod().when(mockPutRequest).setUrl(any());
         doCallRealMethod().when(mockPutRequest).getUrl();
 
         WorkflowCancel workflowCancel = new WorkflowCancel(mockConnection, mockPutRequest);
-        Response response = workflowCancel.cancel("TESTKEY");
+        WorkflowCancelResponse response = workflowCancel.cancel("TESTKEY");
 
-        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
-        assertEquals(200, response.getStatusCode().orElse(-1));
-        assertEquals("success", response.getStatusText().orElse("n\\a"));
+        assertEquals("AutomationExample|Canceled|1423679433714", response.getWorkflowName());
+        Mockito.verify(mockPutRequest, Mockito.never()).setBody(any());
     }
 
     @Test
@@ -135,7 +139,8 @@ public class WorkflowCancelTest {
         ZosConnection mockConnection = Mockito.mock(ZosConnection.class);
         Mockito.when(mockConnection.getZosmfUrl()).thenReturn("https://1:443/zosmf");
         PutJsonZosmfRequest mockPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
-        Mockito.when(mockPutRequest.executeRequest()).thenReturn(new Response(new JSONObject(), 200, "success"));
+        Mockito.when(mockPutRequest.executeRequest())
+                .thenReturn(new Response(new JSONObject(CANCEL_JSON), 200, "success"));
 
         doCallRealMethod().when(mockPutRequest).setUrl(any());
         doCallRealMethod().when(mockPutRequest).getUrl();
@@ -167,7 +172,7 @@ public class WorkflowCancelTest {
         PutJsonZosmfRequest mockPutRequestToken = Mockito.mock(PutJsonZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
         Mockito.when(mockPutRequestToken.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response(new JSONObject(CANCEL_JSON), 200, "success"));
         doCallRealMethod().when(mockPutRequestToken).setHeaders(anyMap());
         doCallRealMethod().when(mockPutRequestToken).setStandardHeaders();
         doCallRealMethod().when(mockPutRequestToken).setUrl(any());
@@ -175,13 +180,11 @@ public class WorkflowCancelTest {
         doCallRealMethod().when(mockPutRequestToken).getUrl();
 
         WorkflowCancel workflowCancel = new WorkflowCancel(tokenConnection, mockPutRequestToken);
-        Response response = workflowCancel.cancel("test-key");
+        WorkflowCancelResponse response = workflowCancel.cancel("test-key");
 
         assertEquals("{X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
                 mockPutRequestToken.getHeaders().toString());
-        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
-        assertEquals(200, response.getStatusCode().orElse(-1));
-        assertEquals("success", response.getStatusText().orElse("n\\a"));
+        assertEquals("AutomationExample|Canceled|1423679433714", response.getWorkflowName());
         assertEquals("https://1:443/zosmf/workflow/rest/1.0/workflows/test-key/operations/cancel",
                 mockPutRequestToken.getUrl());
     }

--- a/src/test/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCancelTest.java
+++ b/src/test/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCancelTest.java
@@ -10,7 +10,6 @@
 package zowe.client.sdk.zosmfworkflow.methods;
 
 import kong.unirest.core.Cookie;
-import kong.unirest.core.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
@@ -100,7 +99,7 @@ public class WorkflowCancelTest {
         Mockito.when(mockConnection.getZosmfUrl()).thenReturn("https://1:443");
         PutJsonZosmfRequest mockPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
         Mockito.when(mockPutRequest.executeRequest())
-                .thenReturn(new Response(new JSONObject(CANCEL_JSON), 200, "success"));
+                .thenReturn(new Response(CANCEL_JSON, 200, "success"));
 
         doCallRealMethod().when(mockPutRequest).setUrl(any());
         doCallRealMethod().when(mockPutRequest).getUrl();
@@ -110,6 +109,11 @@ public class WorkflowCancelTest {
 
         assertEquals("AutomationExample|Canceled|1423679433714", response.getWorkflowName());
         Mockito.verify(mockPutRequest, Mockito.never()).setBody(any());
+
+        assertEquals(
+                "https://1:443/zosmf/workflow/rest/1.0/workflows/TESTKEY/operations/cancel",
+                mockPutRequest.getUrl()
+        );
     }
 
     @Test
@@ -135,26 +139,6 @@ public class WorkflowCancelTest {
     }
 
     @Test
-    public void tstWorkflowCancelUrlGenerationSuccess() throws ZosmfRequestException {
-        ZosConnection mockConnection = Mockito.mock(ZosConnection.class);
-        Mockito.when(mockConnection.getZosmfUrl()).thenReturn("https://1:443/zosmf");
-        PutJsonZosmfRequest mockPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
-        Mockito.when(mockPutRequest.executeRequest())
-                .thenReturn(new Response(new JSONObject(CANCEL_JSON), 200, "success"));
-
-        doCallRealMethod().when(mockPutRequest).setUrl(any());
-        doCallRealMethod().when(mockPutRequest).getUrl();
-
-        WorkflowCancel workflowCancel = new WorkflowCancel(mockConnection, mockPutRequest);
-        workflowCancel.cancel("TESTKEY");
-
-        assertEquals(
-                "https://1:443/zosmf/workflow/rest/1.0/workflows/TESTKEY/operations/cancel",
-                mockPutRequest.getUrl()
-        );
-    }
-
-    @Test
     public void tstWorkflowCancelKeyEmptyFailure() {
         ZosConnection mockConnection = Mockito.mock(ZosConnection.class);
         Mockito.when(mockConnection.getZosmfUrl()).thenReturn("https://1:443/zosmf");
@@ -172,7 +156,7 @@ public class WorkflowCancelTest {
         PutJsonZosmfRequest mockPutRequestToken = Mockito.mock(PutJsonZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
         Mockito.when(mockPutRequestToken.executeRequest()).thenReturn(
-                new Response(new JSONObject(CANCEL_JSON), 200, "success"));
+                new Response(CANCEL_JSON, 200, "success"));
         doCallRealMethod().when(mockPutRequestToken).setHeaders(anyMap());
         doCallRealMethod().when(mockPutRequestToken).setStandardHeaders();
         doCallRealMethod().when(mockPutRequestToken).setUrl(any());

--- a/src/test/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCancelTest.java
+++ b/src/test/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCancelTest.java
@@ -1,0 +1,189 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosmfworkflow.methods;
+
+import kong.unirest.core.Cookie;
+import org.json.simple.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import zowe.client.sdk.core.ZosConnection;
+import zowe.client.sdk.core.ZosConnectionFactory;
+import zowe.client.sdk.rest.PutJsonZosmfRequest;
+import zowe.client.sdk.rest.Response;
+import zowe.client.sdk.rest.ZosmfRequest;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.withSettings;
+
+/**
+ * Class containing unit tests for WorkflowCancel.
+ *
+ * @author Jorge Samaniego
+ * @version 7.0
+ */
+public class WorkflowCancelTest {
+
+    private final ZosConnection connection = ZosConnectionFactory
+            .createBasicConnection("1", 443, "1", "1");
+    private final ZosConnection tokenConnection = ZosConnectionFactory
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
+
+    @Test
+    public void tstWorkflowCancelSecondaryConstructorWithValidRequestTypeSuccess() {
+        ZosmfRequest request = Mockito.mock(PutJsonZosmfRequest.class);
+        WorkflowCancel workflowCancel = new WorkflowCancel(connection, request);
+        assertNotNull(workflowCancel);
+    }
+
+    @Test
+    public void tstWorkflowCancelSecondaryConstructorWithNullConnectionFailure() {
+        ZosmfRequest request = Mockito.mock(PutJsonZosmfRequest.class);
+        NullPointerException exception = assertThrows(
+                NullPointerException.class,
+                () -> new WorkflowCancel(null, request)
+        );
+        assertEquals("connection is null", exception.getMessage());
+    }
+
+    @Test
+    public void tstWorkflowCancelSecondaryConstructorWithNullRequestFailure() {
+        NullPointerException exception = assertThrows(
+                NullPointerException.class,
+                () -> new WorkflowCancel(connection, null)
+        );
+        assertEquals("request is null", exception.getMessage());
+    }
+
+    @Test
+    public void tstWorkflowCancelSecondaryConstructorWithInvalidRequestTypeFailure() {
+        ZosmfRequest request = Mockito.mock(ZosmfRequest.class);
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> new WorkflowCancel(connection, request)
+        );
+        assertEquals("PUT_JSON request type required", exception.getMessage());
+    }
+
+    @Test
+    public void tstWorkflowCancelPrimaryConstructorWithValidConnectionSuccess() {
+        WorkflowCancel workflowCancel = new WorkflowCancel(connection);
+        assertNotNull(workflowCancel);
+    }
+
+    @Test
+    public void tstWorkflowCancelPrimaryConstructorWithNullConnectionFailure() {
+        NullPointerException exception = assertThrows(
+                NullPointerException.class,
+                () -> new WorkflowCancel(null)
+        );
+        assertEquals("connection is null", exception.getMessage());
+    }
+
+    @Test
+    public void tstWorkflowCancelSuccess() throws ZosmfRequestException {
+        ZosConnection mockConnection = Mockito.mock(ZosConnection.class);
+        Mockito.when(mockConnection.getZosmfUrl()).thenReturn("https://1:443");
+        PutJsonZosmfRequest mockPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
+        Mockito.when(mockPutRequest.executeRequest()).thenReturn(new Response(new JSONObject(), 200, "success"));
+
+        doCallRealMethod().when(mockPutRequest).setUrl(any());
+        doCallRealMethod().when(mockPutRequest).getUrl();
+
+        WorkflowCancel workflowCancel = new WorkflowCancel(mockConnection, mockPutRequest);
+        Response response = workflowCancel.cancel("TESTKEY");
+
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
+    }
+
+    @Test
+    public void tstWorkflowCancelWithNullWorkflowKeyFailure() {
+        WorkflowCancel workflowCancel = new WorkflowCancel(connection);
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> workflowCancel.cancel(null)
+        );
+        assertEquals("workflowKey is either null or empty", exception.getMessage());
+    }
+
+    @Test
+    public void tstWorkflowCancelSecondaryConstructorObjectCreateSuccess() {
+        PutJsonZosmfRequest request = Mockito.mock(PutJsonZosmfRequest.class);
+        boolean noError = false;
+        try {
+            new WorkflowCancel(connection, request);
+        } catch (IllegalStateException e) {
+            noError = true;
+        }
+        assertFalse(noError);
+    }
+
+    @Test
+    public void tstWorkflowCancelUrlGenerationSuccess() throws ZosmfRequestException {
+        ZosConnection mockConnection = Mockito.mock(ZosConnection.class);
+        Mockito.when(mockConnection.getZosmfUrl()).thenReturn("https://1:443/zosmf");
+        PutJsonZosmfRequest mockPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
+        Mockito.when(mockPutRequest.executeRequest()).thenReturn(new Response(new JSONObject(), 200, "success"));
+
+        doCallRealMethod().when(mockPutRequest).setUrl(any());
+        doCallRealMethod().when(mockPutRequest).getUrl();
+
+        WorkflowCancel workflowCancel = new WorkflowCancel(mockConnection, mockPutRequest);
+        workflowCancel.cancel("TESTKEY");
+
+        assertEquals(
+                "https://1:443/zosmf/workflow/rest/1.0/workflows/TESTKEY/operations/cancel",
+                mockPutRequest.getUrl()
+        );
+    }
+
+    @Test
+    public void tstWorkflowCancelKeyEmptyFailure() {
+        ZosConnection mockConnection = Mockito.mock(ZosConnection.class);
+        Mockito.when(mockConnection.getZosmfUrl()).thenReturn("https://1:443/zosmf");
+        PutJsonZosmfRequest mockPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
+        WorkflowCancel workflowCancel = new WorkflowCancel(mockConnection, mockPutRequest);
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> workflowCancel.cancel("")
+        );
+        assertEquals("workflowKey is either null or empty", exception.getMessage());
+    }
+
+    @Test
+    public void tstWorkflowCancelTokenSuccess() throws ZosmfRequestException {
+        PutJsonZosmfRequest mockPutRequestToken = Mockito.mock(PutJsonZosmfRequest.class,
+                withSettings().useConstructor(tokenConnection));
+        Mockito.when(mockPutRequestToken.executeRequest()).thenReturn(
+                new Response(new JSONObject(), 200, "success"));
+        doCallRealMethod().when(mockPutRequestToken).setHeaders(anyMap());
+        doCallRealMethod().when(mockPutRequestToken).setStandardHeaders();
+        doCallRealMethod().when(mockPutRequestToken).setUrl(any());
+        doCallRealMethod().when(mockPutRequestToken).getHeaders();
+        doCallRealMethod().when(mockPutRequestToken).getUrl();
+
+        WorkflowCancel workflowCancel = new WorkflowCancel(tokenConnection, mockPutRequestToken);
+        Response response = workflowCancel.cancel("test-key");
+
+        assertEquals("{X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
+                mockPutRequestToken.getHeaders().toString());
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
+        assertEquals("https://1:443/zosmf/workflow/rest/1.0/workflows/test-key/operations/cancel",
+                mockPutRequestToken.getUrl());
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCancelTest.java
+++ b/src/test/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCancelTest.java
@@ -169,7 +169,7 @@ public class WorkflowCancelTest {
         assertEquals("{X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
                 mockPutRequestToken.getHeaders().toString());
         assertEquals("AutomationExample|Canceled|1423679433714", response.getWorkflowName());
-        assertEquals("https://1:443/workflow/rest/1.0/workflows/test-key/operations/cancel",
+        assertEquals("https://1:443/zosmf/workflow/rest/1.0/workflows/test-key/operations/cancel",
                 mockPutRequestToken.getUrl());
     }
 


### PR DESCRIPTION
Closes #472

Provide a workflow API method to cancel a z/OSMF workflow on a z/OS system.

Implementation supports the z/OSMF Cancel Workflow REST API:
- WorkflowCancel class added under zosmfworkflow/methods
- cancel method performs PUT request to /operations/cancel endpoint
- OPERATIONS_CANCEL constant added to WorkflowConstants
- Supports basic and token-based z/OSMF authentication
- 12 unit tests added, all passing**