### PR TITLE
refactor: Standardize JSON request body serialization on Jackson

### DIFF
--- a/src/main/java/zowe/client/sdk/utility/JsonUtils.java
+++ b/src/main/java/zowe/client/sdk/utility/JsonUtils.java
@@ -102,6 +102,26 @@ public final class JsonUtils {
     }
 
     /**
+     * Serialize the given object as a JSON request body.
+     *
+     * @param body object to serialize (Map or POJO)
+     * @return JSON string
+     * @throws IllegalArgumentException if serialization fails
+     */
+    public static String asRequestBodyJson(final Object body) {
+        if (body == null) {
+            return null;
+        }
+
+        try {
+            return objectMapper.writeValueAsString(body);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException(
+                    "Failed to serialize request body to JSON", e);
+        }
+    }
+
+    /**
      * Convert a JSONObject to a {@code Map<String, String>}, converting all values to String.
      * <p>
      * This method supports JSON values of any type (string, number, boolean, null, etc.)

--- a/src/main/java/zowe/client/sdk/zosconsole/methods/ConsoleCmd.java
+++ b/src/main/java/zowe/client/sdk/zosconsole/methods/ConsoleCmd.java
@@ -9,7 +9,7 @@
  */
 package zowe.client.sdk.zosconsole.methods;
 
-import org.json.simple.JSONObject;
+
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.PutJsonZosmfRequest;
 import zowe.client.sdk.rest.UrlConstants;
@@ -144,7 +144,7 @@ public class ConsoleCmd {
             request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
         }
         request.setUrl(url);
-        request.setBody(new JSONObject(issueMap).toString());
+        request.setBody(JsonUtils.asRequestBodyJson(issueMap));
 
         final String responsePhrase = request.executeRequest()
                 .getResponsePhrase()

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnCopy.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnCopy.java
@@ -9,7 +9,7 @@
  */
 package zowe.client.sdk.zosfiles.dsn.methods;
 
-import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.JsonUtils;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.*;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
@@ -113,14 +113,14 @@ public class DsnCopy {
         final Map<String, Object> fromDataSetMap = setFromDataSetMapValues(copyInputData);
         final Map<String, Object> copyMap = new HashMap<>();
         copyMap.put("request", "copy");
-        copyMap.put("from-dataset", new JSONObject(fromDataSetMap));
+        copyMap.put("from-dataset", fromDataSetMap);
         copyMap.put("replace", copyInputData.isReplace());
 
         if (request == null) {
             request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
         }
         request.setUrl(url);
-        request.setBody(new JSONObject(copyMap).toString());
+        request.setBody(JsonUtils.asRequestBodyJson(copyMap));
 
         return request.executeRequest();
     }

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnCreate.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnCreate.java
@@ -9,7 +9,7 @@
  */
 package zowe.client.sdk.zosfiles.dsn.methods;
 
-import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.JsonUtils;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.*;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
@@ -106,7 +106,7 @@ public class DsnCreate {
             request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.POST_JSON);
         }
         request.setUrl(url);
-        request.setBody(new JSONObject(createMap).toString());
+        request.setBody(JsonUtils.asRequestBodyJson(createMap));
 
         return request.executeRequest();
     }

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnRename.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnRename.java
@@ -10,7 +10,7 @@
  */
 package zowe.client.sdk.zosfiles.dsn.methods;
 
-import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.JsonUtils;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.*;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
@@ -139,14 +139,13 @@ public class DsnRename {
             fromDataSetReq.put("member", args[1]);
         }
 
-        final JSONObject fromDataSetObj = new JSONObject(fromDataSetReq);
-        renameMap.put("from-dataset", fromDataSetObj);
+        renameMap.put("from-dataset", fromDataSetReq);
 
         if (request == null) {
             request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
         }
         request.setUrl(url);
-        request.setBody(new JSONObject(renameMap).toString());
+        request.setBody(JsonUtils.asRequestBodyJson(renameMap));
 
         return request.executeRequest();
     }

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeMode.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeMode.java
@@ -9,7 +9,7 @@
  */
 package zowe.client.sdk.zosfiles.uss.methods;
 
-import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.JsonUtils;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.PutJsonZosmfRequest;
 import zowe.client.sdk.rest.Response;
@@ -101,7 +101,7 @@ public class UssChangeMode {
             request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
         }
         request.setUrl(url);
-        request.setBody(new JSONObject(changeModeMap).toString());
+        request.setBody(JsonUtils.asRequestBodyJson(changeModeMap));
 
         return request.executeRequest();
     }

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeOwner.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeOwner.java
@@ -9,7 +9,7 @@
  */
 package zowe.client.sdk.zosfiles.uss.methods;
 
