### PR TITLE
Add update API to persist profile changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ zowe.client.sdk.zosvariables.method
           
 ## TeamConfig Package  
   
-The TeamConfig package provides API methods to retrieve a profile section from Zowe Global Team Configuration with keytar information to help perform connection processing without a hard coding username and password. Keytar represents credentials stored securely on your computer when performing the Zowe Global Initialize [command](https://docs.zowe.org/stable/user-guide/cli-using-initializing-team-configuration/) which prompts you for username and password.   
+The TeamConfig package provides API methods to retrieve and update a profile section from Zowe Global Team Configuration with keytar information to help perform connection processing without a hard coding username and password. Keytar represents credentials stored securely on your computer when performing the Zowe Global Initialize [command](https://docs.zowe.org/stable/user-guide/cli-using-initializing-team-configuration/) which prompts you for username and password.   
   
 TeamConfig class only supports Zowe Global Team Configuration provided by Zowe V2.  
   

--- a/src/main/java/zowe/client/sdk/teamconfig/README.md
+++ b/src/main/java/zowe/client/sdk/teamconfig/README.md
@@ -88,6 +88,11 @@ public class TeamConfigExp {
         );
 
         TeamConfigExp.listMembers(connection, "CCSQA.ASM.JCL");
+        
+        // example of updating the profile
+        System.out.println(teamConfig.getDefaultProfile("zosmf"));
+        System.out.println(teamConfig.updateProfile("zosmf", Map.of("port", 133)));
+        System.out.println(teamConfig.getDefaultProfile("zosmf"));
     }
 
     /**

--- a/src/main/java/zowe/client/sdk/teamconfig/README.md
+++ b/src/main/java/zowe/client/sdk/teamconfig/README.md
@@ -91,7 +91,7 @@ public class TeamConfigExp {
         
         // example of updating the profile
         System.out.println(teamConfig.getDefaultProfile("zosmf"));
-        System.out.println(teamConfig.updateProfile("zosmf", Map.of("port", 133)));
+        System.out.println(teamConfig.updateProfile("frank", Map.of("port", 133)));
         System.out.println(teamConfig.getDefaultProfile("zosmf"));
     }
 

--- a/src/main/java/zowe/client/sdk/teamconfig/README.md
+++ b/src/main/java/zowe/client/sdk/teamconfig/README.md
@@ -1,6 +1,7 @@
 # TeamConfig Package
 
-The TeamConfig package provides API method(s) to retrieve a profile section from Zowe Global Team Configuration with
+The TeamConfig package provides API method(s) to retrieve and update a profile section from Zowe Global Team
+Configuration with
 keytar information to help perform connection processing without hard coding username and password. Keytar represents
 credentials stored securely on your computer when performing the Zowe global initialize command which prompts you for
 username and password.
@@ -57,7 +58,7 @@ import java.util.List;
 public class TeamConfigExp {
 
     /**
-     * Main method defines TeamConfig object and operation to retrieve the default
+     * The main method defines TeamConfig object and operation to retrieve and update the default
      * z/OSMF profile from Zowe Team Configuration.
      * <p>
      * Zowe Team Configuration contains the connection information for z/OSMF REST API.
@@ -67,11 +68,11 @@ public class TeamConfigExp {
      * <p>
      * Calls TeamConfigExp.listMembers example method.
      *
-     * @param args for main not used
+     * @param args for main isn't used
      * @throws ZosmfRequestException request error state
      * @author Frank Giordano
      */
-    public static void main(String[] args) throws ZosmfRequestException {
+    public static void main(String[] args) throws ZosmfRequestException, TeamConfigException {
         TeamConfig teamConfig;
         try {
             teamConfig = new TeamConfig();
@@ -79,8 +80,12 @@ public class TeamConfigExp {
             throw new RuntimeException(e.getMessage());
         }
         ProfileDao profile = teamConfig.getDefaultProfile("zosmf");
-        return (ZosConnectionFactory.createBasicConnection(
-                profile.getHost(), profile.getPort(), profile.getUser(), profile.getPassword()));
+        ZosConnection connection = ZosConnectionFactory.createBasicConnection(
+                profile.getHost(),
+                Integer.parseInt(profile.getPort()),
+                profile.getUser(),
+                profile.getPassword()
+        );
 
         TeamConfigExp.listMembers(connection, "CCSQA.ASM.JCL");
     }
@@ -101,5 +106,4 @@ public class TeamConfigExp {
     }
 
 }
-`````  
-
+`````

--- a/src/main/java/zowe/client/sdk/teamconfig/TeamConfig.java
+++ b/src/main/java/zowe/client/sdk/teamconfig/TeamConfig.java
@@ -175,6 +175,24 @@ public class TeamConfig {
     }
 
     /**
+     * Update a profile's properties in the Zowe Global Team Configuration file on disk.
+     * Only the properties present in {@code updatedProperties} are written; existing properties
+     * not included in the map are left unchanged. The in-memory configuration is refreshed after the update.
+     *
+     * @param profileName       name of the profile to update
+     * @param updatedProperties map of property key/value pairs to set on the profile
+     * @throws TeamConfigException error reading or writing the team configuration file
+     * @author Frank Giordano
+     */
+    public void updateProfile(final String profileName, final Map<String, String> updatedProperties)
+            throws TeamConfigException {
+        ValidateUtils.checkIllegalParameter(profileName, "profileName");
+        ValidateUtils.checkNullParameter(updatedProperties, "updatedProperties");
+        teamConfigService.updateTeamConfig(keyTarConfig, profileName, updatedProperties);
+        config();
+    }
+
+    /**
      * Take two profile objects and merge all non-duplicate properties into the target.
      *
      * @param target Profile object

--- a/src/main/java/zowe/client/sdk/teamconfig/service/TeamConfigService.java
+++ b/src/main/java/zowe/client/sdk/teamconfig/service/TeamConfigService.java
@@ -11,6 +11,7 @@ package zowe.client.sdk.teamconfig.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zowe.client.sdk.teamconfig.exception.TeamConfigException;
@@ -62,6 +63,44 @@ public class TeamConfigService {
             throw new TeamConfigException("Error reading zowe global team configuration file", e);
         }
         return parseJson(root);
+    }
+
+    /**
+     * Update a profile's properties in the Zowe Global Team Configuration file on disk.
+     * Only the properties present in {@code updatedProperties} are written; existing properties
+     * not included in the map are left unchanged.
+     *
+     * @param config            KeyTarConfig object providing the file location
+     * @param profileName       name of the profile to update
+     * @param updatedProperties map of property key/value pairs to set on the profile
+     * @throws TeamConfigException error reading or writing the team configuration file
+     * @author Frank Giordano
+     */
+    public void updateTeamConfig(final KeyTarConfig config, final String profileName,
+                                 final Map<String, String> updatedProperties) throws TeamConfigException {
+        ValidateUtils.checkNullParameter(config, "config");
+        ValidateUtils.checkIllegalParameter(profileName, "profileName");
+        ValidateUtils.checkNullParameter(updatedProperties, "updatedProperties");
+        final File file = new File(config.getLocation());
+        final JsonNode root;
+        try {
+            root = MAPPER.readTree(file);
+        } catch (IOException e) {
+            throw new TeamConfigException("Error reading zowe global team configuration file", e);
+        }
+        final JsonNode profilesNode = root.path("profiles");
+        final JsonNode profileNode = profilesNode.path(profileName);
+        if (profileNode.isMissingNode()) {
+            throw new TeamConfigException("Profile '" + profileName + "' not found in configuration file");
+        }
+        final ObjectNode propertiesNode = (ObjectNode) profileNode.path("properties");
+        updatedProperties.forEach(propertiesNode::put);
+        try {
+            MAPPER.writerWithDefaultPrettyPrinter().writeValue(file, root);
+        } catch (IOException e) {
+            throw new TeamConfigException("Error writing zowe global team configuration file", e);
+        }
+        LOG.debug("updateTeamConfig profile {} updated with {}", profileName, updatedProperties);
     }
 
     /**

--- a/src/test/java/zowe/client/sdk/teamconfig/TeamConfigTest.java
+++ b/src/test/java/zowe/client/sdk/teamconfig/TeamConfigTest.java
@@ -420,4 +420,79 @@ public class TeamConfigTest {
         assertEquals("Found no profile of type ftp in Zowe client configuration.", errMsg);
     }
 
+    // -------------------------------------------------------------------------
+    // Tests for updateProfile
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void tstUpdateProfileSuccess() throws TeamConfigException {
+        Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(buildZoweConfig());
+        Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
+                new KeyTarConfig("", "myuser", "mypassword"));
+        Mockito.doNothing().when(teamConfigServiceMock).updateTeamConfig(any(), any(), any());
+
+        final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
+        final Map<String, String> updates = Map.of("host", "newhost.ibm.com", "port", "8443");
+        teamConfig.updateProfile("zosmf", updates);
+
+        Mockito.verify(teamConfigServiceMock).updateTeamConfig(any(), Mockito.eq("zosmf"), Mockito.eq(updates));
+    }
+
+    @Test
+    public void tstUpdateProfileNullPropertiesFailure() throws TeamConfigException {
+        Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(buildZoweConfig());
+        Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
+                new KeyTarConfig("", "myuser", "mypassword"));
+
+        final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
+        String errMsg = "";
+        try {
+            teamConfig.updateProfile("zosmf", null);
+        } catch (Exception e) {
+            errMsg = e.getMessage();
+        }
+        assertEquals("updatedProperties is null", errMsg);
+    }
+
+    @Test
+    public void tstUpdateProfileBlankNameFailure() throws TeamConfigException {
+        Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(buildZoweConfig());
+        Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
+                new KeyTarConfig("", "myuser", "mypassword"));
+
+        final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
+        String errMsg = "";
+        try {
+            teamConfig.updateProfile("  ", Map.of("host", "newhost.ibm.com"));
+        } catch (Exception e) {
+            errMsg = e.getMessage();
+        }
+        assertEquals("profileName is either null or empty", errMsg);
+    }
+
+    @Test
+    public void tstUpdateProfileRefreshesInMemoryConfigSuccess() throws TeamConfigException {
+        final ConfigContainer initialConfig = buildZoweConfig();
+        final Profile updatedZosmf = new Profile("zosmf", "zosmf", Map.of("port", "8443"), List.of());
+        final Profile base = new Profile("base", "base",
+                Map.of("host", "newhost.ibm.com", "rejectUnauthorized", "true"), List.of("user", "password"));
+        final ConfigContainer refreshedConfig = new ConfigContainer(
+                List.of(), "./zowe.schema.json", List.of(updatedZosmf, base),
+                Map.of("zosmf", "zosmf", "base", "base"), true);
+
+        Mockito.when(teamConfigServiceMock.getTeamConfig(any()))
+                .thenReturn(initialConfig)
+                .thenReturn(refreshedConfig);
+        Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
+                new KeyTarConfig("", "myuser", "mypassword"));
+        Mockito.doNothing().when(teamConfigServiceMock).updateTeamConfig(any(), any(), any());
+
+        final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
+        teamConfig.updateProfile("zosmf", Map.of("host", "newhost.ibm.com", "port", "8443"));
+
+        final ProfileDao profileDao = teamConfig.getDefaultProfile("zosmf");
+        assertEquals("8443", profileDao.getPort());
+        assertEquals("newhost.ibm.com", profileDao.getHost());
+    }
+
 }


### PR DESCRIPTION
Enables SDK consumers to update connection properties (e.g. host, port) in their Zowe team config file at runtime without manually editing JSON, while keeping the in-memory state consistent with the file on disk.