### PR TITLE
Switch teamconfig package to Jackson JSON Parsing

### DIFF
--- a/src/main/java/zowe/client/sdk/teamconfig/TeamConfig.java
+++ b/src/main/java/zowe/client/sdk/teamconfig/TeamConfig.java
@@ -9,7 +9,6 @@
  */
 package zowe.client.sdk.teamconfig;
 
-import org.json.simple.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zowe.client.sdk.teamconfig.exception.TeamConfigException;
@@ -42,6 +41,14 @@ public class TeamConfig {
 
     private static final Logger LOG = LoggerFactory.getLogger(TeamConfig.class);
     /**
+     * Base profile constant
+     */
+    private static final String BASE_PROFILE_NAME = "base";
+    /**
+     * Is Base profile predicate?
+     */
+    private static final Predicate<Profile> isBaseProfile = i -> i.getName().equals(BASE_PROFILE_NAME);
+    /**
      * TeamConfigService dependency
      */
     private final TeamConfigService teamConfigService;
@@ -49,14 +56,6 @@ public class TeamConfig {
      * KeyTarService dependency
      */
     private final KeyTarService keyTarService;
-    /**
-     * Base profile constant
-     */
-    private final String BASE_PROFILE_NAME = "base";
-    /**
-     * Is Base profile predicate?
-     */
-    private final Predicate<Profile> isBaseProfile = i -> i.getName().equals(BASE_PROFILE_NAME);
     /**
      * KeyTarConfig dependency
      */
@@ -125,9 +124,14 @@ public class TeamConfig {
         if (target.isEmpty() || !target.get().getType().equalsIgnoreCase(profileType)) {
             throw new IllegalStateException("Found no profile of type " + profileType + " in Zowe client configuration.");
         } else {
-            target = Optional.of(merge(target.orElse(null), base.orElse(null)));
-            return new ProfileDao(target.get(), keyTarConfig.getUserName(), keyTarConfig.getPassword(),
-                    target.get().getProperties().get("host"), target.get().getProperties().get("port"));
+            final Profile merged = merge(target.get(), base.orElse(null));
+            return new ProfileDao(
+                    merged,
+                    keyTarConfig.getUserName(),
+                    keyTarConfig.getPassword(),
+                    merged.getProperties().get("host"),
+                    merged.getProperties().get("port")
+            );
         }
     }
 
@@ -160,9 +164,14 @@ public class TeamConfig {
             throw new IllegalStateException("Found no " + profileName + " within Zowe client configuration partition");
         }
 
-        target = Optional.of(merge(target.orElse(null), base.orElse(null)));
-        return new ProfileDao(target.get(), keyTarConfig.getUserName(), keyTarConfig.getPassword(),
-                target.get().getProperties().get("host"), target.get().getProperties().get("port"));
+        final Profile merged = merge(target.get(), base.orElse(null));
+        return new ProfileDao(
+                merged,
+                keyTarConfig.getUserName(),
+                keyTarConfig.getPassword(),
+                merged.getProperties().get("host"),
+                merged.getProperties().get("port")
+        );
     }
 
     /**
@@ -171,10 +180,9 @@ public class TeamConfig {
      * @param target Profile object
      * @param base   Profile object
      * @return target profile object
-     * @throws TeamConfigException error processing team configuration
      * @author Frank Giordano
      */
-    private Profile merge(Profile target, final Profile base) throws TeamConfigException {
+    private Profile merge(final Profile target, final Profile base) {
         Optional<Map<String, String>> targetProps = Optional.empty();
         Optional<Map<String, String>> baseProps = Optional.empty();
         if (target != null) {
@@ -193,7 +201,7 @@ public class TeamConfig {
                                     Map.Entry::getKey,
                                     Map.Entry::getValue,
                                     (oldValue, newValue) -> oldValue));
-            return new Profile(target.getName(), target.getType(), new JSONObject(mergedMap), target.getSecure());
+            return new Profile(target.getName(), target.getType(), mergedMap, target.getSecure());
         }
 
         return target;

--- a/src/main/java/zowe/client/sdk/teamconfig/model/Profile.java
+++ b/src/main/java/zowe/client/sdk/teamconfig/model/Profile.java
@@ -9,12 +9,8 @@
  */
 package zowe.client.sdk.teamconfig.model;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
-import zowe.client.sdk.teamconfig.exception.TeamConfigException;
-import zowe.client.sdk.utility.JsonUtils;
-
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -23,6 +19,7 @@ import java.util.Map;
  * @author Frank Giordano
  * @version 7.0
  */
+
 public class Profile {
 
     /**
@@ -36,35 +33,31 @@ public class Profile {
     private final String type;
 
     /**
-     * Profile secure json object
-     */
-    private final JSONArray secure;
-
-    /**
      * Profile property values
      */
     private final Map<String, String> properties;
 
     /**
-     * Partition constructor
-     *
-     * @param name   profile name
-     * @param type   profile type
-     * @param obj    JSON object of property values within a profile section from Zowe Global Team Configuration
-     * @param secure jsonarray value of a secure section
-     * @throws TeamConfigException error processing team configuration
-     * @author Frank Giordano
+     * Profile secure List object
      */
-    public Profile(final String name, final String type, final JSONObject obj, final JSONArray secure)
-            throws TeamConfigException {
+    private final List<String> secure;
+
+    /**
+     * Profile constructor
+     *
+     * @param name       profile name
+     * @param type       profile type
+     * @param properties property values
+     * @param secure     secure List object
+     */
+    public Profile(final String name,
+                   final String type,
+                   final Map<String, String> properties,
+                   final List<String> secure) {
         this.name = name;
         this.type = type;
-        try {
-            this.properties = JsonUtils.parseMap(obj);
-        } catch (JsonProcessingException e) {
-            throw new TeamConfigException("Error parsing properties", e);
-        }
-        this.secure = secure;
+        this.properties = properties != null ? properties : Collections.emptyMap();
+        this.secure = secure != null ? secure : Collections.emptyList();
     }
 
     /**
@@ -97,9 +90,9 @@ public class Profile {
     /**
      * Return secure value
      *
-     * @return secure JSON object
+     * @return secure List object
      */
-    public JSONArray getSecure() {
+    public List<String> getSecure() {
         return secure;
     }
 

--- a/src/main/java/zowe/client/sdk/teamconfig/service/TeamConfigService.java
+++ b/src/main/java/zowe/client/sdk/teamconfig/service/TeamConfigService.java
@@ -9,11 +9,8 @@
  */
 package zowe.client.sdk.teamconfig.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zowe.client.sdk.teamconfig.exception.TeamConfigException;
@@ -21,13 +18,14 @@ import zowe.client.sdk.teamconfig.keytar.KeyTarConfig;
 import zowe.client.sdk.teamconfig.model.ConfigContainer;
 import zowe.client.sdk.teamconfig.model.Partition;
 import zowe.client.sdk.teamconfig.model.Profile;
-import zowe.client.sdk.teamconfig.types.SectionType;
-import zowe.client.sdk.utility.JsonUtils;
 import zowe.client.sdk.utility.ValidateUtils;
 
-import java.io.FileReader;
+import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * TeamConfigService class that provides a service layer to perform Zowe Global Team Configuration processing.
@@ -38,48 +36,13 @@ import java.util.*;
 public class TeamConfigService {
 
     private static final Logger LOG = LoggerFactory.getLogger(TeamConfigService.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     /**
      * Create a new TeamConfigService instance.
      */
     public TeamConfigService() {
         // intentionally empty
-    }
-
-    /**
-     * Parse a JSON representation of a Zowe Global Team Configuration partition section.
-     *
-     * @param name       partition name
-     * @param jsonObject JSONObject object
-     * @return Partition object
-     * @author Frank Giordano
-     */
-    @SuppressWarnings("unchecked")
-    private Partition getPartition(final String name, final JSONObject jsonObject) throws TeamConfigException {
-        final Set<String> keyObjs = jsonObject.keySet();
-        final List<Profile> profiles = new ArrayList<>();
-        Map<String, String> properties = new HashMap<>();
-        LOG.debug("partition found name {} containing {}:", name, jsonObject);
-        for (final String keyObj : keyObjs) {
-            if (SectionType.PROFILES.getValue().equals(keyObj)) {
-                JSONObject jsonProfileObj = (JSONObject) jsonObject.get(SectionType.PROFILES.getValue());
-                final Set<String> jsonProfileKeys = jsonProfileObj.keySet();
-                for (final String profileKeyVal : jsonProfileKeys) {
-                    final JSONObject profileTypeJsonObj = (JSONObject) jsonProfileObj.get(profileKeyVal);
-                    profiles.add(new Profile(profileKeyVal,
-                            (String) profileTypeJsonObj.get("type"),
-                            (JSONObject) profileTypeJsonObj.get("properties"),
-                            (JSONArray) profileTypeJsonObj.get("secure")));
-                }
-            } else if ("properties".equalsIgnoreCase(keyObj)) {
-                try {
-                    properties = JsonUtils.parseMap((JSONObject) jsonObject.get(keyObj));
-                } catch (JsonProcessingException e) {
-                    throw new TeamConfigException("Error parsing properties", e);
-                }
-            }
-        }
-        return new Partition(name, properties, profiles);
     }
 
     /**
@@ -92,80 +55,113 @@ public class TeamConfigService {
      */
     public ConfigContainer getTeamConfig(final KeyTarConfig config) throws TeamConfigException {
         ValidateUtils.checkNullParameter(config, "config");
-        final JSONParser parser = new JSONParser();
-        Object obj;
+        final JsonNode root;
         try {
-            obj = parser.parse(new FileReader(config.getLocation()));
-        } catch (IOException | ParseException e) {
+            root = MAPPER.readTree(new File(config.getLocation()));
+        } catch (IOException e) {
             throw new TeamConfigException("Error reading zowe global team configuration file", e);
         }
-        return parseJson((JSONObject) obj);
+        return parseJson(root);
     }
 
     /**
-     * Determine if JSON contains a partition section next.
+     * Parse the root JSON node of a Zowe Global Team Configuration file into a ConfigContainer.
      *
-     * @param profileKeyObj partition name
-     * @return boolean true or false
-     * @author Frank Giordano
-     */
-    private boolean isPartition(final Set<String> profileKeyObj) {
-        final Iterator<String> itr = profileKeyObj.iterator();
-        if (itr.hasNext()) {
-            String keyVal = itr.next();
-            return SectionType.PROFILES.getValue().equals(keyVal);
-        } else {
-            throw new IllegalStateException("TeamConfig profile type detail missing in profile section.");
-        }
-    }
-
-    /**
-     * Parse a JSON representation of a Zowe Global Team Configuration file.
-     *
-     * @param jsonObj JSONObject object
+     * @param root root JsonNode of the configuration file
      * @return ConfigContainer object
      * @author Frank Giordano
      */
-    @SuppressWarnings("unchecked")
-    private ConfigContainer parseJson(final JSONObject jsonObj) throws TeamConfigException {
-        String schema = null;
-        Boolean autoStore = null;
+    private ConfigContainer parseJson(final JsonNode root) {
+        final String schema = root.path("$schema").asText(null);
+        final Boolean autoStore = root.has("autoStore") ? root.get("autoStore").asBoolean() : null;
         final List<Profile> profiles = new ArrayList<>();
-        final Map<String, String> defaults = new HashMap<>();
         final List<Partition> partitions = new ArrayList<>();
+        final Map<String, String> defaults = new HashMap<>();
 
-        final Set<String> jsonSectionKeys = jsonObj.keySet();
-        for (final String keySectionVal : jsonSectionKeys) {
-            if (SectionType.$SCHEMA.getValue().equals(keySectionVal)) {
-                schema = (String) jsonObj.get(SectionType.$SCHEMA.getValue());
-            } else if (SectionType.PROFILES.getValue().equals(keySectionVal)) {
-                final JSONObject jsonProfileObj = (JSONObject) jsonObj.get(SectionType.PROFILES.getValue());
-                final Set<String> jsonProfileKeys = jsonProfileObj.keySet();
-                for (final String profileKeyVal : jsonProfileKeys) {
-                    JSONObject profileTypeJsonObj = (JSONObject) jsonProfileObj.get(profileKeyVal);
-                    final Set<String> isEmbeddedKeyProfile = profileTypeJsonObj.keySet();
-                    if (isPartition(isEmbeddedKeyProfile)) {
-                        partitions.add(getPartition(profileKeyVal, profileTypeJsonObj));
-                    } else {
-                        profiles.add(new Profile(profileKeyVal,
-                                (String) profileTypeJsonObj.get("type"),
-                                (JSONObject) profileTypeJsonObj.get("properties"),
-                                (JSONArray) profileTypeJsonObj.get("secure")));
-                    }
+        final JsonNode defaultsNode = root.path("defaults");
+        if (defaultsNode.isObject()) {
+            defaultsNode.properties().forEach(e -> defaults.put(e.getKey(), e.getValue().asText()));
+        }
+
+        final JsonNode profilesNode = root.path("profiles");
+        if (profilesNode.isObject()) {
+            profilesNode.properties().forEach(e -> {
+                final String name = e.getKey();
+                final JsonNode node = e.getValue();
+                if (node.has("profiles")) {
+                    partitions.add(getPartition(name, node));
+                } else {
+                    profiles.add(buildProfile(name, node));
                 }
-            } else if (SectionType.DEFAULTS.getValue().equals(keySectionVal)) {
-                final JSONObject keyValues = (JSONObject) jsonObj.get(SectionType.DEFAULTS.getValue());
-                for (final Object defaultKeyVal : keyValues.keySet()) {
-                    final String key = (String) defaultKeyVal;
-                    final String value = (String) keyValues.get(key);
-                    defaults.put(key, value);
-                }
-            } else if (SectionType.AUTOSTORE.getValue().equals(keySectionVal)) {
-                autoStore = (boolean) jsonObj.get(SectionType.AUTOSTORE.getValue());
-            }
+            });
         }
 
         return new ConfigContainer(partitions, schema, profiles, defaults, autoStore);
+    }
+
+    /**
+     * Build a Partition object from a named JSON node that contains a nested profiles section.
+     *
+     * @param name partition name
+     * @param node JsonNode representing the partition
+     * @return Partition object
+     * @author Frank Giordano
+     */
+    private Partition getPartition(final String name, final JsonNode node) {
+        LOG.debug("partition found name {} containing: {}", name, node);
+        final Map<String, String> properties = parseProperties(node.path("properties"));
+        final List<Profile> nestedProfiles = new ArrayList<>();
+        final JsonNode nestedProfilesNode = node.path("profiles");
+        if (nestedProfilesNode.isObject()) {
+            nestedProfilesNode.properties().forEach(e ->
+                    nestedProfiles.add(buildProfile(e.getKey(), e.getValue())));
+        }
+        return new Partition(name, properties, nestedProfiles);
+    }
+
+    /**
+     * Build a Profile object from a named JSON node.
+     *
+     * @param name profile name
+     * @param node JsonNode representing the profile
+     * @return Profile object
+     * @author Frank Giordano
+     */
+    private Profile buildProfile(final String name, final JsonNode node) {
+        final String type = node.path("type").asText(null);
+        final Map<String, String> properties = parseProperties(node.path("properties"));
+        final List<String> secure = parseSecure(node.path("secure"));
+        return new Profile(name, type, properties, secure);
+    }
+
+    /**
+     * Parse a properties JSON node into a key/value map.
+     *
+     * @param propertiesNode JsonNode representing the properties section
+     * @return map of property key/value pairs
+     * @author Frank Giordano
+     */
+    private Map<String, String> parseProperties(final JsonNode propertiesNode) {
+        final Map<String, String> map = new HashMap<>();
+        if (propertiesNode.isObject()) {
+            propertiesNode.properties().forEach(e -> map.put(e.getKey(), e.getValue().asText()));
+        }
+        return map;
+    }
+
+    /**
+     * Parse a secure JSON array node into a list of field names.
+     *
+     * @param secureNode JsonNode representing the secure array
+     * @return list of secure field names
+     * @author Frank Giordano
+     */
+    private List<String> parseSecure(final JsonNode secureNode) {
+        final List<String> list = new ArrayList<>();
+        if (secureNode.isArray()) {
+            secureNode.forEach(item -> list.add(item.asText()));
+        }
+        return list;
     }
 
 }

--- a/src/test/java/zowe/client/sdk/teamconfig/TeamConfigServiceTest.java
+++ b/src/test/java/zowe/client/sdk/teamconfig/TeamConfigServiceTest.java
@@ -1,0 +1,346 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.teamconfig;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import zowe.client.sdk.teamconfig.model.ConfigContainer;
+import zowe.client.sdk.teamconfig.model.Profile;
+import zowe.client.sdk.teamconfig.service.TeamConfigService;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Class containing unit tests for TeamConfigService.parseJson method.
+ *
+ * @author Frank Giordano
+ * @version 7.0
+ */
+public class TeamConfigServiceTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /**
+     * Strip single-line comments (# ...) from a JSON-like string so it can be parsed as valid JSON.
+     */
+    private static String stripComments(final String input) {
+        return input.lines()
+                .map(line -> {
+                    final int idx = line.indexOf('#');
+                    return idx >= 0 ? line.substring(0, idx) : line;
+                })
+                .collect(java.util.stream.Collectors.joining("\n"));
+    }
+
+    /**
+     * Invoke the private parseJson method on TeamConfigService via reflection.
+     */
+    private ConfigContainer invokeParseJson(final JsonNode root) throws Exception {
+        final TeamConfigService service = new TeamConfigService();
+        final Method method = TeamConfigService.class.getDeclaredMethod("parseJson", JsonNode.class);
+        method.setAccessible(true);
+        return (ConfigContainer) method.invoke(service, root);
+    }
+
+    @Test
+    public void tstParseJsonFlatProfilesConfig() throws Exception {
+        final String json = stripComments(
+                "{\n" +
+                        "  \"$schema\": \"./zowe.schema.json\",\n" +
+                        "  \"profiles\": {\n" +
+                        "    \"zosmf\": {\n" +
+                        "      \"type\": \"zosmf\",\n" +
+                        "      \"properties\": {\n" +
+                        "        \"port\": 443\n" +
+                        "      },\n" +
+                        "      \"secure\": []\n" +
+                        "    },\n" +
+                        "    \"tso\": {\n" +
+                        "      \"type\": \"tso\",\n" +
+                        "      \"properties\": {\n" +
+                        "        \"account\": \"\",\n" +
+                        "        \"codePage\": \"1047\",\n" +
+                        "        \"logonProcedure\": \"IZUFPROC\"\n" +
+                        "      },\n" +
+                        "      \"secure\": []\n" +
+                        "    },\n" +
+                        "    \"ssh\": {\n" +
+                        "      \"type\": \"ssh\",\n" +
+                        "      \"properties\": {\n" +
+                        "        \"port\": 22\n" +
+                        "      },\n" +
+                        "      \"secure\": []\n" +
+                        "    },\n" +
+                        "    \"rse\": {\n" +
+                        "      \"type\": \"rse\",\n" +
+                        "      \"properties\": {\n" +
+                        "        \"port\": 6800,\n" +
+                        "        \"basePath\": \"rseapi\",\n" +
+                        "        \"protocol\": \"https\"\n" +
+                        "      },\n" +
+                        "      \"secure\": []\n" +
+                        "    },\n" +
+                        "    # common properties can be defined in the base profile instead of defining them in every profile\n" +
+                        "    \"base\": {\n" +
+                        "      \"type\": \"base\",\n" +
+                        "      \"properties\": {\n" +
+                        "        \"host\": \"myzos.ibm.com\",\n" +
+                        "        # reject connection if self-signed certificate is used\n" +
+                        "        \"rejectUnauthorized\": true\n" +
+                        "      },\n" +
+                        "      # these secure fields will determine the values written to and stored in the OS credential manager.\n" +
+                        "      \"secure\": [\"user\", \"password\"]\n" +
+                        "    }\n" +
+                        "  },\n" +
+                        "  \"defaults\": {\n" +
+                        "    \"zosmf\": \"zosmf\",\n" +
+                        "    \"tso\": \"tso\",\n" +
+                        "    \"ssh\": \"ssh\",\n" +
+                        "    \"rse\": \"rse\",\n" +
+                        "    \"base\": \"base\"\n" +
+                        "  },\n" +
+                        "  # setting determines if information is written to the file or credential manager\n" +
+                        "  \"autoStore\": true\n" +
+                        "}"
+        );
+
+        final JsonNode root = MAPPER.readTree(json);
+        final ConfigContainer container = invokeParseJson(root);
+
+        // validate schema
+        assertEquals("./zowe.schema.json", container.getSchema());
+
+        // validate autoStore
+        assertTrue(container.isAutoStore());
+
+        // validate defaults
+        final Map<String, String> defaults = container.getDefaults();
+        assertEquals(5, defaults.size());
+        assertEquals("zosmf", defaults.get("zosmf"));
+        assertEquals("tso", defaults.get("tso"));
+        assertEquals("ssh", defaults.get("ssh"));
+        assertEquals("rse", defaults.get("rse"));
+        assertEquals("base", defaults.get("base"));
+
+        // validate no partitions
+        assertTrue(container.getPartitions().isEmpty());
+
+        // validate profiles
+        final List<Profile> profiles = container.getProfiles();
+        assertEquals(5, profiles.size());
+
+        // zosmf profile
+        final Profile zosmf = profiles.stream().filter(p -> "zosmf".equals(p.getName())).findFirst().orElseThrow();
+        assertEquals("zosmf", zosmf.getType());
+        assertEquals("443", zosmf.getProperties().get("port"));
+        assertTrue(zosmf.getSecure().isEmpty());
+
+        // tso profile
+        final Profile tso = profiles.stream().filter(p -> "tso".equals(p.getName())).findFirst().orElseThrow();
+        assertEquals("tso", tso.getType());
+        assertEquals("", tso.getProperties().get("account"));
+        assertEquals("1047", tso.getProperties().get("codePage"));
+        assertEquals("IZUFPROC", tso.getProperties().get("logonProcedure"));
+        assertTrue(tso.getSecure().isEmpty());
+
+        // ssh profile
+        final Profile ssh = profiles.stream().filter(p -> "ssh".equals(p.getName())).findFirst().orElseThrow();
+        assertEquals("ssh", ssh.getType());
+        assertEquals("22", ssh.getProperties().get("port"));
+        assertTrue(ssh.getSecure().isEmpty());
+
+        // rse profile
+        final Profile rse = profiles.stream().filter(p -> "rse".equals(p.getName())).findFirst().orElseThrow();
+        assertEquals("rse", rse.getType());
+        assertEquals("6800", rse.getProperties().get("port"));
+        assertEquals("rseapi", rse.getProperties().get("basePath"));
+        assertEquals("https", rse.getProperties().get("protocol"));
+        assertTrue(rse.getSecure().isEmpty());
+
+        // base profile
+        final Profile base = profiles.stream().filter(p -> "base".equals(p.getName())).findFirst().orElseThrow();
+        assertEquals("base", base.getType());
+        assertEquals("myzos.ibm.com", base.getProperties().get("host"));
+        assertEquals("true", base.getProperties().get("rejectUnauthorized"));
+        assertEquals(List.of("user", "password"), base.getSecure());
+    }
+
+    @Test
+    public void tstParseJsonNestedLparConfig() throws Exception {
+        final String json = stripComments(
+                "{\n" +
+                        "  \"$schema\": \"./zowe.schema.json\",\n" +
+                        "  \"profiles\": {\n" +
+                        "    \"lpar1\": {\n" +
+                        "      \"properties\": {\n" +
+                        "        \"host\": \"lpar1.com\",\n" +
+                        "        \"rejectUnauthorized\": false\n" +
+                        "      },\n" +
+                        "      \"secure\": [\"user\", \"password\"],\n" +
+                        "      # Example of shared credentials across LPAR profiles\n" +
+                        "      \"profiles\": {\n" +
+                        "        \"zosmf\": {\n" +
+                        "          \"type\": \"zosmf\",\n" +
+                        "          \"properties\": {\n" +
+                        "            \"port\": 443\n" +
+                        "          }\n" +
+                        "        },\n" +
+                        "        \"rse\": {\n" +
+                        "          \"type\": \"rse\",\n" +
+                        "          \"properties\": {\n" +
+                        "            \"port\": 6800,\n" +
+                        "            \"basePath\": \"rseapi\",\n" +
+                        "            \"protocol\": \"https\"\n" +
+                        "          }\n" +
+                        "        },\n" +
+                        "        \"ssh\": {\n" +
+                        "          \"type\": \"ssh\",\n" +
+                        "          \"properties\": {\n" +
+                        "            \"port\": 22\n" +
+                        "          }\n" +
+                        "        }\n" +
+                        "      }\n" +
+                        "    },\n" +
+                        "    \"lpar2\": {\n" +
+                        "      \"properties\": {\n" +
+                        "        \"host\": \"lpar2.com\",\n" +
+                        "        \"rejectUnauthorized\": false\n" +
+                        "      },\n" +
+                        "      \"profiles\": {\n" +
+                        "        \"zosmf\": {\n" +
+                        "          \"type\": \"zosmf\",\n" +
+                        "          \"properties\": {\n" +
+                        "            \"port\": 443\n" +
+                        "          },\n" +
+                        "          \"secure\": [\"user\", \"password\"]\n" +
+                        "          # Example of credentials that are profile specific\n" +
+                        "        },\n" +
+                        "        \"ssh\": {\n" +
+                        "          \"type\": \"ssh\",\n" +
+                        "          \"properties\": {\n" +
+                        "            \"port\": 22\n" +
+                        "          },\n" +
+                        "          \"secure\": [\"user\", \"password\"]\n" +
+                        "        }\n" +
+                        "      }\n" +
+                        "    },\n" +
+                        "    \"lpar3\": {\n" +
+                        "      \"properties\": {\n" +
+                        "        \"host\": \"lpar3.com\",\n" +
+                        "        \"rejectUnauthorized\": false\n" +
+                        "      },\n" +
+                        "      \"secure\": [\"user\", \"password\"],\n" +
+                        "      \"profiles\": {\n" +
+                        "        \"zosmf\": {\n" +
+                        "          \"type\": \"zosmf\",\n" +
+                        "          \"properties\": {\n" +
+                        "            \"port\": 3128,\n" +
+                        "            \"protocol\": \"http\"\n" +
+                        "          }\n" +
+                        "        }\n" +
+                        "      }\n" +
+                        "    }\n" +
+                        "  },\n" +
+                        "  \"defaults\": {\n" +
+                        "    \"zosmf\": \"lpar1.zosmf\",\n" +
+                        "    \"ssh\": \"lpar1.ssh\",\n" +
+                        "    \"rse\": \"lpar1.rse\"\n" +
+                        "  },\n" +
+                        "  \"autoStore\": true\n" +
+                        "}"
+        );
+
+        final JsonNode root = MAPPER.readTree(json);
+        final ConfigContainer container = invokeParseJson(root);
+
+        // validate schema
+        assertEquals("./zowe.schema.json", container.getSchema());
+
+        // validate autoStore
+        assertTrue(container.isAutoStore());
+
+        // validate defaults
+        final Map<String, String> defaults = container.getDefaults();
+        assertEquals(3, defaults.size());
+        assertEquals("lpar1.zosmf", defaults.get("zosmf"));
+        assertEquals("lpar1.ssh", defaults.get("ssh"));
+        assertEquals("lpar1.rse", defaults.get("rse"));
+
+        // validate no flat profiles (all are partitions)
+        assertTrue(container.getProfiles().isEmpty());
+
+        // validate 3 partitions
+        final List<zowe.client.sdk.teamconfig.model.Partition> partitions = container.getPartitions();
+        assertEquals(3, partitions.size());
+
+        // --- lpar1 ---
+        final zowe.client.sdk.teamconfig.model.Partition lpar1 =
+                partitions.stream().filter(p -> "lpar1".equals(p.getName())).findFirst().orElseThrow();
+        assertEquals("lpar1.com", lpar1.getProperties().get("host"));
+        assertEquals("false", lpar1.getProperties().get("rejectUnauthorized"));
+
+        final List<Profile> lpar1Profiles = lpar1.getProfiles();
+        assertEquals(3, lpar1Profiles.size());
+
+        final Profile lpar1Zosmf = lpar1Profiles.stream().filter(p -> "zosmf".equals(p.getName())).findFirst().orElseThrow();
+        assertEquals("zosmf", lpar1Zosmf.getType());
+        assertEquals("443", lpar1Zosmf.getProperties().get("port"));
+
+        final Profile lpar1Rse = lpar1Profiles.stream().filter(p -> "rse".equals(p.getName())).findFirst().orElseThrow();
+        assertEquals("rse", lpar1Rse.getType());
+        assertEquals("6800", lpar1Rse.getProperties().get("port"));
+        assertEquals("rseapi", lpar1Rse.getProperties().get("basePath"));
+        assertEquals("https", lpar1Rse.getProperties().get("protocol"));
+
+        final Profile lpar1Ssh = lpar1Profiles.stream().filter(p -> "ssh".equals(p.getName())).findFirst().orElseThrow();
+        assertEquals("ssh", lpar1Ssh.getType());
+        assertEquals("22", lpar1Ssh.getProperties().get("port"));
+
+        // --- lpar2 ---
+        final zowe.client.sdk.teamconfig.model.Partition lpar2 =
+                partitions.stream().filter(p -> "lpar2".equals(p.getName())).findFirst().orElseThrow();
+        assertEquals("lpar2.com", lpar2.getProperties().get("host"));
+        assertEquals("false", lpar2.getProperties().get("rejectUnauthorized"));
+
+        final List<Profile> lpar2Profiles = lpar2.getProfiles();
+        assertEquals(2, lpar2Profiles.size());
+
+        final Profile lpar2Zosmf = lpar2Profiles.stream().filter(p -> "zosmf".equals(p.getName())).findFirst().orElseThrow();
+        assertEquals("zosmf", lpar2Zosmf.getType());
+        assertEquals("443", lpar2Zosmf.getProperties().get("port"));
+        assertEquals(List.of("user", "password"), lpar2Zosmf.getSecure());
+
+        final Profile lpar2Ssh = lpar2Profiles.stream().filter(p -> "ssh".equals(p.getName())).findFirst().orElseThrow();
+        assertEquals("ssh", lpar2Ssh.getType());
+        assertEquals("22", lpar2Ssh.getProperties().get("port"));
+        assertEquals(List.of("user", "password"), lpar2Ssh.getSecure());
+
+        // --- lpar3 ---
+        final zowe.client.sdk.teamconfig.model.Partition lpar3 =
+                partitions.stream().filter(p -> "lpar3".equals(p.getName())).findFirst().orElseThrow();
+        assertEquals("lpar3.com", lpar3.getProperties().get("host"));
+        assertEquals("false", lpar3.getProperties().get("rejectUnauthorized"));
+
+        final List<Profile> lpar3Profiles = lpar3.getProfiles();
+        assertEquals(1, lpar3Profiles.size());
+
+        final Profile lpar3Zosmf = lpar3Profiles.stream().filter(p -> "zosmf".equals(p.getName())).findFirst().orElseThrow();
+        assertEquals("zosmf", lpar3Zosmf.getType());
+        assertEquals("3128", lpar3Zosmf.getProperties().get("port"));
+        assertEquals("http", lpar3Zosmf.getProperties().get("protocol"));
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/teamconfig/TeamConfigTest.java
+++ b/src/test/java/zowe/client/sdk/teamconfig/TeamConfigTest.java
@@ -9,13 +9,13 @@
  */
 package zowe.client.sdk.teamconfig;
 
-import org.json.simple.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import zowe.client.sdk.teamconfig.exception.TeamConfigException;
 import zowe.client.sdk.teamconfig.keytar.KeyTarConfig;
 import zowe.client.sdk.teamconfig.model.ConfigContainer;
+import zowe.client.sdk.teamconfig.model.Partition;
 import zowe.client.sdk.teamconfig.model.Profile;
 import zowe.client.sdk.teamconfig.model.ProfileDao;
 import zowe.client.sdk.teamconfig.service.KeyTarService;
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 
 /**
@@ -46,8 +47,7 @@ public class TeamConfigTest {
 
     @Test
     public void tstTeamConfigGetDefaultProfileFailure() throws TeamConfigException {
-        final JSONObject props = new JSONObject(Map.of("port", "433"));
-        final List<Profile> profiles = List.of(new Profile("frank1", "zosmf", props, null));
+        final List<Profile> profiles = List.of(new Profile("frank1", "zosmf", Map.of("port", "433"), null));
         final Map<String, String> defaults = Map.of("zosmf", "frank");
         Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(
                 new ConfigContainer(null, null, profiles, defaults, null));
@@ -71,8 +71,7 @@ public class TeamConfigTest {
 
     @Test
     public void tstTeamConfigGetDefaultProfileTypeNotFoundFailure() throws TeamConfigException {
-        final JSONObject props = new JSONObject(Map.of("port", "433"));
-        final List<Profile> profiles = List.of(new Profile("frank", "zosmf1", props, null));
+        final List<Profile> profiles = List.of(new Profile("frank", "zosmf1", Map.of("port", "433"), null));
         final Map<String, String> defaults = Map.of("zosmf", "frank");
         Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(
                 new ConfigContainer(null, null, profiles, defaults, null));
@@ -96,8 +95,7 @@ public class TeamConfigTest {
 
     @Test
     public void tstTeamConfigGetDefaultProfileSuccess() throws TeamConfigException {
-        final JSONObject props = new JSONObject(Map.of("port", "433"));
-        final List<Profile> profiles = List.of(new Profile("frank", "zosmf", props, null));
+        final List<Profile> profiles = List.of(new Profile("frank", "zosmf", Map.of("port", "433"), null));
         final Map<String, String> defaults = Map.of("zosmf", "frank");
         Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(
                 new ConfigContainer(null, null, profiles, defaults, null));
@@ -124,8 +122,7 @@ public class TeamConfigTest {
 
     @Test
     public void tstTeamConfigGetDefaultProfileHostAndPortValuesSuccess() throws TeamConfigException {
-        final JSONObject props = new JSONObject(Map.of("port", "433", "host", "host"));
-        final List<Profile> profiles = List.of(new Profile("frank", "zosmf", props, null));
+        final List<Profile> profiles = List.of(new Profile("frank", "zosmf", Map.of("port", "433", "host", "host"), null));
         final Map<String, String> defaults = Map.of("zosmf", "frank");
         Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(
                 new ConfigContainer(null, null, profiles, defaults, null));
@@ -140,10 +137,8 @@ public class TeamConfigTest {
 
     @Test
     public void tstTeamConfigGetDefaultProfileMergeNonBaseHostValueSuccess() throws TeamConfigException {
-        final JSONObject props = new JSONObject(Map.of("port", "433", "host", "host"));
-        final JSONObject baseProps = new JSONObject(Map.of("port", "433", "host", "host1"));
-        final List<Profile> profiles = List.of(new Profile("frank", "zosmf", props, null),
-                new Profile("base", "base", baseProps, null));
+        final List<Profile> profiles = List.of(new Profile("frank", "zosmf", Map.of("port", "433", "host", "host"), null),
+                new Profile("base", "base", Map.of("port", "433", "host", "host1"), null));
         final Map<String, String> defaults = Map.of("zosmf", "frank");
         Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(
                 new ConfigContainer(null, null, profiles, defaults, null));
@@ -157,10 +152,8 @@ public class TeamConfigTest {
 
     @Test
     public void tstTeamConfigGetDefaultProfileMergeBaseHostValueSuccess() throws TeamConfigException {
-        final JSONObject props = new JSONObject(Map.of("port", "433"));
-        final JSONObject baseProps = new JSONObject(Map.of("port", "433", "host", "host1"));
-        final List<Profile> profiles = List.of(new Profile("frank", "zosmf", props, null),
-                new Profile("base", "base", baseProps, null));
+        final List<Profile> profiles = List.of(new Profile("frank", "zosmf", Map.of("port", "433"), null),
+                new Profile("base", "base", Map.of("port", "433", "host", "host1"), null));
         final Map<String, String> defaults = Map.of("zosmf", "frank");
         Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(
                 new ConfigContainer(null, null, profiles, defaults, null));
@@ -174,8 +167,7 @@ public class TeamConfigTest {
 
     @Test
     public void tstTeamConfigGetDefaultProfileUserNameAndPasswordValuesSuccess() throws TeamConfigException {
-        final JSONObject props = new JSONObject(Map.of("port", "433"));
-        final List<Profile> profiles = List.of(new Profile("frank", "zosmf", props, null));
+        final List<Profile> profiles = List.of(new Profile("frank", "zosmf", Map.of("port", "433"), null));
         final Map<String, String> defaults = Map.of("zosmf", "frank");
         Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(
                 new ConfigContainer(null, null, profiles, defaults, null));
@@ -186,6 +178,246 @@ public class TeamConfigTest {
         final ProfileDao profileDao = teamConfig.getDefaultProfile("zosmf");
         assertEquals("username", profileDao.getUser());
         assertEquals("pwd", profileDao.getPassword());
+    }
+
+    @Test
+    public void tstTeamConfigGetDefaultProfileFromPartitionPartitionNotFoundFailure() throws TeamConfigException {
+        final List<Profile> partitionProfiles = List.of(new Profile("lpar1zosmf", "zosmf", Map.of("host", "lpar1.example.com", "port", "443"), null));
+        final Partition partition = new Partition("lpar1", Map.of(), partitionProfiles);
+        Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(
+                new ConfigContainer(List.of(partition), null, List.of(), Map.of(), null));
+        Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
+                new KeyTarConfig("", "username", "pwd"));
+
+        final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
+        String errMsg = "";
+        try {
+            teamConfig.getDefaultProfileFromPartition("lpar1zosmf", "nonexistent");
+        } catch (Exception e) {
+            errMsg = e.getMessage();
+        }
+        assertEquals("Found no nonexistent in Zowe client configuration.", errMsg);
+    }
+
+    @Test
+    public void tstTeamConfigGetDefaultProfileFromPartitionProfileNotFoundFailure() throws TeamConfigException {
+        final List<Profile> partitionProfiles = List.of(new Profile("lpar1zosmf", "zosmf", Map.of("host", "lpar1.example.com", "port", "443"), null));
+        final Partition partition = new Partition("lpar1", Map.of(), partitionProfiles);
+        Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(
+                new ConfigContainer(List.of(partition), null, List.of(), Map.of(), null));
+        Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
+                new KeyTarConfig("", "username", "pwd"));
+
+        final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
+        String errMsg = "";
+        try {
+            teamConfig.getDefaultProfileFromPartition("nonexistent", "lpar1");
+        } catch (Exception e) {
+            errMsg = e.getMessage();
+        }
+        assertEquals("Found no nonexistent within Zowe client configuration partition", errMsg);
+    }
+
+    @Test
+    public void tstTeamConfigGetDefaultProfileFromPartitionSuccess() throws TeamConfigException {
+        final List<Profile> partitionProfiles = List.of(new Profile("lpar1zosmf", "zosmf", Map.of("host", "lpar1.example.com", "port", "443"), null));
+        final Partition partition = new Partition("lpar1", Map.of(), partitionProfiles);
+        Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(
+                new ConfigContainer(List.of(partition), null, List.of(), Map.of(), null));
+        Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
+                new KeyTarConfig("", "username", "pwd"));
+
+        final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
+        final ProfileDao profileDao = teamConfig.getDefaultProfileFromPartition("lpar1zosmf", "lpar1");
+        assertNotNull(profileDao);
+        assertEquals("lpar1zosmf", profileDao.getProfile().getName());
+        assertEquals("lpar1.example.com", profileDao.getHost());
+        assertEquals("443", profileDao.getPort());
+    }
+
+    @Test
+    public void tstTeamConfigGetDefaultProfileFromPartitionUserNameAndPasswordSuccess() throws TeamConfigException {
+        final List<Profile> partitionProfiles = List.of(new Profile("lpar1zosmf", "zosmf", Map.of("host", "lpar1.example.com", "port", "443"), null));
+        final Partition partition = new Partition("lpar1", Map.of(), partitionProfiles);
+        Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(
+                new ConfigContainer(List.of(partition), null, List.of(), Map.of(), null));
+        Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
+                new KeyTarConfig("", "lpar1user", "lpar1pwd"));
+
+        final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
+        final ProfileDao profileDao = teamConfig.getDefaultProfileFromPartition("lpar1zosmf", "lpar1");
+        assertEquals("lpar1user", profileDao.getUser());
+        assertEquals("lpar1pwd", profileDao.getPassword());
+    }
+
+    @Test
+    public void tstTeamConfigGetDefaultProfileFromPartitionMergeBaseHostSuccess() throws TeamConfigException {
+        final List<Profile> partitionProfiles = List.of(new Profile("lpar1zosmf", "zosmf", Map.of("port", "443"), null));
+        final Partition partition = new Partition("lpar1", Map.of(), partitionProfiles);
+        final List<Profile> baseProfiles = List.of(new Profile("base", "base", Map.of("host", "base.example.com", "port", "10443"), null));
+        Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(
+                new ConfigContainer(List.of(partition), null, baseProfiles, Map.of(), null));
+        Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
+                new KeyTarConfig("", "username", "pwd"));
+
+        final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
+        final ProfileDao profileDao = teamConfig.getDefaultProfileFromPartition("lpar1zosmf", "lpar1");
+        assertEquals("base.example.com", profileDao.getHost());
+        assertEquals("443", profileDao.getPort());
+    }
+
+    @Test
+    public void tstTeamConfigGetDefaultProfileFromPartitionMergeNonBaseHostSuccess() throws TeamConfigException {
+        final List<Profile> partitionProfiles = List.of(new Profile("lpar1zosmf", "zosmf", Map.of("host", "lpar1.example.com", "port", "443"), null));
+        final Partition partition = new Partition("lpar1", Map.of(), partitionProfiles);
+        final List<Profile> baseProfiles = List.of(new Profile("base", "base", Map.of("host", "base.example.com", "port", "10443"), null));
+        Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(
+                new ConfigContainer(List.of(partition), null, baseProfiles, Map.of(), null));
+        Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
+                new KeyTarConfig("", "username", "pwd"));
+
+        final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
+        final ProfileDao profileDao = teamConfig.getDefaultProfileFromPartition("lpar1zosmf", "lpar1");
+        assertEquals("lpar1.example.com", profileDao.getHost());
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests using the Zowe team config JSON structure:
+    //   profiles: zosmf (port 443), tso (account/codePage/logonProcedure),
+    //             ssh (port 22), rse (port 6800/basePath/protocol),
+    //             base (host myzos.ibm.com, rejectUnauthorized, secure: user/password)
+    //   defaults: zosmf->zosmf, tso->tso, ssh->ssh, rse->rse, base->base
+    //   autoStore: true
+    // -------------------------------------------------------------------------
+
+    private ConfigContainer buildZoweConfig() {
+        final Profile zosmf = new Profile("zosmf", "zosmf", Map.of("port", "443"), List.of());
+        final Profile tso = new Profile("tso", "tso",
+                Map.of("account", "", "codePage", "1047", "logonProcedure", "IZUFPROC"), List.of());
+        final Profile ssh = new Profile("ssh", "ssh", Map.of("port", "22"), List.of());
+        final Profile rse = new Profile("rse", "rse",
+                Map.of("port", "6800", "basePath", "rseapi", "protocol", "https"), List.of());
+        final Profile base = new Profile("base", "base",
+                Map.of("host", "myzos.ibm.com", "rejectUnauthorized", "true"),
+                List.of("user", "password"));
+        final List<Profile> profiles = List.of(zosmf, tso, ssh, rse, base);
+        final Map<String, String> defaults = Map.of(
+                "zosmf", "zosmf", "tso", "tso", "ssh", "ssh", "rse", "rse", "base", "base");
+        return new ConfigContainer(List.of(), "./zowe.schema.json", profiles, defaults, true);
+    }
+
+    @Test
+    public void tstZoweJsonGetDefaultZosmfProfileSuccess() throws TeamConfigException {
+        Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(buildZoweConfig());
+        Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
+                new KeyTarConfig("", "myuser", "mypassword"));
+
+        final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
+        final ProfileDao profileDao = teamConfig.getDefaultProfile("zosmf");
+        assertNotNull(profileDao);
+        assertEquals("zosmf", profileDao.getProfile().getName());
+        assertEquals("443", profileDao.getPort());
+        // host comes from merged base profile
+        assertEquals("myzos.ibm.com", profileDao.getHost());
+        assertEquals("true", profileDao.getProfile().getProperties().get("rejectUnauthorized"));
+    }
+
+    @Test
+    public void tstZoweJsonGetDefaultZosmfProfileUserAndPasswordSuccess() throws TeamConfigException {
+        Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(buildZoweConfig());
+        Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
+                new KeyTarConfig("", "myuser", "mypassword"));
+
+        final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
+        final ProfileDao profileDao = teamConfig.getDefaultProfile("zosmf");
+        assertEquals("myuser", profileDao.getUser());
+        assertEquals("mypassword", profileDao.getPassword());
+    }
+
+    @Test
+    public void tstZoweJsonGetDefaultSshProfileSuccess() throws TeamConfigException {
+        Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(buildZoweConfig());
+        Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
+                new KeyTarConfig("", "myuser", "mypassword"));
+
+        final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
+        final ProfileDao profileDao = teamConfig.getDefaultProfile("ssh");
+        assertNotNull(profileDao);
+        assertEquals("ssh", profileDao.getProfile().getName());
+        assertEquals("22", profileDao.getPort());
+        assertEquals("myzos.ibm.com", profileDao.getHost());
+    }
+
+    @Test
+    public void tstZoweJsonGetDefaultRseProfileSuccess() throws TeamConfigException {
+        Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(buildZoweConfig());
+        Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
+                new KeyTarConfig("", "myuser", "mypassword"));
+
+        final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
+        final ProfileDao profileDao = teamConfig.getDefaultProfile("rse");
+        assertNotNull(profileDao);
+        assertEquals("rse", profileDao.getProfile().getName());
+        assertEquals("6800", profileDao.getPort());
+        assertEquals("myzos.ibm.com", profileDao.getHost());
+        assertEquals("rseapi", profileDao.getProfile().getProperties().get("basePath"));
+        assertEquals("https", profileDao.getProfile().getProperties().get("protocol"));
+    }
+
+    @Test
+    public void tstZoweJsonGetDefaultTsoProfileSuccess() throws TeamConfigException {
+        Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(buildZoweConfig());
+        Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
+                new KeyTarConfig("", "myuser", "mypassword"));
+
+        final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
+        final ProfileDao profileDao = teamConfig.getDefaultProfile("tso");
+        assertNotNull(profileDao);
+        assertEquals("tso", profileDao.getProfile().getName());
+        assertEquals("1047", profileDao.getProfile().getProperties().get("codePage"));
+        assertEquals("IZUFPROC", profileDao.getProfile().getProperties().get("logonProcedure"));
+        assertEquals("myzos.ibm.com", profileDao.getHost());
+    }
+
+    @Test
+    public void tstZoweJsonGetDefaultBaseProfileHostSuccess() throws TeamConfigException {
+        Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(buildZoweConfig());
+        Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
+                new KeyTarConfig("", "myuser", "mypassword"));
+
+        final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
+        final ProfileDao profileDao = teamConfig.getDefaultProfile("base");
+        assertNotNull(profileDao);
+        assertEquals("base", profileDao.getProfile().getName());
+        assertEquals("myzos.ibm.com", profileDao.getHost());
+        assertEquals("true", profileDao.getProfile().getProperties().get("rejectUnauthorized"));
+    }
+
+    @Test
+    public void tstZoweJsonBaseProfileSecureFieldsSuccess() throws TeamConfigException {
+        Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(buildZoweConfig());
+        Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
+                new KeyTarConfig("", "myuser", "mypassword"));
+
+        final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
+        final ProfileDao profileDao = teamConfig.getDefaultProfile("base");
+        assertEquals(List.of("user", "password"), profileDao.getProfile().getSecure());
+    }
+
+    @Test
+    public void tstZoweJsonUnknownProfileTypeFailure() throws TeamConfigException {
+        Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(buildZoweConfig());
+        Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
+                new KeyTarConfig("", "myuser", "mypassword"));
+
+        final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
+        String errMsg = "";
+        try {
+            teamConfig.getDefaultProfile("ftp");
+        } catch (Exception e) {
+            errMsg = e.getMessage();
+        }
+        assertEquals("Found no profile of type ftp in Zowe client configuration.", errMsg);
     }
 
 }


### PR DESCRIPTION
This PR includes a partial refactor of the `teamconfig` package to use the Jackson JSON parsing library. Adopting Jackson enables support for a broader range of Zowe `config.json` configuration variants and improves overall robustness.

In addition, the PR expands unit test coverage and addresses several minor code-smell issues, resulting in cleaner and more maintainable code.