-import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.JsonUtils;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.PutJsonZosmfRequest;
 import zowe.client.sdk.rest.Response;
@@ -113,7 +113,7 @@ public class UssChangeOwner {
             request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
         }
         request.setUrl(url);
-        request.setBody(new JSONObject(changeOnerMap).toString());
+        request.setBody(JsonUtils.asRequestBodyJson(changeOnerMap));
 
         return request.executeRequest();
     }

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeTag.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeTag.java
@@ -9,7 +9,7 @@
  */
 package zowe.client.sdk.zosfiles.uss.methods;
 
-import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.JsonUtils;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.PutJsonZosmfRequest;
 import zowe.client.sdk.rest.Response;
@@ -159,7 +159,7 @@ public class UssChangeTag {
             request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
         }
         request.setUrl(url);
-        request.setBody(new JSONObject(changeTagMap).toString());
+        request.setBody(JsonUtils.asRequestBodyJson(changeTagMap));
 
         return request.executeRequest();
     }

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssCopy.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssCopy.java
@@ -9,7 +9,7 @@
  */
 package zowe.client.sdk.zosfiles.uss.methods;
 
-import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.JsonUtils;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.PutJsonZosmfRequest;
 import zowe.client.sdk.rest.Response;
@@ -116,7 +116,7 @@ public class UssCopy {
             request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
         }
         request.setUrl(url);
-        request.setBody(new JSONObject(copyMap).toString());
+        request.setBody(JsonUtils.asRequestBodyJson(copyMap));
 
         return request.executeRequest();
     }

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssCreate.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssCreate.java
@@ -9,7 +9,7 @@
  */
 package zowe.client.sdk.zosfiles.uss.methods;
 
-import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.JsonUtils;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.*;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
@@ -97,7 +97,7 @@ public class UssCreate {
             request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.POST_JSON);
         }
         request.setUrl(url);
-        request.setBody(new JSONObject(createMap).toString());
+        request.setBody(JsonUtils.asRequestBodyJson(createMap));
 
         return request.executeRequest();
     }
@@ -160,7 +160,7 @@ public class UssCreate {
         }
 
         request.setUrl(url.toString());
-        request.setBody(new JSONObject(createZfsMap).toString());
+        request.setBody(JsonUtils.asRequestBodyJson(createZfsMap));
 
         return request.executeRequest();
     }

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssExtAttr.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssExtAttr.java
@@ -10,7 +10,7 @@
 package zowe.client.sdk.zosfiles.uss.methods;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.json.simple.JSONObject;
+
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.PutJsonZosmfRequest;
 import zowe.client.sdk.rest.Response;
@@ -153,7 +153,7 @@ public class UssExtAttr {
             request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
         }
         request.setUrl(url);
-        request.setBody(new JSONObject(jsonMap).toString());
+        request.setBody(JsonUtils.asRequestBodyJson(jsonMap));
 
         return request.executeRequest();
     }

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssGetAcl.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssGetAcl.java
@@ -10,7 +10,7 @@
 package zowe.client.sdk.zosfiles.uss.methods;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.json.simple.JSONObject;
+
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.PutJsonZosmfRequest;
 import zowe.client.sdk.rest.Response;
@@ -133,7 +133,7 @@ public class UssGetAcl {
             request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
         }
         request.setUrl(url);
-        request.setBody(new JSONObject(getAclMap).toString());
+        request.setBody(JsonUtils.asRequestBodyJson(getAclMap));
 
         return request.executeRequest();
     }

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssMount.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssMount.java
@@ -9,7 +9,7 @@
  */
 package zowe.client.sdk.zosfiles.uss.methods;
 
-import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.JsonUtils;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.*;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
@@ -137,7 +137,7 @@ public class UssMount {
             request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
         }
         request.setUrl(url);
-        request.setBody(new JSONObject(mountMap).toString());
+        request.setBody(JsonUtils.asRequestBodyJson(mountMap));
 
         return request.executeRequest();
     }

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssMove.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssMove.java
@@ -9,7 +9,7 @@
  */
 package zowe.client.sdk.zosfiles.uss.methods;
 
-import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.JsonUtils;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.PutJsonZosmfRequest;
 import zowe.client.sdk.rest.Response;
@@ -126,7 +126,7 @@ public class UssMove {
             request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
         }
         request.setUrl(url);
