### PR TITLE
Fix z/OSMF JSON parsing and USS file response handling

### DIFF
--- a/src/main/java/zowe/client/sdk/utility/JsonUtils.java
+++ b/src/main/java/zowe/client/sdk/utility/JsonUtils.java
@@ -43,17 +43,17 @@ public final class JsonUtils {
     }
 
     /**
-     * This method is a wrapper for JSONParser().parse() call to parse z/OSMF response
+     * This method is a wrapper for ObjectMapper.readTree() call to parse z/OSMF response
      * which may return ZosmfRequestException.
      *
      * @param item JSON string representation
-     * @return JSONObject object
+     * @return JsonNode object
      * @throws ZosmfRequestException indicates the JSON item from z/OSMF request is invalid for parsing
      */
-    public static JSONObject parse(final String item) throws ZosmfRequestException {
+    public static JsonNode parse(final String item) throws ZosmfRequestException {
         try {
-            return (JSONObject) new JSONParser().parse(item);
-        } catch (ParseException e) {
+            return objectMapper.readTree(item);
+        } catch (JsonProcessingException e) {
             LOG.debug(PARSE_ERROR_MSG, e);
             throw new ZosmfRequestException(e.getMessage(), e);
         }

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnList.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnList.java
@@ -9,8 +9,7 @@
  */
 package zowe.client.sdk.zosfiles.dsn.methods;
 
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zowe.client.sdk.core.ZosConnection;
@@ -184,7 +183,7 @@ public class DsnList {
         }
 
         final String jsonStr = response.getResponsePhrase().get().toString();
-        final JSONObject jsonObject = JsonUtils.parse(jsonStr);
+        final JsonNode jsonObject = JsonUtils.parse(jsonStr);
         if (jsonObject.isEmpty()) {
             if (datasetLst == null) {
                 return memberLst;
@@ -193,13 +192,13 @@ public class DsnList {
             }
         }
 
-        final JSONArray items = (JSONArray) jsonObject.get(ZosFilesConstants.RESPONSE_ITEMS);
+        final JsonNode items = jsonObject.get(ZosFilesConstants.RESPONSE_ITEMS);
         final String context = "getResult";
-        for (final Object obj : items) {
+        for (final JsonNode obj : items) {
             if (datasetLst == null) {
-                memberLst.add((T) JsonUtils.parseResponse(String.valueOf(obj), Member.class, context));
+                memberLst.add((T) JsonUtils.parseResponse(obj.toString(), Member.class, context));
             } else {
-                datasetLst.add((T) JsonUtils.parseResponse(String.valueOf(obj), Dataset.class, context));
+                datasetLst.add((T) JsonUtils.parseResponse(obj.toString(), Dataset.class, context));
             }
         }
 

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssExtAttr.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssExtAttr.java
@@ -9,7 +9,7 @@
  */
 package zowe.client.sdk.zosfiles.uss.methods;
 
-import org.json.simple.JSONArray;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.json.simple.JSONObject;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.PutJsonZosmfRequest;
@@ -81,10 +81,10 @@ public class UssExtAttr {
         final Map<String, String> requestMap = new HashMap<>();
         requestMap.put("request", "extattr");
         final Response response = executeRequest(targetPath, requestMap);
-        final JSONObject json = JsonUtils.parse(response.getResponsePhrase()
+        final JsonNode json = JsonUtils.parse(response.getResponsePhrase()
                 .orElseThrow(() -> new IllegalStateException(ZosFilesConstants.RESPONSE_PHRASE_ERROR)).toString());
         final StringBuilder str = new StringBuilder();
-        ((JSONArray) json.get("stdout")).forEach(item -> str.append(item.toString()).append("\n"));
+        json.get("stdout").forEach(item -> str.append(item.asText()).append("\n"));
         return str.toString();
     }
 

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssGetAcl.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssGetAcl.java
@@ -9,7 +9,7 @@
  */
 package zowe.client.sdk.zosfiles.uss.methods;
 
-import org.json.simple.JSONArray;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.json.simple.JSONObject;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.PutJsonZosmfRequest;
@@ -84,13 +84,13 @@ public class UssGetAcl {
         final Response response = useCommas ?
                 getAclCommon(targetPath, new UssGetAclInputData.Builder().usecommas(true).build()) :
                 getAclCommon(targetPath, new UssGetAclInputData.Builder().build());
-        final JSONObject json = JsonUtils.parse(response.getResponsePhrase()
+        final JsonNode json = JsonUtils.parse(response.getResponsePhrase()
                 .orElseThrow(() -> new IllegalStateException(ZosFilesConstants.RESPONSE_PHRASE_ERROR)).toString());
         final StringBuilder str = new StringBuilder();
         if (useCommas) {
-            ((JSONArray) json.get("stdout")).forEach(item -> str.append(item.toString()));
+            json.get("stdout").forEach(item -> str.append(item.asText()));
         } else {
-            ((JSONArray) json.get("stdout")).forEach(item -> str.append(item.toString()).append("\n"));
+            json.get("stdout").forEach(item -> str.append(item.asText()).append("\n"));
         }
         return str.toString();
     }

--- a/src/test/java/zowe/client/sdk/utility/JsonUtilsTest.java
+++ b/src/test/java/zowe/client/sdk/utility/JsonUtilsTest.java
@@ -9,7 +9,12 @@
  */
 package zowe.client.sdk.utility;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.jupiter.api.Test;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Class containing unit test for JsonParserUtils.
@@ -26,6 +31,18 @@ public class JsonUtilsTest {
     public void tstJsonParserUtilsClassStructureSuccess() {
         final String privateConstructorExceptionMsg = "Utility class";
         UtilsTestHelper.validateClass(JsonUtils.class, privateConstructorExceptionMsg);
+    }
+
+    @Test
+    public void tstParseSuccess() throws ZosmfRequestException {
+        final JsonNode json = JsonUtils.parse("{\"key\":\"value\"}");
+
+        assertEquals("value", json.get("key").asText());
+    }
+
+    @Test
+    public void tstParseInvalidJsonFailure() {
+        assertThrows(ZosmfRequestException.class, () -> JsonUtils.parse("{\"key\":\"value\""));
     }
 
 }

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssListTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssListTest.java
@@ -9,6 +9,7 @@
  */
 package zowe.client.sdk.zosfiles.uss.methods;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import kong.unirest.core.Cookie;
 import org.json.simple.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,7 +62,7 @@ public class UssListTest {
             "         \"user\": \"user\",\n" +
             "         \"gid\": 8,\n" +
             "         \"group\": \"FRAMEWKG\",\n" +
-            "         \"mtime\": \"2022-11-03T10:48:32\"\n" +
+            "         \"mtime\": \"2022-11-03T10:48:32\",\n" +
             "         \"target\": \"target\"\n" +
             "      },\n" +
             "      {\n" +
@@ -72,7 +73,7 @@ public class UssListTest {
             "         \"user\": \"user2\",\n" +
             "         \"gid\": 8,\n" +
             "         \"group\": \"FRAMEWKG\",\n" +
-            "         \"mtime\": \"2022-11-12T15:20:11\"\n" +
+            "         \"mtime\": \"2022-11-12T15:20:11\",\n" +
             "         \"target\": \"target\"\n" +
             "      }\n" +
             "   ],\n" +
@@ -83,10 +84,10 @@ public class UssListTest {
     private final static String partialDataForFileList = "{\n" +
             "   \"items\": [\n" +
             "      {\n" +
-            "         \"size\": 0,\n" +
+            "         \"size\": 0\n" +
             "      },\n" +
             "      {\n" +
-            "         \"name\": \"test2\",\n" +
+            "         \"name\": \"test2\"\n" +
             "      }\n" +
             "   ],\n" +
             "   \"returnedRows\": 7,\n" +
@@ -170,7 +171,7 @@ public class UssListTest {
 
     @Test
     public void tstUssListFileListSuccess() throws ZosmfRequestException {
-        final JSONObject json = JsonUtils.parse(dataForFileList);
+        final JsonNode json = JsonUtils.parse(dataForFileList);
         Mockito.when(mockJsonGetRequest.executeRequest()).thenReturn(
                 new Response(json, 200, "success"));
         final UssList ussList = new UssList(connection, mockJsonGetRequest);
@@ -202,7 +203,7 @@ public class UssListTest {
 
     @Test
     public void tstUssListFileListPartialSuccess() throws ZosmfRequestException {
-        final JSONObject json = JsonUtils.parse(partialDataForFileList);
+        final JsonNode json = JsonUtils.parse(partialDataForFileList);
         Mockito.when(mockJsonGetRequest.executeRequest()).thenReturn(
                 new Response(json, 200, "success"));
         final UssList ussList = new UssList(connection, mockJsonGetRequest);
@@ -235,7 +236,7 @@ public class UssListTest {
 
     @Test
     public void tstUssListEmptyFileListSuccess() throws ZosmfRequestException {
-        final JSONObject json = JsonUtils.parse("{}");
+        final JsonNode json = JsonUtils.parse("{}");
         Mockito.when(mockJsonGetRequest.executeRequest()).thenReturn(
                 new Response(json, 200, "success"));
         final UssList ussList = new UssList(connection, mockJsonGetRequest);
@@ -256,7 +257,7 @@ public class UssListTest {
 
     @Test
     public void tstUssListZfsListSuccess() throws ZosmfRequestException {
-        final JSONObject json = JsonUtils.parse(dataForZfsList);
+        final JsonNode json = JsonUtils.parse(dataForZfsList);
         Mockito.when(mockJsonGetRequest.executeRequest()).thenReturn(
                 new Response(json, 200, "success"));
         final UssList ussList = new UssList(connection, mockJsonGetRequest);
@@ -609,7 +610,7 @@ public class UssListTest {
 
     @Test
     public void tstUssListZfsListWithFsnameSuccess() throws Exception {
-        final JSONObject json = JsonUtils.parse(dataForZfsList);
+        final JsonNode json = JsonUtils.parse(dataForZfsList);
         Mockito.when(mockJsonGetRequest.executeRequest()).thenReturn(
                 new Response(json, 200, "success"));
         doCallRealMethod().when(mockJsonGetRequest).setUrl(any());
@@ -627,7 +628,7 @@ public class UssListTest {
 
     @Test
     public void tstUssListZfsListWithMaxLengthSuccess() throws Exception {
-        final JSONObject json = JsonUtils.parse(dataForZfsList);
+        final JsonNode json = JsonUtils.parse(dataForZfsList);
         Mockito.when(mockJsonGetRequestToken.executeRequest()).thenReturn(
                 new Response(json, 200, "success"));
         doCallRealMethod().when(mockJsonGetRequestToken).setUrl(any());
@@ -783,7 +784,7 @@ public class UssListTest {
 
     @Test
     public void tstUssListZfsListWithPathSuccess() throws Exception {
-        final JSONObject json = JsonUtils.parse(dataForZfsList);
+        final JsonNode json = JsonUtils.parse(dataForZfsList);
         Mockito.when(mockJsonGetRequest.executeRequest()).thenReturn(
                 new Response(json, 200, "success"));
         doCallRealMethod().when(mockJsonGetRequest).setUrl(any());
@@ -840,7 +841,7 @@ public class UssListTest {
 
     @Test
     public void tstUssListZfsListZeroMaxLengthNoHeaderSuccess() throws Exception {
-        final JSONObject json = JsonUtils.parse(dataForZfsList);
+        final JsonNode json = JsonUtils.parse(dataForZfsList);
         Mockito.when(mockJsonGetRequestToken.executeRequest()).thenReturn(
                 new Response(json, 200, "success"));
         doCallRealMethod().when(mockJsonGetRequestToken).setUrl(any());


### PR DESCRIPTION
 ## Description
  This PR updates the z/OS file handling flow to use Jackson JsonNode parsing
  instead of json-simple for z/OSMF JSON responses. The change aligns parsing
  across JsonUtils, DsnList, UssExtAttr, and UssGetAcl, and updates the related
  tests to validate the new behavior.

  ## What changed

  - Switched JsonUtils.parse() to return Jackson JsonNode
  - Updated DSN and USS methods to consume Jackson JSON trees
  - Reworked UssExtAttr and UssGetAcl stdout handling to use JsonNode
  - Added coverage for valid and invalid JSON parsing in JsonUtilsTest
  - Adjusted UssListTest fixtures and expectations for the new parser behavior

  ## Validation

  - Ran ./mvnw test under JDK 17 with the Byte Buddy agent preloaded
  - Result: 1029 tests run, 0 failures, 0 errors
  
## Closes 
#529 