### PR TITLE
Add createLocal to WorkflowCreate for local-file workflow creation

### DIFF
--- a/src/main/java/zowe/client/sdk/zosmfworkflow/WorkflowConstants.java
+++ b/src/main/java/zowe/client/sdk/zosmfworkflow/WorkflowConstants.java
@@ -71,4 +71,9 @@ public final class WorkflowConstants {
      */
     public static final String OPERATIONS_START = URL_PATH_DELIM + "operations" + URL_PATH_DELIM + "start";
 
+    /**
+     * Default USS directory used to hold local workflow files temporarily uploaded for a local create.
+     */
+    public static final String TEMP_PATH = "/tmp";
+
 }

--- a/src/main/java/zowe/client/sdk/zosmfworkflow/input/WorkflowCreateInputData.java
+++ b/src/main/java/zowe/client/sdk/zosmfworkflow/input/WorkflowCreateInputData.java
@@ -329,6 +329,35 @@ public class WorkflowCreateInputData {
     }
 
     /**
+     * Create a builder pre-populated with the values of this instance. Useful for producing a modified copy,
+     * for example swapping local file paths for the uploaded USS paths during a local workflow create.
+     *
+     * @return builder instance populated with this instance's values
+     */
+    public Builder toBuilder() {
+        return new Builder()
+                .workflowName(workflowName)
+                .workflowDefinitionFile(workflowDefinitionFile)
+                .workflowDefinitionFileSystem(workflowDefinitionFileSystem)
+                .variableInputFile(variableInputFile)
+                .variables(variables)
+                .resolveGlobalConflictByUsing(resolveGlobalConflictByUsing)
+                .system(system)
+                .owner(owner)
+                .workflowArchiveSAFID(workflowArchiveSAFID)
+                .comments(comments)
+                .assignToOwner(assignToOwner)
+                .accessType(accessType)
+                .accountInfo(accountInfo)
+                .jobStatement(jobStatement)
+                .deleteCompletedJobs(deleteCompletedJobs)
+                .jobsOutputDirectory(jobsOutputDirectory)
+                .autoDeleteOnCompletion(autoDeleteOnCompletion)
+                .targetSystemuid(targetSystemuid)
+                .targetSystempwd(targetSystempwd);
+    }
+
+    /**
      * Return a string value representing a WorkflowCreateInputData object.
      *
      * @return string representation of WorkflowCreateInputData

--- a/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCreate.java
+++ b/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCreate.java
@@ -19,9 +19,18 @@ import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.rest.type.ZosmfRequestType;
 import zowe.client.sdk.utility.JsonUtils;
 import zowe.client.sdk.utility.ValidateUtils;
+import zowe.client.sdk.zosfiles.uss.methods.UssDelete;
+import zowe.client.sdk.zosfiles.uss.methods.UssWrite;
 import zowe.client.sdk.zosmfworkflow.WorkflowConstants;
 import zowe.client.sdk.zosmfworkflow.input.WorkflowCreateInputData;
+import zowe.client.sdk.zosmfworkflow.response.WorkflowCreateLocalResponse;
 import zowe.client.sdk.zosmfworkflow.response.WorkflowCreateResponse;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Provides create workflow functionality through the z/OSMF workflow REST API.
@@ -37,6 +46,9 @@ public class WorkflowCreate {
     private static final String CONTEXT = "create";
     private final ZosConnection connection;
     private ZosmfRequest request;
+    // package-private so unit tests can inject mock USS helpers; lazily created for real use
+    UssWrite ussWrite;
+    UssDelete ussDelete;
 
     /**
      * WorkflowCreate constructor.
@@ -104,6 +116,129 @@ public class WorkflowCreate {
                 .toString();
 
         return JsonUtils.parseResponse(responsePhrase, WorkflowCreateResponse.class, CONTEXT);
+    }
+
+    /**
+     * Create a z/OSMF workflow from local files, deleting the uploaded temporary USS files on completion.
+     * <p>
+     * The workflow definition file and optional variable input file referenced in the input data are treated as
+     * local paths. They are uploaded to a temporary USS location before the workflow is created.
+     *
+     * @param createInputData workflow creation parameters holding local file paths
+     * @return local create workflow details, see WorkflowCreateLocalResponse object
+     * @throws ZosmfRequestException request error state
+     * @author Ashish Kumar Dash
+     */
+    public WorkflowCreateLocalResponse createLocal(final WorkflowCreateInputData createInputData)
+            throws ZosmfRequestException {
+        return createLocal(createInputData, false, null);
+    }
+
+    /**
+     * Create a z/OSMF workflow from local files.
+     * <p>
+     * The workflow definition file and optional variable input file referenced in the input data are treated as
+     * local paths. They are uploaded to a temporary USS location before the workflow is created. When keepFiles
+     * is false, the uploaded temporary files are deleted after the create completes.
+     *
+     * @param createInputData workflow creation parameters holding local file paths
+     * @param keepFiles       true to retain the uploaded temporary USS files, false to delete them after create
+     * @param customDir       optional USS directory to upload the temporary files to; when null or empty a default
+     *                        temporary directory is used
+     * @return local create workflow details, see WorkflowCreateLocalResponse object
+     * @throws ZosmfRequestException request error state
+     * @author Ashish Kumar Dash
+     */
+    public WorkflowCreateLocalResponse createLocal(final WorkflowCreateInputData createInputData,
+                                                   final boolean keepFiles,
+                                                   final String customDir) throws ZosmfRequestException {
+        ValidateUtils.checkNullParameter(createInputData, "createInputData");
+        ValidateUtils.checkIllegalParameter(createInputData.getWorkflowName(), "workflowName");
+        ValidateUtils.checkIllegalParameter(createInputData.getWorkflowDefinitionFile(), "workflowDefinitionFile");
+        ValidateUtils.checkIllegalParameter(createInputData.getSystem(), "system");
+        ValidateUtils.checkIllegalParameter(createInputData.getOwner(), "owner");
+
+        if (ussWrite == null) {
+            ussWrite = new UssWrite(connection);
+        }
+        if (ussDelete == null) {
+            ussDelete = new UssDelete(connection);
+        }
+
+        // upload the local workflow definition file to a temporary USS location
+        final String tempDefinitionFile = buildTempPath(createInputData.getWorkflowDefinitionFile(), customDir);
+        uploadLocalFile(createInputData.getWorkflowDefinitionFile(), tempDefinitionFile);
+
+        // upload the optional local variable input file
+        String tempVariableInputFile = null;
+        final String localVariableInputFile = createInputData.getVariableInputFile();
+        if (localVariableInputFile != null && !localVariableInputFile.isBlank()) {
+            tempVariableInputFile = buildTempPath(localVariableInputFile, customDir);
+            uploadLocalFile(localVariableInputFile, tempVariableInputFile);
+        }
+
+        // create the workflow pointing at the uploaded USS paths
+        final WorkflowCreateInputData ussInputData = createInputData.toBuilder()
+                .workflowDefinitionFile(tempDefinitionFile)
+                .variableInputFile(tempVariableInputFile)
+                .build();
+        final WorkflowCreateResponse workflow = create(ussInputData);
+
+        // retain or delete the uploaded temporary files
+        final List<String> tempFiles = new ArrayList<>();
+        tempFiles.add(tempDefinitionFile);
+        if (tempVariableInputFile != null) {
+            tempFiles.add(tempVariableInputFile);
+        }
+
+        final List<String> filesKept = new ArrayList<>();
+        final List<String> failedToDelete = new ArrayList<>();
+        if (keepFiles) {
+            filesKept.addAll(tempFiles);
+        } else {
+            for (final String tempFile : tempFiles) {
+                try {
+                    ussDelete.delete(tempFile);
+                } catch (ZosmfRequestException e) {
+                    failedToDelete.add(tempFile);
+                }
+            }
+        }
+
+        return new WorkflowCreateLocalResponse(workflow, filesKept, failedToDelete);
+    }
+
+    /**
+     * Build a temporary USS path for a local file.
+     *
+     * @param localFile local file path
+     * @param customDir optional USS directory to place the temporary file in
+     * @return temporary USS path
+     */
+    private String buildTempPath(final String localFile, final String customDir) {
+        final String baseName = Paths.get(localFile).getFileName().toString();
+        if (customDir != null && !customDir.isBlank()) {
+            return customDir + "/" + baseName;
+        }
+        final String user = connection.getUser() == null ? "" : connection.getUser();
+        return WorkflowConstants.TEMP_PATH + "/" + user + System.currentTimeMillis() + baseName;
+    }
+
+    /**
+     * Upload a local file to a target USS path as binary content.
+     *
+     * @param localFile  local file path to read
+     * @param remoteFile target USS path to write
+     * @throws ZosmfRequestException request error state
+     */
+    private void uploadLocalFile(final String localFile, final String remoteFile) throws ZosmfRequestException {
+        final byte[] content;
+        try {
+            content = Files.readAllBytes(Paths.get(localFile));
+        } catch (IOException e) {
+            throw new IllegalStateException("unable to read local file: " + localFile, e);
+        }
+        ussWrite.writeBinary(remoteFile, content);
     }
 
 }