-        request.setBody(new JSONObject(moveMap).toString());
+        request.setBody(JsonUtils.asRequestBodyJson(moveMap));
 
         return request.executeRequest();
     }

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssSetAcl.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssSetAcl.java
@@ -9,7 +9,7 @@
  */
 package zowe.client.sdk.zosfiles.uss.methods;
 
-import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.JsonUtils;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.PutJsonZosmfRequest;
 import zowe.client.sdk.rest.Response;
@@ -173,7 +173,7 @@ public class UssSetAcl {
             request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
         }
         request.setUrl(url);
-        request.setBody(new JSONObject(setAclMap).toString());
+        request.setBody(JsonUtils.asRequestBodyJson(setAclMap));
 
         return request.executeRequest();
     }

--- a/src/main/java/zowe/client/sdk/zosjobs/methods/JobCancel.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/methods/JobCancel.java
@@ -9,7 +9,7 @@
  */
 package zowe.client.sdk.zosjobs.methods;
 
-import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.JsonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zowe.client.sdk.core.ZosConnection;
@@ -150,7 +150,7 @@ public class JobCancel {
         if (request == null) {
             request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
         }
-        request.setBody(new JSONObject(cancelMap).toString());
+        request.setBody(JsonUtils.asRequestBodyJson(cancelMap));
         request.setUrl(url);
 
         // if synchronously response should contain a job document that was canceled and http return code

--- a/src/main/java/zowe/client/sdk/zosjobs/methods/JobChange.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/methods/JobChange.java
@@ -9,7 +9,7 @@
  */
 package zowe.client.sdk.zosjobs.methods;
 
-import org.json.simple.JSONObject;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zowe.client.sdk.core.ZosConnection;
@@ -141,7 +141,7 @@ public class JobChange {
             request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
         }
         request.setUrl(url);
-        request.setBody(new JSONObject(changeMap).toString());
+        request.setBody(JsonUtils.asRequestBodyJson(changeMap));
 
         final String responsePhrase = request.executeRequest()
                 .getResponsePhrase()
@@ -213,7 +213,7 @@ public class JobChange {
             request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
         }
         request.setUrl(url);
-        request.setBody(new JSONObject(holdMap).toString());
+        request.setBody(JsonUtils.asRequestBodyJson(holdMap));
 
         final String responsePhrase = request.executeRequest()
                 .getResponsePhrase()
@@ -285,7 +285,7 @@ public class JobChange {
             request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
         }
         request.setUrl(url);
-        request.setBody(new JSONObject(releaseMap).toString());
+        request.setBody(JsonUtils.asRequestBodyJson(releaseMap));
 
         final String responsePhrase = request.executeRequest()
                 .getResponsePhrase()

--- a/src/main/java/zowe/client/sdk/zosjobs/methods/JobSubmit.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/methods/JobSubmit.java
@@ -9,7 +9,7 @@
  */
 package zowe.client.sdk.zosjobs.methods;
 
-import org.json.simple.JSONObject;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zowe.client.sdk.core.ZosConnection;
@@ -215,7 +215,7 @@ public class JobSubmit {
             request.setHeaders(getSubstitutionHeaders(submitInputData.getJclSymbols().get()));
         }
         request.setUrl(url);
-        request.setBody(new JSONObject(submitMap).toString());
+        request.setBody(JsonUtils.asRequestBodyJson(submitMap));
 
         final String responsePhrase = request.executeRequest()
                 .getResponsePhrase()

--- a/src/main/java/zowe/client/sdk/zosmfauth/methods/ZosmfPassword.java
+++ b/src/main/java/zowe/client/sdk/zosmfauth/methods/ZosmfPassword.java
@@ -9,7 +9,7 @@
  */
 package zowe.client.sdk.zosmfauth.methods;
 
-import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.JsonUtils;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.PutJsonZosmfRequest;
 import zowe.client.sdk.rest.Response;
@@ -93,7 +93,7 @@ public class ZosmfPassword {
         }
 
         request.setUrl(url);
-        request.setBody(new JSONObject(passwordMap).toJSONString());
+        request.setBody(JsonUtils.asRequestBodyJson(passwordMap));
 
         return request.executeRequest();
     }

--- a/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCreate.java
+++ b/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCreate.java
@@ -9,8 +9,7 @@
  */
 package zowe.client.sdk.zosmfworkflow.methods;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zowe.client.sdk.core.ZosConnection;
