### PR TITLE
Migrate KeyTar implementation to Jackson and improve state handling and testability

### DIFF
--- a/src/main/java/zowe/client/sdk/teamconfig/TeamConfig.java
+++ b/src/main/java/zowe/client/sdk/teamconfig/TeamConfig.java
@@ -111,10 +111,9 @@ public class TeamConfig {
      *
      * @param profileType profile type
      * @return ProfileDao object
-     * @throws TeamConfigException error processing team configuration
      * @author Frank Giordano
      */
-    public ProfileDao getDefaultProfile(final String profileType) throws TeamConfigException {
+    public ProfileDao getDefaultProfile(final String profileType) {
         ValidateUtils.checkIllegalParameter(profileType, "profileType");
         final Optional<String> defaultName = Optional.ofNullable(teamConfig.getDefaults().get(profileType));
         final Predicate<Profile> isProfileName = i -> i.getName().equals(defaultName.orElse(profileType));
@@ -143,10 +142,9 @@ public class TeamConfig {
      * @param profileName   profile name
      * @param partitionName partition name
      * @return ProfileDao object
-     * @throws TeamConfigException error processing team configuration
      * @author Frank Giordano
      */
-    public ProfileDao getDefaultProfileFromPartition(final String profileName, final String partitionName) throws TeamConfigException {
+    public ProfileDao getDefaultProfileFromPartition(final String profileName, final String partitionName) {
         ValidateUtils.checkIllegalParameter(profileName, "profileName");
         ValidateUtils.checkIllegalParameter(partitionName, "partitionName");
         final Optional<String> defaultName = Optional.ofNullable(teamConfig.getDefaults().get(profileName));

--- a/src/main/java/zowe/client/sdk/teamconfig/keytar/KeyTarConfig.java
+++ b/src/main/java/zowe/client/sdk/teamconfig/keytar/KeyTarConfig.java
@@ -33,17 +33,27 @@ public class KeyTarConfig {
     private final String password;
 
     /**
+     * Represents a string value of the OS credential store name
+     */
+    private final String storeName;
+
+    /**
      * KeyTarConfig constructor
      *
      * @param location location of the Zowe Global Team Configuration filename and path
      * @param userName userName specified from parsed KeyTar keyValue
      * @param password password specified from parsed KeyTar keyValue
+     * @param storeName store name specified in the OS credential store
      * @author Frank Giordano
      */
-    public KeyTarConfig(final String location, final String userName, final String password) {
+    public KeyTarConfig(final String location,
+                        final String userName,
+                        final String password,
+                        final String storeName) {
         this.location = location;
         this.userName = userName;
         this.password = password;
+        this.storeName = storeName;
     }
 
     /**
@@ -67,13 +77,30 @@ public class KeyTarConfig {
     }
 
     /**
+     * Return username
+     *
+     * @return username string value from OS credential store
+     */
+    public String getUser() {
+        return userName;
+    }
+
+    /**
      * Return userName
      *
      * @return userName string value from OS credential store
-     * @author Frank Giordano
      */
     public String getUserName() {
         return userName;
+    }
+
+    /**
+     * Return storeName
+     *
+     * @return storeName string value from OS credential store
+     */
+    public String getStoreName() {
+        return storeName;
     }
 
     /**

--- a/src/main/java/zowe/client/sdk/teamconfig/keytar/KeyTarImpl.java
+++ b/src/main/java/zowe/client/sdk/teamconfig/keytar/KeyTarImpl.java
@@ -9,11 +9,11 @@
  */
 package zowe.client.sdk.teamconfig.keytar;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.starxg.keytar.Keytar;
 import com.starxg.keytar.KeytarException;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zowe.client.sdk.teamconfig.exception.TeamConfigException;
@@ -22,7 +22,7 @@ import zowe.client.sdk.utility.ValidateUtils;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
 /**
  * Implementation class for IkeyTar interface that contains the logic for KeyTar processing
@@ -33,6 +33,9 @@ import java.util.Set;
 public class KeyTarImpl implements IKeyTar {
 
     private static final Logger LOG = LoggerFactory.getLogger(KeyTarImpl.class);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String USER_FIELD = "profiles.base.properties.user";
+    private static final String PASSWORD_FIELD = "profiles.base.properties.password";
 
     /**
      * List of KeyTarConfig objects - OS might contain multiple OS stores
@@ -71,9 +74,11 @@ public class KeyTarImpl implements IKeyTar {
     public List<KeyTarConfig> getKeyConfigs() throws TeamConfigException {
         ValidateUtils.checkNullParameter(keyString, "keyString", "perform processKey first");
         ValidateUtils.checkIllegalParameter(keyString.isBlank(), "keyString is empty");
+
         if (!keyTarConfigs.isEmpty()) {
             return keyTarConfigs;
         }
+
         return parseJson();
     }
 
@@ -96,23 +101,47 @@ public class KeyTarImpl implements IKeyTar {
      * @throws TeamConfigException error processing team configuration
      * @author Frank Giordano
      */
-    @SuppressWarnings("unchecked")
     private List<KeyTarConfig> parseJson() throws TeamConfigException {
-        final JSONObject jsonKeyTar;
+        final JsonNode rootNode;
         try {
-            jsonKeyTar = (JSONObject) new JSONParser().parse(keyString);
-        } catch (ParseException e) {
-            throw new TeamConfigException("Error parsing KeyTar string.", e);
+            rootNode = OBJECT_MAPPER.readTree(keyString);
+        } catch (JsonProcessingException e) {
+            throw new TeamConfigException("Error parsing KeyTar JSON string.", e);
         }
 
-        final Set<String> keyTarKeys = jsonKeyTar.keySet();
-        for (final String keyVal : keyTarKeys) {
-            JSONObject jsonVal = (JSONObject) jsonKeyTar.get(keyVal);
-            keyTarConfigs.add(new KeyTarConfig(keyVal,
-                    (String) jsonVal.get("profiles.base.properties.user"),
-                    (String) jsonVal.get("profiles.base.properties.password")));
+        if (!rootNode.isObject()) {
+            throw new TeamConfigException("Invalid KeyTar JSON structure: expected object root.");
         }
+
+        for (final Map.Entry<String, JsonNode> entry : rootNode.properties()) {
+            String storeName = entry.getKey();
+            JsonNode storeNode = entry.getValue();
+
+            if (!storeNode.isObject()) {
+                LOG.debug(
+                        "Unexpected KeyTar store node type for store '{}': {}",
+                        storeName,
+                        storeNode
+                );
+                continue;
+            }
+
+            String user = getRequiredText(storeNode, USER_FIELD);
+            String password = getRequiredText(storeNode, PASSWORD_FIELD);
+
+            keyTarConfigs.add(new KeyTarConfig("", user, password, storeName));
+        }
+
         return keyTarConfigs;
+    }
+
+    private String getRequiredText(final JsonNode node, final String fieldName) throws TeamConfigException {
+        JsonNode valueNode = node.get(fieldName);
+        if (valueNode == null || valueNode.isNull() || !valueNode.isTextual()) {
+            throw new TeamConfigException(
+                    "Missing or invalid KeyTar field: " + fieldName);
+        }
+        return valueNode.asText();
     }
 
     /**
@@ -126,17 +155,26 @@ public class KeyTarImpl implements IKeyTar {
     public void processKey() throws TeamConfigException {
         ValidateUtils.checkIllegalParameter(serviceName, "serviceName");
         ValidateUtils.checkIllegalParameter(accountName, "accountName");
+
+        keyTarConfigs.clear();
+        this.keyString = null;
+
         final Keytar instance = Keytar.getInstance();
         final String encodedString;
+
         try {
             encodedString = instance.getPassword(serviceName, accountName);
         } catch (KeytarException e) {
             throw new TeamConfigException("Error retrieving KeyTar password", e);
         }
-        LOG.debug("KeyTar encodedString retrieved {}", encodedString);
+
+        LOG.debug("KeyTar encodedString retrieved (length={})",
+                encodedString != null ? encodedString.length() : 0);
+
         if (encodedString == null) {
             throw new TeamConfigException("Unknown service name or account name");
         }
+
         final byte[] decodedBytes = Base64.getDecoder().decode(encodedString);
         this.keyString = new String(decodedBytes);
     }

--- a/src/test/java/zowe/client/sdk/teamconfig/KeyTarImplTest.java
+++ b/src/test/java/zowe/client/sdk/teamconfig/KeyTarImplTest.java
@@ -51,7 +51,7 @@ public class KeyTarImplTest {
     }
 
     @Test
-    void shouldParseValidKeyTarJson() throws Exception {
+    void tstShouldParseValidKeyTarJsonSuccess() throws Exception {
         String json =
                 "{"
                         + "\"store1\": {"
@@ -72,7 +72,7 @@ public class KeyTarImplTest {
     }
 
     @Test
-    void shouldHandleMultipleStores() throws Exception {
+    void tstShouldHandleMultipleStoresSuccess() throws Exception {
         String json =
                 "{"
                         + "\"store1\": {"
@@ -91,10 +91,16 @@ public class KeyTarImplTest {
         List<KeyTarConfig> configs = keyTar.getKeyConfigs();
 
         assertEquals(2, configs.size());
+        assertEquals("store1", configs.get(0).getStoreName());
+        assertEquals("user1", configs.get(0).getUser());
+        assertEquals("pass1", configs.get(0).getPassword());
+        assertEquals("store2", configs.get(1).getStoreName());
+        assertEquals("user2", configs.get(1).getUser());
+        assertEquals("pass2", configs.get(1).getPassword());
     }
 
     @Test
-    void shouldSkipNonObjectStoreNodes() throws Exception {
+    void tstShouldSkipNonObjectStoreNodesSuccess() throws Exception {
         String json =
                 "{"
                         + "\"store1\": \"unexpected\","
@@ -111,10 +117,12 @@ public class KeyTarImplTest {
 
         assertEquals(1, configs.size());
         assertEquals("store2", configs.get(0).getStoreName());
+        assertEquals("user", configs.get(0).getUser());
+        assertEquals("pass", configs.get(0).getPassword());
     }
 
     @Test
-    void shouldThrowWhenRequiredFieldMissing() {
+    void tstShouldThrowWhenRequiredFieldMissingFailure() {
         String json =
                 "{"
                         + "\"store1\": {"
@@ -134,7 +142,7 @@ public class KeyTarImplTest {
     }
 
     @Test
-    void shouldFailIfGettersCalledBeforeProcessKey() {
+    void tstShouldFailIfGettersCalledBeforeProcessKeyFailure() {
         KeyTarImpl keyTar = new KeyTarImpl();
 
         assertThrows(

--- a/src/test/java/zowe/client/sdk/teamconfig/KeyTarImplTest.java
+++ b/src/test/java/zowe/client/sdk/teamconfig/KeyTarImplTest.java
@@ -1,0 +1,151 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.teamconfig;
+
+import org.junit.jupiter.api.Test;
+import zowe.client.sdk.teamconfig.exception.TeamConfigException;
+import zowe.client.sdk.teamconfig.keytar.KeyTarConfig;
+import zowe.client.sdk.teamconfig.keytar.KeyTarImpl;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Class containing unit test for KeyTarImpl.
+ *
+ * @author Frank Giordano
+ * @version 7.0
+ */
+public class KeyTarImplTest {
+
+    /**
+     * Simple test double to inject decoded JSON directly
+     */
+    static class TestKeyTarImpl extends KeyTarImpl {
+
+        private final String testKeyString;
+
+        TestKeyTarImpl(String testKeyString) {
+            this.testKeyString = testKeyString;
+        }
+
+        @Override
+        public void processKey() {
+            try {
+                java.lang.reflect.Field field =
+                        KeyTarImpl.class.getDeclaredField("keyString");
+                field.setAccessible(true);
+                field.set(this, testKeyString);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    @Test
+    void shouldParseValidKeyTarJson() throws Exception {
+        String json =
+                "{"
+                        + "\"store1\": {"
+                        + "\"profiles.base.properties.user\": \"fred\","
+                        + "\"profiles.base.properties.password\": \"secret\""
+                        + "}"
+                        + "}";
+
+        TestKeyTarImpl keyTar = new TestKeyTarImpl(json);
+        keyTar.processKey();
+
+        List<KeyTarConfig> configs = keyTar.getKeyConfigs();
+
+        assertEquals(1, configs.size());
+        assertEquals("store1", configs.get(0).getStoreName());
+        assertEquals("fred", configs.get(0).getUser());
+        assertEquals("secret", configs.get(0).getPassword());
+    }
+
+    @Test
+    void shouldHandleMultipleStores() throws Exception {
+        String json =
+                "{"
+                        + "\"store1\": {"
+                        + "\"profiles.base.properties.user\": \"user1\","
+                        + "\"profiles.base.properties.password\": \"pass1\""
+                        + "},"
+                        + "\"store2\": {"
+                        + "\"profiles.base.properties.user\": \"user2\","
+                        + "\"profiles.base.properties.password\": \"pass2\""
+                        + "}"
+                        + "}";
+
+        TestKeyTarImpl keyTar = new TestKeyTarImpl(json);
+        keyTar.processKey();
+
+        List<KeyTarConfig> configs = keyTar.getKeyConfigs();
+
+        assertEquals(2, configs.size());
+    }
+
+    @Test
+    void shouldSkipNonObjectStoreNodes() throws Exception {
+        String json =
+                "{"
+                        + "\"store1\": \"unexpected\","
+                        + "\"store2\": {"
+                        + "\"profiles.base.properties.user\": \"user\","
+                        + "\"profiles.base.properties.password\": \"pass\""
+                        + "}"
+                        + "}";
+
+        TestKeyTarImpl keyTar = new TestKeyTarImpl(json);
+        keyTar.processKey();
+
+        List<KeyTarConfig> configs = keyTar.getKeyConfigs();
+
+        assertEquals(1, configs.size());
+        assertEquals("store2", configs.get(0).getStoreName());
+    }
+
+    @Test
+    void shouldThrowWhenRequiredFieldMissing() {
+        String json =
+                "{"
+                        + "\"store1\": {"
+                        + "\"profiles.base.properties.user\": \"user\""
+                        + "}"
+                        + "}";
+
+        TestKeyTarImpl keyTar = new TestKeyTarImpl(json);
+        keyTar.processKey();
+
+        TeamConfigException ex = assertThrows(
+                TeamConfigException.class,
+                keyTar::getKeyConfigs
+        );
+
+        assertTrue(ex.getMessage().contains("Missing or invalid KeyTar field"));
+    }
+
+    @Test
+    void shouldFailIfGettersCalledBeforeProcessKey() {
+        KeyTarImpl keyTar = new KeyTarImpl();
+
+        assertThrows(
+                NullPointerException.class,
+                keyTar::getKeyTarValue
+        );
+
+        assertThrows(
+                NullPointerException.class,
+                keyTar::getKeyConfigs
+        );
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/teamconfig/KeyTarImplTest.java
+++ b/src/test/java/zowe/client/sdk/teamconfig/KeyTarImplTest.java
@@ -71,6 +71,7 @@ public class KeyTarImplTest {
         assertEquals("secret", configs.get(0).getPassword());
     }
 
+    @SuppressWarnings("ExtractMethodRecommender")
     @Test
     void tstShouldHandleMultipleStoresSuccess() throws Exception {
         String json =

--- a/src/test/java/zowe/client/sdk/teamconfig/TeamConfigServiceTest.java
+++ b/src/test/java/zowe/client/sdk/teamconfig/TeamConfigServiceTest.java
@@ -56,7 +56,7 @@ public class TeamConfigServiceTest {
     }
 
     @Test
-    public void tstParseJsonFlatProfilesConfig() throws Exception {
+    public void tstParseJsonFlatProfilesConfigSuccess() throws Exception {
         final String json = stripComments(
                 "{\n" +
                         "  \"$schema\": \"./zowe.schema.json\",\n" +
@@ -179,7 +179,7 @@ public class TeamConfigServiceTest {
     }
 
     @Test
-    public void tstParseJsonNestedLparConfig() throws Exception {
+    public void tstParseJsonNestedLparConfigSuccess() throws Exception {
         final String json = stripComments(
                 "{\n" +
                         "  \"$schema\": \"./zowe.schema.json\",\n" +

--- a/src/test/java/zowe/client/sdk/teamconfig/TeamConfigTest.java
+++ b/src/test/java/zowe/client/sdk/teamconfig/TeamConfigTest.java
@@ -52,7 +52,7 @@ public class TeamConfigTest {
         Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(
                 new ConfigContainer(null, null, profiles, defaults, null));
         Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
-                new KeyTarConfig("", "", ""));
+                new KeyTarConfig("", "", "", ""));
 
         TeamConfig teamConfig;
         try {
@@ -76,7 +76,7 @@ public class TeamConfigTest {
         Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(
                 new ConfigContainer(null, null, profiles, defaults, null));
         Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
-                new KeyTarConfig("", "", ""));
+                new KeyTarConfig("", "", "", ""));
 
         TeamConfig teamConfig;
         try {
@@ -100,7 +100,7 @@ public class TeamConfigTest {
         Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(
                 new ConfigContainer(null, null, profiles, defaults, null));
         Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
-                new KeyTarConfig("", "", ""));
+                new KeyTarConfig("", "", "", ""));
 
         TeamConfig teamConfig;
         try {
@@ -127,7 +127,7 @@ public class TeamConfigTest {
         Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(
                 new ConfigContainer(null, null, profiles, defaults, null));
         Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
-                new KeyTarConfig("", "username", "pwd"));
+                new KeyTarConfig("", "username", "pwd", ""));
 
         final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
         ProfileDao profileDao = teamConfig.getDefaultProfile("zosmf");
@@ -143,7 +143,7 @@ public class TeamConfigTest {
         Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(
                 new ConfigContainer(null, null, profiles, defaults, null));
         Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
-                new KeyTarConfig("", "username", "pwd"));
+                new KeyTarConfig("", "username", "pwd", ""));
 
         final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
         ProfileDao profileDao = teamConfig.getDefaultProfile("zosmf");
@@ -158,7 +158,7 @@ public class TeamConfigTest {
         Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(
                 new ConfigContainer(null, null, profiles, defaults, null));
         Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
-                new KeyTarConfig("", "username", "pwd"));
+                new KeyTarConfig("", "username", "pwd", ""));
 
         final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
         ProfileDao profileDao = teamConfig.getDefaultProfile("zosmf");
@@ -172,7 +172,7 @@ public class TeamConfigTest {
         Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(
                 new ConfigContainer(null, null, profiles, defaults, null));
         Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
-                new KeyTarConfig("", "username", "pwd"));
+                new KeyTarConfig("", "username", "pwd", ""));
 
         final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
         final ProfileDao profileDao = teamConfig.getDefaultProfile("zosmf");
@@ -187,7 +187,7 @@ public class TeamConfigTest {
         Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(
                 new ConfigContainer(List.of(partition), null, List.of(), Map.of(), null));
         Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
-                new KeyTarConfig("", "username", "pwd"));
+                new KeyTarConfig("", "username", "pwd", ""));
 
         final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
         String errMsg = "";
@@ -206,7 +206,7 @@ public class TeamConfigTest {
         Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(
                 new ConfigContainer(List.of(partition), null, List.of(), Map.of(), null));
         Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
-                new KeyTarConfig("", "username", "pwd"));
+                new KeyTarConfig("", "username", "pwd", ""));
 
         final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
         String errMsg = "";
@@ -225,7 +225,7 @@ public class TeamConfigTest {
         Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(
                 new ConfigContainer(List.of(partition), null, List.of(), Map.of(), null));
         Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
-                new KeyTarConfig("", "username", "pwd"));
+                new KeyTarConfig("", "username", "pwd", ""));
 
         final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
         final ProfileDao profileDao = teamConfig.getDefaultProfileFromPartition("lpar1zosmf", "lpar1");
@@ -242,7 +242,7 @@ public class TeamConfigTest {
         Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(
                 new ConfigContainer(List.of(partition), null, List.of(), Map.of(), null));
         Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
-                new KeyTarConfig("", "lpar1user", "lpar1pwd"));
+                new KeyTarConfig("", "lpar1user", "lpar1pwd", ""));
 
         final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
         final ProfileDao profileDao = teamConfig.getDefaultProfileFromPartition("lpar1zosmf", "lpar1");
@@ -258,7 +258,7 @@ public class TeamConfigTest {
         Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(
                 new ConfigContainer(List.of(partition), null, baseProfiles, Map.of(), null));
         Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
-                new KeyTarConfig("", "username", "pwd"));
+                new KeyTarConfig("", "username", "pwd", ""));
 
         final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
         final ProfileDao profileDao = teamConfig.getDefaultProfileFromPartition("lpar1zosmf", "lpar1");
@@ -274,7 +274,7 @@ public class TeamConfigTest {
         Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(
                 new ConfigContainer(List.of(partition), null, baseProfiles, Map.of(), null));
         Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
-                new KeyTarConfig("", "username", "pwd"));
+                new KeyTarConfig("", "username", "pwd", ""));
 
         final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
         final ProfileDao profileDao = teamConfig.getDefaultProfileFromPartition("lpar1zosmf", "lpar1");
@@ -310,7 +310,7 @@ public class TeamConfigTest {
     public void tstZoweJsonGetDefaultZosmfProfileSuccess() throws TeamConfigException {
         Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(buildZoweConfig());
         Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
-                new KeyTarConfig("", "myuser", "mypassword"));
+                new KeyTarConfig("", "myuser", "mypassword", "store1"));
 
         final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
         final ProfileDao profileDao = teamConfig.getDefaultProfile("zosmf");
@@ -326,7 +326,7 @@ public class TeamConfigTest {
     public void tstZoweJsonGetDefaultZosmfProfileUserAndPasswordSuccess() throws TeamConfigException {
         Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(buildZoweConfig());
         Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
-                new KeyTarConfig("", "myuser", "mypassword"));
+                new KeyTarConfig("", "myuser", "mypassword", "store1"));
 
         final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
         final ProfileDao profileDao = teamConfig.getDefaultProfile("zosmf");
@@ -338,7 +338,7 @@ public class TeamConfigTest {
     public void tstZoweJsonGetDefaultSshProfileSuccess() throws TeamConfigException {
         Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(buildZoweConfig());
         Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
-                new KeyTarConfig("", "myuser", "mypassword"));
+                new KeyTarConfig("", "myuser", "mypassword", "store1"));
 
         final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
         final ProfileDao profileDao = teamConfig.getDefaultProfile("ssh");
@@ -352,7 +352,7 @@ public class TeamConfigTest {
     public void tstZoweJsonGetDefaultRseProfileSuccess() throws TeamConfigException {
         Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(buildZoweConfig());
         Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
-                new KeyTarConfig("", "myuser", "mypassword"));
+                new KeyTarConfig("", "myuser", "mypassword", "store1"));
 
         final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
         final ProfileDao profileDao = teamConfig.getDefaultProfile("rse");
@@ -368,7 +368,7 @@ public class TeamConfigTest {
     public void tstZoweJsonGetDefaultTsoProfileSuccess() throws TeamConfigException {
         Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(buildZoweConfig());
         Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
-                new KeyTarConfig("", "myuser", "mypassword"));
+                new KeyTarConfig("", "myuser", "mypassword", "store1"));
 
         final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
         final ProfileDao profileDao = teamConfig.getDefaultProfile("tso");
@@ -383,7 +383,7 @@ public class TeamConfigTest {
     public void tstZoweJsonGetDefaultBaseProfileHostSuccess() throws TeamConfigException {
         Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(buildZoweConfig());
         Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
-                new KeyTarConfig("", "myuser", "mypassword"));
+                new KeyTarConfig("", "myuser", "mypassword", "store1"));
 
         final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
         final ProfileDao profileDao = teamConfig.getDefaultProfile("base");
@@ -397,7 +397,7 @@ public class TeamConfigTest {
     public void tstZoweJsonBaseProfileSecureFieldsSuccess() throws TeamConfigException {
         Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(buildZoweConfig());
         Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
-                new KeyTarConfig("", "myuser", "mypassword"));
+                new KeyTarConfig("", "myuser", "mypassword", "store1"));
 
         final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
         final ProfileDao profileDao = teamConfig.getDefaultProfile("base");
@@ -408,7 +408,7 @@ public class TeamConfigTest {
     public void tstZoweJsonUnknownProfileTypeFailure() throws TeamConfigException {
         Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(buildZoweConfig());
         Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
-                new KeyTarConfig("", "myuser", "mypassword"));
+                new KeyTarConfig("", "myuser", "mypassword", "store1"));
 
         final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
         String errMsg = "";
@@ -428,7 +428,7 @@ public class TeamConfigTest {
     public void tstUpdateProfileSuccess() throws TeamConfigException {
         Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(buildZoweConfig());
         Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
-                new KeyTarConfig("", "myuser", "mypassword"));
+                new KeyTarConfig("", "myuser", "mypassword", "store1"));
         Mockito.doNothing().when(teamConfigServiceMock).updateTeamConfig(any(), any(), any());
 
         final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
@@ -442,7 +442,7 @@ public class TeamConfigTest {
     public void tstUpdateProfileNullPropertiesFailure() throws TeamConfigException {
         Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(buildZoweConfig());
         Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
-                new KeyTarConfig("", "myuser", "mypassword"));
+                new KeyTarConfig("", "myuser", "mypassword", "store1"));
 
         final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
         String errMsg = "";
@@ -458,7 +458,7 @@ public class TeamConfigTest {
     public void tstUpdateProfileBlankNameFailure() throws TeamConfigException {
         Mockito.when(teamConfigServiceMock.getTeamConfig(any())).thenReturn(buildZoweConfig());
         Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
-                new KeyTarConfig("", "myuser", "mypassword"));
+                new KeyTarConfig("", "myuser", "mypassword", "store1"));
 
         final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);
         String errMsg = "";
@@ -484,7 +484,7 @@ public class TeamConfigTest {
                 .thenReturn(initialConfig)
                 .thenReturn(refreshedConfig);
         Mockito.when(keyTarServiceMock.getKeyTarConfig()).thenReturn(
-                new KeyTarConfig("", "myuser", "mypassword"));
+                new KeyTarConfig("", "myuser", "mypassword", "store1"));
         Mockito.doNothing().when(teamConfigServiceMock).updateTeamConfig(any(), any(), any());
 
         final TeamConfig teamConfig = new TeamConfig(keyTarServiceMock, teamConfigServiceMock);


### PR DESCRIPTION
Migrate KeyTar implementation to Jackson and improve state handling and testability.

**Changes**

Jackson Migration

- Replaced org.json.simple parsing with Jackson ObjectMapper and JsonNode
- Improved JSON parsing safety and error handling
- Eliminated unsafe casting and legacy JSON parsing dependency

State Management Fixes

- Fixed state leakage in KeyTarImpl by properly clearing internal state during processKey()
- Ensured keyTarConfigs does not retain stale data across multiple service lookups
- Improved correctness when iterating through multiple KeyTar service names

Service Layer Improvements

- Enhanced KeyTarService logging and fallback behavior across multiple credential stores
- Added clearer debug messages for multi-store scenarios

Validation & Robustness

- Strengthened JSON parsing validation for KeyTar response structure
- Added handling for malformed or unexpected store nodes
- Improved error reporting for missing credential fields

Testability Improvements

- Added test support for multi-store parsing, malformed nodes, and missing fields
- Enabled safer verification of stateful behavior in isolation