--- a/src/main/java/zowe/client/sdk/zosmfworkflow/response/WorkflowCreateLocalResponse.java
+++ b/src/main/java/zowe/client/sdk/zosmfworkflow/response/WorkflowCreateLocalResponse.java
@@ -1,0 +1,97 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosmfworkflow.response;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * API response for a local create workflow. Wraps the create workflow response together with the outcome of the
+ * temporary USS files that were uploaded to drive the create.
+ * <p>
+ * <a href="https://www.ibm.com/docs/en/zos/3.2.0?topic=services-create-workflow">z/OSMF REST API</a>
+ *
+ * @author Ashish Kumar Dash
+ * @version 7.0
+ */
+public final class WorkflowCreateLocalResponse {
+
+    /**
+     * Workflow details returned by the create workflow request.
+     */
+    private final WorkflowCreateResponse workflow;
+
+    /**
+     * Temporary USS files that were kept because keepFiles was requested. Empty when the files were deleted.
+     */
+    private final List<String> filesKept;
+
+    /**
+     * Temporary USS files that could not be deleted during cleanup. Empty when all files were deleted successfully.
+     */
+    private final List<String> failedToDelete;
+
+    /**
+     * WorkflowCreateLocalResponse constructor.
+     *
+     * @param workflow       workflow details returned by the create workflow request
+     * @param filesKept      temporary USS files that were kept
+     * @param failedToDelete temporary USS files that could not be deleted
+     */
+    public WorkflowCreateLocalResponse(final WorkflowCreateResponse workflow,
+                                       final List<String> filesKept,
+                                       final List<String> failedToDelete) {
+        this.workflow = workflow;
+        this.filesKept = filesKept == null ? Collections.emptyList() : filesKept;
+        this.failedToDelete = failedToDelete == null ? Collections.emptyList() : failedToDelete;
+    }
+
+    /**
+     * Retrieve workflow value.
+     *
+     * @return workflow value
+     */
+    public WorkflowCreateResponse getWorkflow() {
+        return workflow;
+    }
+
+    /**
+     * Retrieve filesKept value.
+     *
+     * @return filesKept value
+     */
+    public List<String> getFilesKept() {
+        return filesKept;
+    }
+
+    /**
+     * Retrieve failedToDelete value.
+     *
+     * @return failedToDelete value
+     */
+    public List<String> getFailedToDelete() {
+        return failedToDelete;
+    }
+
+    /**
+     * Return a string value representing a WorkflowCreateLocalResponse object.
+     *
+     * @return string representation of WorkflowCreateLocalResponse
+     */
+    @Override
+    public String toString() {
+        return "WorkflowCreateLocalResponse{" +
+                "workflow=" + workflow +
+                ", filesKept=" + filesKept +
+                ", failedToDelete=" + failedToDelete +
+                '}';
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/zosmfworkflow/input/WorkflowCreateInputDataTest.java
+++ b/src/test/java/zowe/client/sdk/zosmfworkflow/input/WorkflowCreateInputDataTest.java
@@ -74,4 +74,32 @@ public class WorkflowCreateInputDataTest {
         assertEquals("remotepwd", inputData.getTargetSystempwd());
     }
 
+    @Test
+    public void tstWorkflowCreateInputDataToBuilderCopiesAndOverridesSuccess() {
+        final WorkflowCreateInputData original = WorkflowCreateInputData.builder()
+                .workflowName("AutomationExample")
+                .workflowDefinitionFile("/local/workflow.xml")
+                .variableInputFile("/local/vars.properties")
+                .system("SY1")
+                .owner("zosmfad")
+                .accessType("Public")
+                .build();
+
+        final WorkflowCreateInputData copy = original.toBuilder()
+                .workflowDefinitionFile("/tmp/workflow.xml")
+                .variableInputFile("/tmp/vars.properties")
+                .build();
+
+        // overridden values
+        assertEquals("/tmp/workflow.xml", copy.getWorkflowDefinitionFile());
+        assertEquals("/tmp/vars.properties", copy.getVariableInputFile());
+        // copied values
+        assertEquals("AutomationExample", copy.getWorkflowName());
+        assertEquals("SY1", copy.getSystem());
+        assertEquals("zosmfad", copy.getOwner());
+        assertEquals("Public", copy.getAccessType());
+        // original is unchanged
+        assertEquals("/local/workflow.xml", original.getWorkflowDefinitionFile());
+    }
+
 }

--- a/src/test/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCreateTest.java
+++ b/src/test/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCreateTest.java
@@ -15,6 +15,7 @@ import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
@@ -23,10 +24,15 @@ import zowe.client.sdk.rest.PostJsonZosmfRequest;
 import zowe.client.sdk.rest.Response;
 import zowe.client.sdk.rest.ZosmfRequest;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
+import zowe.client.sdk.zosfiles.uss.methods.UssDelete;
+import zowe.client.sdk.zosfiles.uss.methods.UssWrite;
 import zowe.client.sdk.zosmfworkflow.input.WorkflowCreateInputData;
 import zowe.client.sdk.zosmfworkflow.model.WorkflowVariable;
+import zowe.client.sdk.zosmfworkflow.response.WorkflowCreateLocalResponse;
 import zowe.client.sdk.zosmfworkflow.response.WorkflowCreateResponse;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -246,6 +252,106 @@ public class WorkflowCreateTest {
                 () -> new WorkflowCreate(null)
         );
         assertEquals("connection is null", exception.getMessage());
+    }
+
+    private WorkflowCreate workflowCreateWithUss(final UssWrite ussWrite, final UssDelete ussDelete) {
+        final WorkflowCreate workflowCreate = new WorkflowCreate(connection, mockPostJsonZosmfRequest);
+        workflowCreate.ussWrite = ussWrite;
+        workflowCreate.ussDelete = ussDelete;
+        return workflowCreate;
+    }
+
+    private static WorkflowCreateInputData localInputData(final Path tempDir, final boolean withVarFile)
+            throws Exception {
+        final Path definitionFile = Files.write(tempDir.resolve("workflow.xml"), "<workflow/>".getBytes());
+        final WorkflowCreateInputData.Builder builder = WorkflowCreateInputData.builder()
+                .workflowName("AutomationExample")
+                .workflowDefinitionFile(definitionFile.toString())
+                .system("SY1")
+                .owner("zosmfad");
+        if (withVarFile) {
+            final Path variableFile = Files.write(tempDir.resolve("vars.properties"), "k=v".getBytes());
+            builder.variableInputFile(variableFile.toString());
+        }
+        return builder.build();
+    }
+
+    @Test
+    public void tstWorkflowCreateLocalDeletesTempFilesSuccess(@TempDir Path tempDir) throws Exception {
+        final UssWrite mockUssWrite = Mockito.mock(UssWrite.class);
+        final UssDelete mockUssDelete = Mockito.mock(UssDelete.class);
+        final WorkflowCreate workflowCreate = workflowCreateWithUss(mockUssWrite, mockUssDelete);
+
+        final WorkflowCreateLocalResponse response = workflowCreate.createLocal(localInputData(tempDir, true));
+
+        // definition and variable files uploaded as binary, then both temp files deleted
+        verify(mockUssWrite, times(2)).writeBinary(any(), any());
+        verify(mockUssDelete, times(2)).delete(any());
+
+        // create request body points at the uploaded USS temp paths, not the local paths
+        final ArgumentCaptor<Object> bodyCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(mockPostJsonZosmfRequest).setBody(bodyCaptor.capture());
+        final JSONObject requestBody = (JSONObject) new JSONParser().parse(bodyCaptor.getValue().toString());
+        assertTrue(requestBody.get("workflowDefinitionFile").toString().startsWith("/tmp/"));
+        assertTrue(requestBody.get("variableInputFile").toString().startsWith("/tmp/"));
+        // non-file fields are preserved through toBuilder
+        assertEquals("AutomationExample", requestBody.get("workflowName"));
+        assertEquals("SY1", requestBody.get("system"));
+        assertEquals("zosmfad", requestBody.get("owner"));
+
+        assertEquals("workflow-key", response.getWorkflow().getWorkflowKey());
+        assertTrue(response.getFilesKept().isEmpty());
+        assertTrue(response.getFailedToDelete().isEmpty());
+    }
+
+    @Test
+    public void tstWorkflowCreateLocalKeepFilesSuccess(@TempDir Path tempDir) throws Exception {
+        final UssWrite mockUssWrite = Mockito.mock(UssWrite.class);
+        final UssDelete mockUssDelete = Mockito.mock(UssDelete.class);
+        final WorkflowCreate workflowCreate = workflowCreateWithUss(mockUssWrite, mockUssDelete);
+
+        final WorkflowCreateLocalResponse response =
+                workflowCreate.createLocal(localInputData(tempDir, true), true, null);
+
+        verify(mockUssDelete, never()).delete(any());
+        assertEquals(2, response.getFilesKept().size());
+        assertTrue(response.getFailedToDelete().isEmpty());
+    }
+
+    @Test
+    public void tstWorkflowCreateLocalCustomDirSuccess(@TempDir Path tempDir) throws Exception {
+        final UssWrite mockUssWrite = Mockito.mock(UssWrite.class);
+        final UssDelete mockUssDelete = Mockito.mock(UssDelete.class);
+        final WorkflowCreate workflowCreate = workflowCreateWithUss(mockUssWrite, mockUssDelete);
+
+        workflowCreate.createLocal(localInputData(tempDir, false), true, "/u/user/uploads");
+
+        final ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockUssWrite).writeBinary(pathCaptor.capture(), any());
+        assertEquals("/u/user/uploads/workflow.xml", pathCaptor.getValue());
+    }
+
+    @Test
+    public void tstWorkflowCreateLocalFailedDeleteTracked(@TempDir Path tempDir) throws Exception {
+        final UssWrite mockUssWrite = Mockito.mock(UssWrite.class);
+        final UssDelete mockUssDelete = Mockito.mock(UssDelete.class);
+        Mockito.when(mockUssDelete.delete(any())).thenThrow(new ZosmfRequestException("delete failed"));
+        final WorkflowCreate workflowCreate = workflowCreateWithUss(mockUssWrite, mockUssDelete);
+
+        final WorkflowCreateLocalResponse response =
+                workflowCreate.createLocal(localInputData(tempDir, false));
+
+        assertEquals(1, response.getFailedToDelete().size());
+        assertTrue(response.getFailedToDelete().get(0).startsWith("/tmp/"));
+        assertTrue(response.getFilesKept().isEmpty());
+    }
+
+    @Test
+    public void tstWorkflowCreateLocalNullInputData() {
+        final WorkflowCreate workflowCreate = new WorkflowCreate(connection, mockPostJsonZosmfRequest);
+        NullPointerException exception = assertThrows(NullPointerException.class,
+                () -> workflowCreate.createLocal(null));
+        assertEquals("createInputData is null", exception.getMessage());
     }
 
 }


### PR DESCRIPTION
## Summary
Ports the node SDK's createWorkflowLocal to WorkflowCreate. Uploads local workflow files to a temporary USS location, creates the workflow against the uploaded paths, and optionally cleans up the temp files.

## Changes
- WorkflowCreate.createLocal(inputData[, keepFiles, customDir]) — reads the local definition file (+ optional variable input file), uploads each as binary via UssWrite, calls create(...) with the uploaded USS paths, then deletes the temps via UssDelete unless keepFiles is set.
- WorkflowCreateLocalResponse — wraps the create response plus filesKept and failedToDelete (mirrors node's ICreatedWorkflowLocal).
- WorkflowCreateInputData.toBuilder() — copy-builder used to swap the local file paths for the uploaded USS paths.
- WorkflowConstants.TEMP_PATH — default temp USS directory.

## Notes
- Temp path: /tmp/<user><timestamp><basename>, or <customDir>/<basename>.
- ussWrite/ussDelete are package-private so tests inject mocks; lazily created
  otherwise.