@@ -45,7 +44,6 @@ import java.util.List;
 public class WorkflowCreate {
 
     private static final Logger LOG = LoggerFactory.getLogger(WorkflowCreate.class);
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final String CONTEXT = "create";
     private final ZosConnection connection;
     private ZosmfRequest request;
@@ -107,11 +105,7 @@ public class WorkflowCreate {
         }
         request.setUrl(url);
 
-        try {
-            request.setBody(OBJECT_MAPPER.writeValueAsString(createInputData));
-        } catch (JsonProcessingException e) {
-            throw new ZosmfRequestException("error serializing workflow create request", e);
-        }
+        request.setBody(JsonUtils.asRequestBodyJson(createInputData));
 
         final String responsePhrase = request.executeRequest()
                 .getResponsePhrase()

--- a/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowStart.java
+++ b/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowStart.java
@@ -9,8 +9,7 @@
  */
 package zowe.client.sdk.zosmfworkflow.methods;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import zowe.client.sdk.utility.JsonUtils;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.*;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
@@ -30,7 +29,6 @@ import zowe.client.sdk.zosmfworkflow.input.WorkflowStartInputData;
  */
 public class WorkflowStart {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private final ZosConnection connection;
     private ZosmfRequest request;
 
@@ -100,11 +98,7 @@ public class WorkflowStart {
         }
         request.setUrl(url);
 
-        try {
-            request.setBody(OBJECT_MAPPER.writeValueAsString(startInputData));
-        } catch (JsonProcessingException e) {
-            throw new IllegalStateException("error serializing workflow start request", e);
-        }
+        request.setBody(JsonUtils.asRequestBodyJson(startInputData));
 
         return request.executeRequest();
     }

--- a/src/main/java/zowe/client/sdk/zosvariables/methods/VariableCreate.java
+++ b/src/main/java/zowe/client/sdk/zosvariables/methods/VariableCreate.java
@@ -9,8 +9,7 @@
  */
 package zowe.client.sdk.zosvariables.methods;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import zowe.client.sdk.utility.JsonUtils;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.*;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
@@ -33,7 +32,6 @@ import java.util.Map;
  */
 public class VariableCreate {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private final ZosConnection connection;
     private final ZosmfRequest request;
@@ -97,11 +95,7 @@ public class VariableCreate {
                 EncodeUtils.encodeURIComponent(sysplexName) + "." +
                 EncodeUtils.encodeURIComponent(systemName);
 
-        try {
-            request.setBody(OBJECT_MAPPER.writeValueAsString(Map.of("system-variable-list", variables)));
-        } catch (JsonProcessingException e) {
-            throw new IllegalStateException("error serializing variables", e);
-        }
+        request.setBody(JsonUtils.asRequestBodyJson(Map.of("system-variable-list", variables)));
 
         request.setUrl(url);
         return request.executeRequest();

--- a/src/main/java/zowe/client/sdk/zosvariables/methods/VariableDelete.java
+++ b/src/main/java/zowe/client/sdk/zosvariables/methods/VariableDelete.java
@@ -9,8 +9,7 @@
  */
 package zowe.client.sdk.zosvariables.methods;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import zowe.client.sdk.utility.JsonUtils;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.*;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
@@ -31,7 +30,6 @@ import java.util.List;
  */
 public class VariableDelete {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private final ZosConnection connection;
     private final ZosmfRequest request;
@@ -134,11 +132,7 @@ public class VariableDelete {
             request.setBody(null);
         } else {
             ValidateUtils.checkNullParameter(variableNames, "variableNames");
-            try {
-                request.setBody(OBJECT_MAPPER.writeValueAsString(variableNames));
-            } catch (JsonProcessingException e) {
-                throw new IllegalStateException("error serializing variable names", e);
-            }
+            request.setBody(JsonUtils.asRequestBodyJson(variableNames));
         }
 
         request.setUrl(url);

--- a/src/main/java/zowe/client/sdk/zosvariables/methods/VariableExport.java
+++ b/src/main/java/zowe/client/sdk/zosvariables/methods/VariableExport.java
@@ -9,7 +9,7 @@
  */
 package zowe.client.sdk.zosvariables.methods;
 
-import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.JsonUtils;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.*;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
@@ -132,7 +132,7 @@ public class VariableExport {
         bodyMap.put("overwrite", overwrite);
 
         request.setUrl(url);
-        request.setBody(new JSONObject(bodyMap).toString());
+        request.setBody(JsonUtils.asRequestBodyJson(bodyMap));
 
         return request.executeRequest();
     }

--- a/src/main/java/zowe/client/sdk/zosvariables/methods/VariableImport.java
+++ b/src/main/java/zowe/client/sdk/zosvariables/methods/VariableImport.java
@@ -9,7 +9,7 @@
  */
 package zowe.client.sdk.zosvariables.methods;
 
-import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.JsonUtils;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.*;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
@@ -95,7 +95,7 @@ public class VariableImport {
         bodyMap.put("variables-import-file", targetFile);
 
         request.setUrl(url);
-        request.setBody(new JSONObject(bodyMap).toString());
+        request.setBody(JsonUtils.asRequestBodyJson(bodyMap));
 
         return request.executeRequest();
     }

--- a/src/test/java/zowe/client/sdk/zosvariables/methods/VariableExportTest.java
+++ b/src/test/java/zowe/client/sdk/zosvariables/methods/VariableExportTest.java
@@ -71,7 +71,7 @@ public class VariableExportTest {
         assertEquals(204, response.getStatusCode().orElse(-1));
         assertEquals("No Content", response.getStatusText().orElse("n\\a"));
         assertEquals("https://1:443/zosmf/variables/rest/1.0/systems/PLEX1.SYS1/actions/export", mockPostRequest.getUrl());
-        Mockito.verify(mockPostRequest).setBody("{\"overwrite\":false,\"variables-export-file\":\"\\/path\\/to\\/export.csv\"}");
+        Mockito.verify(mockPostRequest).setBody("{\"overwrite\":false,\"variables-export-file\":\"/path/to/export.csv\"}");
     }
 
     @Test
@@ -82,7 +82,7 @@ public class VariableExportTest {
         assertEquals(204, response.getStatusCode().orElse(-1));
         assertEquals("No Content", response.getStatusText().orElse("n\\a"));
         assertEquals("https://1:443/zosmf/variables/rest/1.0/systems/PLEX1.SYS1/actions/export", mockPostRequest.getUrl());
-        Mockito.verify(mockPostRequest).setBody("{\"overwrite\":true,\"variables-export-file\":\"\\/path\\/to\\/export.csv\"}");
+        Mockito.verify(mockPostRequest).setBody("{\"overwrite\":true,\"variables-export-file\":\"/path/to/export.csv\"}");
     }
 
     @Test
@@ -93,7 +93,7 @@ public class VariableExportTest {
         assertEquals(204, response.getStatusCode().orElse(-1));
         assertEquals("No Content", response.getStatusText().orElse("n\\a"));
         assertEquals("https://1:443/zosmf/variables/rest/1.0/systems/PLEX1.SYS1/actions/export", mockPostRequest.getUrl());
-        Mockito.verify(mockPostRequest).setBody("{\"overwrite\":false,\"variables-export-file\":\"\\/path\\/to\\/export.csv\"}");
+        Mockito.verify(mockPostRequest).setBody("{\"overwrite\":false,\"variables-export-file\":\"/path/to/export.csv\"}");
     }
 
     @Test
@@ -106,7 +106,7 @@ public class VariableExportTest {
         assertEquals(204, response.getStatusCode().orElse(-1));
         assertEquals("No Content", response.getStatusText().orElse("n\\a"));
         assertEquals("https://1:443/zosmf/variables/rest/1.0/systems/PLEX1.SYS1/actions/export", mockPostRequestToken.getUrl());
-        Mockito.verify(mockPostRequestToken).setBody("{\"overwrite\":false,\"variables-export-file\":\"\\/path\\/to\\/export.csv\"}");
+        Mockito.verify(mockPostRequestToken).setBody("{\"overwrite\":false,\"variables-export-file\":\"/path/to/export.csv\"}");
     }
 
     @Test


### PR DESCRIPTION
## Overview
This PR addresses [Issue #526](https://github.com/zowe/zowe-client-java-sdk/issues/526) by standardizing all z/OSMF REST request body serialization on Jackson and removing the redundant `org.json.simple.JSONObject` usage for payload serialization.

## Proposed Changes
1. **Added Centralized Helper**:
   - Implemented `JsonUtils.asRequestBodyJson(final Object body)` which serializes POJOs/Maps using the shared `objectMapper` and wraps checked exceptions into `IllegalArgumentException`.
2. **Standardized Requests Serialization**:
   - Replaced all usages of `request.setBody(new JSONObject(...).toString())` and direct `OBJECT_MAPPER.writeValueAsString(...)` calls with `request.setBody(JsonUtils.asRequestBodyJson(...))` in all SDK service methods (Console, Dataset, USS, Job, Auth, Variable, and Workflow services).
   - Removed unused `org.json.simple.JSONObject` imports across the codebase.
3. **Updated Unit Tests**:
   - Adjusted `VariableExportTest.java` mock assertions to reflect standard Jackson JSON formatting (which does not escape forward slashes, unlike `org.json.simple.JSONObject`).

## Verification
- Executed the full test suite locally: `./mvnw clean test`
- All 1094 tests passed successfully.