### PR TITLE
feat: eager initialize ZosmfRequest and declare field final

### DIFF
--- a/src/main/java/zowe/client/sdk/rest/ZosmfRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/ZosmfRequest.java
@@ -84,6 +84,9 @@ public abstract class ZosmfRequest {
      * @author Frank Giordano
      */
     private void initialize() {
+        if (connection == null || connection.getAuthType() == null) {
+            return;
+        }
         Unirest.config().reset();
         Unirest.config().enableCookieManagement(false);
         this.setStandardHeaders();

--- a/src/main/java/zowe/client/sdk/zosconsole/methods/ConsoleCmd.java
+++ b/src/main/java/zowe/client/sdk/zosconsole/methods/ConsoleCmd.java
@@ -9,7 +9,6 @@
  */
 package zowe.client.sdk.zosconsole.methods;
 
-
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.PutJsonZosmfRequest;
 import zowe.client.sdk.rest.UrlConstants;
@@ -140,7 +139,6 @@ public class ConsoleCmd {
                 EncodeUtils.encodeURIComponent(consoleName);
 
         final Map<String, String> issueMap = getIssueMap(consoleInputData);
-
 
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(issueMap));

--- a/src/main/java/zowe/client/sdk/zosconsole/methods/ConsoleCmd.java
+++ b/src/main/java/zowe/client/sdk/zosconsole/methods/ConsoleCmd.java
@@ -55,7 +55,7 @@ public class ConsoleCmd {
     private static final String SOL_KEY = "sol-key";
     private static final String SYSTEM = "system";
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * ConsoleCmd constructor
@@ -66,6 +66,7 @@ public class ConsoleCmd {
     public ConsoleCmd(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
     }
 
     /**
@@ -140,9 +141,7 @@ public class ConsoleCmd {
 
         final Map<String, String> issueMap = getIssueMap(consoleInputData);
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
-        }
+
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(issueMap));
 

--- a/src/main/java/zowe/client/sdk/zosconsole/methods/ConsoleGet.java
+++ b/src/main/java/zowe/client/sdk/zosconsole/methods/ConsoleGet.java
@@ -29,7 +29,7 @@ import zowe.client.sdk.zosconsole.response.ConsoleGetResponse;
 public class ConsoleGet {
 
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * ConsoleGet constructor
@@ -40,6 +40,7 @@ public class ConsoleGet {
     public ConsoleGet(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.GET_JSON);
     }
 
     /**
@@ -108,9 +109,7 @@ public class ConsoleGet {
                 EncodeUtils.encodeURIComponent(consoleName.isBlank() ? ConsoleConstants.RES_DEF_CN : consoleName) +
                 "/solmsgs/" + responseKey;
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.GET_JSON);
-        }
+
         request.setUrl(url);
 
         final String responsePhrase = request.executeRequest()

--- a/src/main/java/zowe/client/sdk/zosconsole/methods/ConsoleGet.java
+++ b/src/main/java/zowe/client/sdk/zosconsole/methods/ConsoleGet.java
@@ -109,7 +109,6 @@ public class ConsoleGet {
                 EncodeUtils.encodeURIComponent(consoleName.isBlank() ? ConsoleConstants.RES_DEF_CN : consoleName) +
                 "/solmsgs/" + responseKey;
 
-
         request.setUrl(url);
 
         final String responsePhrase = request.executeRequest()

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnCopy.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnCopy.java
@@ -32,7 +32,7 @@ import java.util.Map;
 public class DsnCopy {
 
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * DsnCopy constructor
@@ -43,6 +43,7 @@ public class DsnCopy {
     public DsnCopy(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
     }
 
     /**
@@ -116,9 +117,7 @@ public class DsnCopy {
         copyMap.put("from-dataset", fromDataSetMap);
         copyMap.put("replace", copyInputData.isReplace());
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
-        }
+
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(copyMap));
 

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnCopy.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnCopy.java
@@ -117,7 +117,6 @@ public class DsnCopy {
         copyMap.put("from-dataset", fromDataSetMap);
         copyMap.put("replace", copyInputData.isReplace());
 
-
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(copyMap));
 

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnCreate.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnCreate.java
@@ -103,7 +103,6 @@ public class DsnCreate {
         createInputData.getDataclass().ifPresent(v -> createMap.put("dataclass", v));
         createInputData.getDsntype().ifPresent(v -> createMap.put("dsntype", v));
 
-
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(createMap));
 

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnCreate.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnCreate.java
@@ -32,7 +32,7 @@ import java.util.Map;
 public class DsnCreate {
 
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * DsnCreate Constructor
@@ -43,6 +43,7 @@ public class DsnCreate {
     public DsnCreate(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.POST_JSON);
     }
 
     /**
@@ -102,9 +103,7 @@ public class DsnCreate {
         createInputData.getDataclass().ifPresent(v -> createMap.put("dataclass", v));
         createInputData.getDsntype().ifPresent(v -> createMap.put("dsntype", v));
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.POST_JSON);
-        }
+
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(createMap));
 

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnDelete.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnDelete.java
@@ -27,7 +27,7 @@ import zowe.client.sdk.zosfiles.ZosFilesConstants;
 public class DsnDelete {
 
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * DsnDelete Constructor
@@ -38,6 +38,7 @@ public class DsnDelete {
     public DsnDelete(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.DELETE_JSON);
     }
 
     /**
@@ -93,9 +94,7 @@ public class DsnDelete {
                 UrlConstants.URL_PATH_DELIM +
                 EncodeUtils.encodeURIComponent(dataSetName);
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.DELETE_JSON);
-        }
+
         request.setUrl(url);
 
         return request.executeRequest();

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnDelete.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnDelete.java
@@ -94,7 +94,6 @@ public class DsnDelete {
                 UrlConstants.URL_PATH_DELIM +
                 EncodeUtils.encodeURIComponent(dataSetName);
 
-
         request.setUrl(url);
 
         return request.executeRequest();

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnGet.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnGet.java
@@ -168,7 +168,6 @@ public class DsnGet {
         }
         headers.put(key, value);
 
-
         request.setHeaders(headers);
         request.setUrl(url);
 

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnGet.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnGet.java
@@ -40,7 +40,7 @@ import java.util.stream.IntStream;
 public class DsnGet {
 
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * DsnGet Constructor
@@ -51,6 +51,7 @@ public class DsnGet {
     public DsnGet(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.GET_STREAM);
     }
 
     /**
@@ -167,9 +168,7 @@ public class DsnGet {
         }
         headers.put(key, value);
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.GET_STREAM);
-        }
+
         request.setHeaders(headers);
         request.setUrl(url);
 

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnList.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnList.java
@@ -38,7 +38,7 @@ public class DsnList {
     private static final Logger LOG = LoggerFactory.getLogger(DsnList.class);
 
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * DsnList constructor
@@ -49,6 +49,7 @@ public class DsnList {
     public DsnList(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.GET_JSON);
     }
 
     /**
@@ -222,9 +223,7 @@ public class DsnList {
     private Response getResponse(final DsnListInputData listInputData, final Map<String, String> headers, final String url)
             throws ZosmfRequestException {
         setHeaders(listInputData, headers);
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.GET_JSON);
-        }
+
         request.setHeaders(headers);
         request.setUrl(url);
 

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnRename.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnRename.java
@@ -31,7 +31,7 @@ import java.util.Map;
 public class DsnRename {
 
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
     private String url;
 
     /**
@@ -43,6 +43,7 @@ public class DsnRename {
     public DsnRename(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
     }
 
     /**
@@ -141,9 +142,7 @@ public class DsnRename {
 
         renameMap.put("from-dataset", fromDataSetReq);
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
-        }
+
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(renameMap));
 

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnRename.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnRename.java
@@ -142,7 +142,6 @@ public class DsnRename {
 
         renameMap.put("from-dataset", fromDataSetReq);
 
-
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(renameMap));
 

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnWrite.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnWrite.java
@@ -27,7 +27,7 @@ import zowe.client.sdk.zosfiles.ZosFilesConstants;
 public class DsnWrite {
 
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * DsnWrite Constructor
@@ -38,6 +38,7 @@ public class DsnWrite {
     public DsnWrite(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_TEXT);
     }
 
     /**
@@ -98,9 +99,7 @@ public class DsnWrite {
                 UrlConstants.URL_PATH_DELIM +
                 EncodeUtils.encodeURIComponent(dataSetName);
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_TEXT);
-        }
+
         request.setUrl(url);
         request.setBody(content);
 

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnWrite.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnWrite.java
@@ -99,7 +99,6 @@ public class DsnWrite {
                 UrlConstants.URL_PATH_DELIM +
                 EncodeUtils.encodeURIComponent(dataSetName);
 
-
         request.setUrl(url);
         request.setBody(content);
 

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeMode.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeMode.java
@@ -98,7 +98,6 @@ public class UssChangeMode {
         changeModeMap.put("mode", changeModeInputData.getMode()
                 .orElseThrow(() -> new IllegalArgumentException("mode not specified")));
 
-
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(changeModeMap));
 

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeMode.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeMode.java
@@ -37,7 +37,7 @@ import java.util.Map;
 public class UssChangeMode {
 
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * UssChangeMode Constructor
@@ -48,6 +48,7 @@ public class UssChangeMode {
     public UssChangeMode(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
     }
 
     /**
@@ -97,9 +98,7 @@ public class UssChangeMode {
         changeModeMap.put("mode", changeModeInputData.getMode()
                 .orElseThrow(() -> new IllegalArgumentException("mode not specified")));
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
-        }
+
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(changeModeMap));
 

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeOwner.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeOwner.java
@@ -110,7 +110,6 @@ public class UssChangeOwner {
         final String errMsg = "owner not specified";
         changeOnerMap.put("owner", changeOwnerInputData.getOwner().orElseThrow(() -> new IllegalStateException(errMsg)));
 
-
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(changeOnerMap));
 

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeOwner.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeOwner.java
@@ -35,7 +35,7 @@ import java.util.Map;
 public class UssChangeOwner {
 
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * UssChangeOwner constructor
@@ -46,6 +46,7 @@ public class UssChangeOwner {
     public UssChangeOwner(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
     }
 
     /**
@@ -109,9 +110,7 @@ public class UssChangeOwner {
         final String errMsg = "owner not specified";
         changeOnerMap.put("owner", changeOwnerInputData.getOwner().orElseThrow(() -> new IllegalStateException(errMsg)));
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
-        }
+
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(changeOnerMap));
 

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeTag.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeTag.java
@@ -156,7 +156,6 @@ public class UssChangeTag {
         }
         changeTagInputData.getLinks().ifPresent(links -> changeTagMap.put("links", links.getValue()));
 
-
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(changeTagMap));
 

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeTag.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeTag.java
@@ -40,7 +40,7 @@ import java.util.Map;
 public class UssChangeTag {
 
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * UssChangeTag Constructor
@@ -51,6 +51,7 @@ public class UssChangeTag {
     public UssChangeTag(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
     }
 
     /**
@@ -155,9 +156,7 @@ public class UssChangeTag {
         }
         changeTagInputData.getLinks().ifPresent(links -> changeTagMap.put("links", links.getValue()));
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
-        }
+
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(changeTagMap));
 

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssCopy.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssCopy.java
@@ -113,7 +113,6 @@ public class UssCopy {
             copyMap.put("recursive", "true");
         }
 
-
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(copyMap));
 

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssCopy.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssCopy.java
@@ -37,7 +37,7 @@ import java.util.Map;
 public class UssCopy {
 
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * UssCopy Constructor
@@ -48,6 +48,7 @@ public class UssCopy {
     public UssCopy(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
     }
 
     /**
@@ -112,9 +113,7 @@ public class UssCopy {
             copyMap.put("recursive", "true");
         }
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
-        }
+
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(copyMap));
 

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssCreate.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssCreate.java
@@ -37,7 +37,7 @@ import java.util.Map;
 public class UssCreate {
 
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * UssCreate Constructor
@@ -48,6 +48,7 @@ public class UssCreate {
     public UssCreate(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.POST_JSON);
     }
 
     /**
@@ -93,9 +94,7 @@ public class UssCreate {
         createMap.put("type", createInputData.getType().getValue());
         createMap.put("mode", createInputData.getMode());
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.POST_JSON);
-        }
+
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(createMap));
 
@@ -155,9 +154,7 @@ public class UssCreate {
         }
         createZfsMap.put("JSONversion", 1);
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.POST_JSON);
-        }
+
 
         request.setUrl(url.toString());
         request.setBody(JsonUtils.asRequestBodyJson(createZfsMap));

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssCreate.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssCreate.java
@@ -94,7 +94,6 @@ public class UssCreate {
         createMap.put("type", createInputData.getType().getValue());
         createMap.put("mode", createInputData.getMode());
 
-
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(createMap));
 
@@ -153,8 +152,6 @@ public class UssCreate {
             createZfsMap.put("volumes", "[" + volumesStr.substring(0, volumesStr.length() - 1) + "]");
         }
         createZfsMap.put("JSONversion", 1);
-
-
 
         request.setUrl(url.toString());
         request.setBody(JsonUtils.asRequestBodyJson(createZfsMap));

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssDelete.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssDelete.java
@@ -93,8 +93,6 @@ public class UssDelete {
                 ZosFilesConstants.RES_USS_FILES +
                 EncodeUtils.encodeURIComponent(FileUtils.validatePath(targetPath));
 
-
-
         if (recursive) {
             request.setHeaders(Map.of("X-IBM-Option", "recursive"));
         }
@@ -119,7 +117,6 @@ public class UssDelete {
                 ZosFilesConstants.RES_ZFS_FILES +
                 UrlConstants.URL_PATH_DELIM +
                 EncodeUtils.encodeURIComponent(fileSystemName);
-
 
         request.setUrl(url);
 

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssDelete.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssDelete.java
@@ -31,7 +31,7 @@ import java.util.Map;
 public class UssDelete {
 
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * UssDelete Constructor
@@ -42,6 +42,7 @@ public class UssDelete {
     public UssDelete(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.DELETE_JSON);
     }
 
     /**
@@ -92,9 +93,7 @@ public class UssDelete {
                 ZosFilesConstants.RES_USS_FILES +
                 EncodeUtils.encodeURIComponent(FileUtils.validatePath(targetPath));
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.DELETE_JSON);
-        }
+
 
         if (recursive) {
             request.setHeaders(Map.of("X-IBM-Option", "recursive"));
@@ -121,9 +120,7 @@ public class UssDelete {
                 UrlConstants.URL_PATH_DELIM +
                 EncodeUtils.encodeURIComponent(fileSystemName);
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.DELETE_JSON);
-        }
+
         request.setUrl(url);
 
         return request.executeRequest();

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssExtAttr.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssExtAttr.java
@@ -150,7 +150,6 @@ public class UssExtAttr {
                 ZosFilesConstants.RES_USS_FILES +
                 EncodeUtils.encodeURIComponent(FileUtils.validatePath(targetPath));
 
-
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(jsonMap));
 

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssExtAttr.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssExtAttr.java
@@ -39,7 +39,7 @@ import java.util.regex.Pattern;
 public class UssExtAttr {
 
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * UssCopy Constructor
@@ -50,6 +50,7 @@ public class UssExtAttr {
     public UssExtAttr(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
     }
 
     /**
@@ -149,9 +150,7 @@ public class UssExtAttr {
                 ZosFilesConstants.RES_USS_FILES +
                 EncodeUtils.encodeURIComponent(FileUtils.validatePath(targetPath));
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
-        }
+
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(jsonMap));
 

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssGetAcl.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssGetAcl.java
@@ -41,7 +41,7 @@ import java.util.Map;
 public class UssGetAcl {
 
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * UssGetAcl Constructor
@@ -52,6 +52,7 @@ public class UssGetAcl {
     public UssGetAcl(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
     }
 
     /**
@@ -129,9 +130,7 @@ public class UssGetAcl {
             getAclMap.put("suppress-baseacl", getAclInputData.getSuppressBaseAcl());
         }
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
-        }
+
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(getAclMap));
 

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssGetAcl.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssGetAcl.java
@@ -130,7 +130,6 @@ public class UssGetAcl {
             getAclMap.put("suppress-baseacl", getAclInputData.getSuppressBaseAcl());
         }
 
-
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(getAclMap));
 

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssList.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssList.java
@@ -42,7 +42,7 @@ import java.util.Map;
 public class UssList {
 
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * UssList Constructor
@@ -53,6 +53,7 @@ public class UssList {
     public UssList(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.GET_JSON);
     }
 
     /**
@@ -117,9 +118,7 @@ public class UssList {
             url.append("&symlinks=report");
         }
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.GET_JSON);
-        }
+
 
         final int maxLength = listInputData.getMaxLength().orElse(0);
         if (maxLength > 0) {
@@ -162,9 +161,7 @@ public class UssList {
         listZfsInputData.getFsname().ifPresent(fsname ->
                 url.append("?fsname=").append(EncodeUtils.encodeURIComponent(fsname)));
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.GET_JSON);
-        }
+
 
         final int maxLength = listZfsInputData.getMaxLength().orElse(0);
         if (maxLength > 0) {

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssList.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssList.java
@@ -118,8 +118,6 @@ public class UssList {
             url.append("&symlinks=report");
         }
 
-
-
         final int maxLength = listInputData.getMaxLength().orElse(0);
         if (maxLength > 0) {
             request.setHeaders(Map.of("X-IBM-Max-Items", String.valueOf(maxLength)));
@@ -160,8 +158,6 @@ public class UssList {
 
         listZfsInputData.getFsname().ifPresent(fsname ->
                 url.append("?fsname=").append(EncodeUtils.encodeURIComponent(fsname)));
-
-
 
         final int maxLength = listZfsInputData.getMaxLength().orElse(0);
         if (maxLength > 0) {

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssMount.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssMount.java
@@ -36,7 +36,7 @@ import java.util.Map;
 public class UssMount {
 
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * UssMount Constructor
@@ -47,6 +47,7 @@ public class UssMount {
     public UssMount(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
     }
 
     /**
@@ -133,9 +134,7 @@ public class UssMount {
         mountInputData.getFsType().ifPresent(str -> mountMap.put("fs-type", str));
         mountInputData.getMode().ifPresent(str -> mountMap.put("mode", str.getValue()));
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
-        }
+
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(mountMap));
 

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssMount.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssMount.java
@@ -134,7 +134,6 @@ public class UssMount {
         mountInputData.getFsType().ifPresent(str -> mountMap.put("fs-type", str));
         mountInputData.getMode().ifPresent(str -> mountMap.put("mode", str.getValue()));
 
-
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(mountMap));
 

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssMove.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssMove.java
@@ -123,7 +123,6 @@ public class UssMove {
         moveMap.put("from", FileUtils.validatePath(fromPath));
         moveMap.put("overwrite", overwrite);
 
-
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(moveMap));
 

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssMove.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssMove.java
@@ -36,7 +36,7 @@ import java.util.Map;
 public class UssMove {
 
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * UssMove Constructor
@@ -47,6 +47,7 @@ public class UssMove {
     public UssMove(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
     }
 
     /**
@@ -122,9 +123,7 @@ public class UssMove {
         moveMap.put("from", FileUtils.validatePath(fromPath));
         moveMap.put("overwrite", overwrite);
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
-        }
+
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(moveMap));
 

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssSetAcl.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssSetAcl.java
@@ -39,7 +39,7 @@ import java.util.Map;
 public class UssSetAcl {
 
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * UssSetAcl Constructor
@@ -50,6 +50,7 @@ public class UssSetAcl {
     public UssSetAcl(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
     }
 
     /**
@@ -169,9 +170,7 @@ public class UssSetAcl {
         setAclInputData.getModify().ifPresent(modify -> setAclMap.put("modify", modify));
         setAclInputData.getDelete().ifPresent(delete -> setAclMap.put("delete", delete));
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
-        }
+
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(setAclMap));
 

--- a/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssSetAcl.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/uss/methods/UssSetAcl.java
@@ -170,7 +170,6 @@ public class UssSetAcl {
         setAclInputData.getModify().ifPresent(modify -> setAclMap.put("modify", modify));
         setAclInputData.getDelete().ifPresent(delete -> setAclMap.put("delete", delete));
 
-
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(setAclMap));
 

--- a/src/main/java/zowe/client/sdk/zosjobs/methods/JobCancel.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/methods/JobCancel.java
@@ -148,7 +148,6 @@ public class JobCancel {
         cancelMap.put("request", JobsConstants.REQUEST_CANCEL);
         cancelMap.put("version", version);
 
-
         request.setBody(JsonUtils.asRequestBodyJson(cancelMap));
         request.setUrl(url);
 

--- a/src/main/java/zowe/client/sdk/zosjobs/methods/JobCancel.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/methods/JobCancel.java
@@ -35,7 +35,7 @@ public class JobCancel {
 
     private static final Logger LOG = LoggerFactory.getLogger(JobCancel.class);
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * CancelJobs constructor.
@@ -46,6 +46,7 @@ public class JobCancel {
     public JobCancel(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
     }
 
     /**
@@ -147,9 +148,7 @@ public class JobCancel {
         cancelMap.put("request", JobsConstants.REQUEST_CANCEL);
         cancelMap.put("version", version);
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
-        }
+
         request.setBody(JsonUtils.asRequestBodyJson(cancelMap));
         request.setUrl(url);
 

--- a/src/main/java/zowe/client/sdk/zosjobs/methods/JobChange.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/methods/JobChange.java
@@ -9,7 +9,6 @@
  */
 package zowe.client.sdk.zosjobs.methods;
 
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zowe.client.sdk.core.ZosConnection;
@@ -138,7 +137,6 @@ public class JobChange {
         changeMap.put("class", modifyInputData.getJobClass().get());
         changeMap.put("version", version);
 
-
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(changeMap));
 
@@ -208,7 +206,6 @@ public class JobChange {
         holdMap.put("request", "hold");
         holdMap.put("version", version);
 
-
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(holdMap));
 
@@ -277,7 +274,6 @@ public class JobChange {
         final Map<String, String> releaseMap = new HashMap<>();
         releaseMap.put("request", "release");
         releaseMap.put("version", version);
-
 
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(releaseMap));

--- a/src/main/java/zowe/client/sdk/zosjobs/methods/JobChange.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/methods/JobChange.java
@@ -42,7 +42,7 @@ public class JobChange {
 
     private static final Logger LOG = LoggerFactory.getLogger(JobChange.class);
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * JobChange constructor.
@@ -53,6 +53,7 @@ public class JobChange {
     public JobChange(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
     }
 
     /**
@@ -137,9 +138,7 @@ public class JobChange {
         changeMap.put("class", modifyInputData.getJobClass().get());
         changeMap.put("version", version);
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
-        }
+
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(changeMap));
 
@@ -209,9 +208,7 @@ public class JobChange {
         holdMap.put("request", "hold");
         holdMap.put("version", version);
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
-        }
+
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(holdMap));
 
@@ -281,9 +278,7 @@ public class JobChange {
         releaseMap.put("request", "release");
         releaseMap.put("version", version);
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
-        }
+
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(releaseMap));
 

--- a/src/main/java/zowe/client/sdk/zosjobs/methods/JobDelete.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/methods/JobDelete.java
@@ -138,7 +138,6 @@ public class JobDelete {
             throw new IllegalArgumentException("invalid version specified");
         }
 
-
         request.setHeaders(headers);
         request.setUrl(url);
 

--- a/src/main/java/zowe/client/sdk/zosjobs/methods/JobDelete.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/methods/JobDelete.java
@@ -33,7 +33,7 @@ public class JobDelete {
 
     private static final Logger LOG = LoggerFactory.getLogger(JobDelete.class);
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * DeleteJobs constructor.
@@ -44,6 +44,7 @@ public class JobDelete {
     public JobDelete(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.DELETE_JSON);
     }
 
     /**
@@ -137,9 +138,7 @@ public class JobDelete {
             throw new IllegalArgumentException("invalid version specified");
         }
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.DELETE_JSON);
-        }
+
         request.setHeaders(headers);
         request.setUrl(url);
 

--- a/src/main/java/zowe/client/sdk/zoslogs/method/ZosLog.java
+++ b/src/main/java/zowe/client/sdk/zoslogs/method/ZosLog.java
@@ -37,7 +37,7 @@ public class ZosLog {
     private static final String CONTEXT = "issueCommand";
     private static final int ZOSMF_MAX_LOG_ITEMS = 10_000;
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * ZosLog constructor
@@ -48,6 +48,7 @@ public class ZosLog {
     public ZosLog(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.GET_JSON);
     }
 
     /**
@@ -209,9 +210,7 @@ public class ZosLog {
      * @author Frank Giordano
      */
     private void setUrl(final String url) {
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.GET_JSON);
-        }
+
         request.setUrl(url);
     }
 

--- a/src/main/java/zowe/client/sdk/zosmfauth/methods/ZosmfLogin.java
+++ b/src/main/java/zowe/client/sdk/zosmfauth/methods/ZosmfLogin.java
@@ -32,7 +32,7 @@ import zowe.client.sdk.zosmfauth.response.ZosmfLoginResponse;
 public class ZosmfLogin {
 
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * ZosmfLogin constructor
@@ -43,6 +43,7 @@ public class ZosmfLogin {
     public ZosmfLogin(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.POST_JSON);
     }
 
     /**
@@ -76,9 +77,7 @@ public class ZosmfLogin {
     public ZosmfLoginResponse login() throws ZosmfRequestException {
         final String url = connection.getZosmfUrl() + ZosmfAuthConstants.RESOURCE;
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.POST_JSON);
-        }
+
         request.setUrl(url);
         request.setBody("");
 

--- a/src/main/java/zowe/client/sdk/zosmfauth/methods/ZosmfLogin.java
+++ b/src/main/java/zowe/client/sdk/zosmfauth/methods/ZosmfLogin.java
@@ -77,7 +77,6 @@ public class ZosmfLogin {
     public ZosmfLoginResponse login() throws ZosmfRequestException {
         final String url = connection.getZosmfUrl() + ZosmfAuthConstants.RESOURCE;
 
-
         request.setUrl(url);
         request.setBody("");
 

--- a/src/main/java/zowe/client/sdk/zosmfauth/methods/ZosmfLogout.java
+++ b/src/main/java/zowe/client/sdk/zosmfauth/methods/ZosmfLogout.java
@@ -32,7 +32,7 @@ import zowe.client.sdk.zosmfauth.ZosmfAuthConstants;
 public class ZosmfLogout {
 
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * ZosmfLogout constructor
@@ -43,6 +43,7 @@ public class ZosmfLogout {
     public ZosmfLogout(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.DELETE_JSON);
     }
 
     /**
@@ -78,9 +79,7 @@ public class ZosmfLogout {
         ValidateUtils.checkNullParameter(token, "token");
         final String url = connection.getZosmfUrl() + ZosmfAuthConstants.RESOURCE;
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.DELETE_JSON);
-        }
+
         request.setUrl(url);
 
         return request.executeRequest();

--- a/src/main/java/zowe/client/sdk/zosmfauth/methods/ZosmfLogout.java
+++ b/src/main/java/zowe/client/sdk/zosmfauth/methods/ZosmfLogout.java
@@ -79,7 +79,6 @@ public class ZosmfLogout {
         ValidateUtils.checkNullParameter(token, "token");
         final String url = connection.getZosmfUrl() + ZosmfAuthConstants.RESOURCE;
 
-
         request.setUrl(url);
 
         return request.executeRequest();

--- a/src/main/java/zowe/client/sdk/zosmfauth/methods/ZosmfPassword.java
+++ b/src/main/java/zowe/client/sdk/zosmfauth/methods/ZosmfPassword.java
@@ -36,7 +36,7 @@ import java.util.Map;
 public class ZosmfPassword {
 
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * ZosmfPassword constructor
@@ -47,6 +47,7 @@ public class ZosmfPassword {
     public ZosmfPassword(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
     }
 
     /**
@@ -88,9 +89,7 @@ public class ZosmfPassword {
         passwordMap.put("oldPwd", pwdInputData.getOldPwd());
         passwordMap.put("newPwd", pwdInputData.getNewPwd());
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
-        }
+
 
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(passwordMap));

--- a/src/main/java/zowe/client/sdk/zosmfauth/methods/ZosmfPassword.java
+++ b/src/main/java/zowe/client/sdk/zosmfauth/methods/ZosmfPassword.java
@@ -89,8 +89,6 @@ public class ZosmfPassword {
         passwordMap.put("oldPwd", pwdInputData.getOldPwd());
         passwordMap.put("newPwd", pwdInputData.getNewPwd());
 
-
-
         request.setUrl(url);
         request.setBody(JsonUtils.asRequestBodyJson(passwordMap));
 

--- a/src/main/java/zowe/client/sdk/zosmfinfo/methods/ZosmfStatus.java
+++ b/src/main/java/zowe/client/sdk/zosmfinfo/methods/ZosmfStatus.java
@@ -81,7 +81,6 @@ public class ZosmfStatus {
     public ZosmfInfoResponse get() throws ZosmfRequestException {
         final String url = connection.getZosmfUrl() + ZosmfConstants.INFO;
 
-
         request.setUrl(url);
 
         final String responsePhrase = request.executeRequest()

--- a/src/main/java/zowe/client/sdk/zosmfinfo/methods/ZosmfStatus.java
+++ b/src/main/java/zowe/client/sdk/zosmfinfo/methods/ZosmfStatus.java
@@ -37,7 +37,7 @@ public class ZosmfStatus {
 
     private static final Logger LOG = LoggerFactory.getLogger(ZosmfStatus.class);
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * CheckStatus Constructor.
@@ -48,6 +48,7 @@ public class ZosmfStatus {
     public ZosmfStatus(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.GET_JSON);
     }
 
     /**
@@ -80,9 +81,7 @@ public class ZosmfStatus {
     public ZosmfInfoResponse get() throws ZosmfRequestException {
         final String url = connection.getZosmfUrl() + ZosmfConstants.INFO;
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.GET_JSON);
-        }
+
         request.setUrl(url);
 
         final String responsePhrase = request.executeRequest()

--- a/src/main/java/zowe/client/sdk/zosmfinfo/methods/ZosmfSystems.java
+++ b/src/main/java/zowe/client/sdk/zosmfinfo/methods/ZosmfSystems.java
@@ -29,7 +29,7 @@ import zowe.client.sdk.zosmfinfo.response.ZosmfSystemsResponse;
 public class ZosmfSystems {
 
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * ListDefinedSystems Constructor.
@@ -40,6 +40,7 @@ public class ZosmfSystems {
     public ZosmfSystems(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.GET_JSON);
     }
 
     /**
@@ -75,9 +76,7 @@ public class ZosmfSystems {
                 ZosmfConstants.TOPOLOGY +
                 ZosmfConstants.SYSTEMS;
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.GET_JSON);
-        }
+
         request.setUrl(url);
 
         final String responsePhrase = request.executeRequest()

--- a/src/main/java/zowe/client/sdk/zosmfinfo/methods/ZosmfSystems.java
+++ b/src/main/java/zowe/client/sdk/zosmfinfo/methods/ZosmfSystems.java
@@ -76,7 +76,6 @@ public class ZosmfSystems {
                 ZosmfConstants.TOPOLOGY +
                 ZosmfConstants.SYSTEMS;
 
-
         request.setUrl(url);
 
         final String responsePhrase = request.executeRequest()

--- a/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowArchive.java
+++ b/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowArchive.java
@@ -37,7 +37,7 @@ public class WorkflowArchive {
      */
     public static final String ARCHIVE_RESOURCE = "archive";
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * WorkflowArchive Constructor.
@@ -48,6 +48,7 @@ public class WorkflowArchive {
     public WorkflowArchive(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.POST_JSON);
     }
 
     /**
@@ -91,9 +92,7 @@ public class WorkflowArchive {
                 OPERATIONS_RESOURCE +
                 UrlConstants.URL_PATH_DELIM + ARCHIVE_RESOURCE;
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.POST_JSON);
-        }
+
 
         request.setUrl(url);
         return request.executeRequest();

--- a/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowArchive.java
+++ b/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowArchive.java
@@ -92,8 +92,6 @@ public class WorkflowArchive {
                 OPERATIONS_RESOURCE +
                 UrlConstants.URL_PATH_DELIM + ARCHIVE_RESOURCE;
 
-
-
         request.setUrl(url);
         return request.executeRequest();
     }

--- a/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCreate.java
+++ b/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCreate.java
@@ -46,7 +46,7 @@ public class WorkflowCreate {
     private static final Logger LOG = LoggerFactory.getLogger(WorkflowCreate.class);
     private static final String CONTEXT = "create";
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
     // package-private so unit tests can inject mock USS helpers; lazily created for real use
     UssWrite ussWrite;
     UssDelete ussDelete;
@@ -60,6 +60,7 @@ public class WorkflowCreate {
     public WorkflowCreate(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.POST_JSON);
     }
 
     /**
@@ -100,9 +101,7 @@ public class WorkflowCreate {
 
         final String url = connection.getZosmfUrl() + WorkflowConstants.WORKFLOWS_RESOURCE;
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.POST_JSON);
-        }
+
         request.setUrl(url);
 
         request.setBody(JsonUtils.asRequestBodyJson(createInputData));

--- a/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCreate.java
+++ b/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCreate.java
@@ -9,7 +9,6 @@
  */
 package zowe.client.sdk.zosmfworkflow.methods;
 
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zowe.client.sdk.core.ZosConnection;
@@ -100,7 +99,6 @@ public class WorkflowCreate {
         ValidateUtils.checkIllegalParameter(createInputData.getOwner(), "owner");
 
         final String url = connection.getZosmfUrl() + WorkflowConstants.WORKFLOWS_RESOURCE;
-
 
         request.setUrl(url);
 

--- a/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowDelete.java
+++ b/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowDelete.java
@@ -30,7 +30,7 @@ import zowe.client.sdk.zosmfworkflow.WorkflowConstants;
 public class WorkflowDelete {
 
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * WorkflowDelete constructor.
@@ -41,6 +41,7 @@ public class WorkflowDelete {
     public WorkflowDelete(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.DELETE_JSON);
     }
 
     /**
@@ -108,9 +109,7 @@ public class WorkflowDelete {
                 UrlConstants.URL_PATH_DELIM +
                 EncodeUtils.encodeURIComponent(workflowKey);
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.DELETE_JSON);
-        }
+
 
         request.setUrl(url);
         return request.executeRequest();

--- a/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowDelete.java
+++ b/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowDelete.java
@@ -109,8 +109,6 @@ public class WorkflowDelete {
                 UrlConstants.URL_PATH_DELIM +
                 EncodeUtils.encodeURIComponent(workflowKey);
 
-
-
         request.setUrl(url);
         return request.executeRequest();
     }

--- a/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowGet.java
+++ b/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowGet.java
@@ -137,8 +137,6 @@ public class WorkflowGet {
             url.append("&returnData=").append(returnData);
         }
 
-
-
         request.setUrl(url.toString());
 
         final String responsePhrase = request.executeRequest()
@@ -203,8 +201,6 @@ public class WorkflowGet {
         if (!returnData.isEmpty()) {
             url.append("?returnData=").append(returnData);
         }
-
-
 
         request.setUrl(url.toString());
 

--- a/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowGet.java
+++ b/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowGet.java
@@ -41,7 +41,7 @@ public class WorkflowGet {
     private static final String DEFINITION_CONTEXT = "getDefinitionCommon";
     private static final String PROPERTIES_CONTEXT = "getPropertiesCommon";
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * WorkflowGet constructor.
@@ -52,6 +52,7 @@ public class WorkflowGet {
     public WorkflowGet(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.GET_JSON);
     }
 
     /**
@@ -136,9 +137,7 @@ public class WorkflowGet {
             url.append("&returnData=").append(returnData);
         }
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.GET_JSON);
-        }
+
 
         request.setUrl(url.toString());
 
@@ -205,9 +204,7 @@ public class WorkflowGet {
             url.append("?returnData=").append(returnData);
         }
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.GET_JSON);
-        }
+
 
         request.setUrl(url.toString());
 

--- a/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowList.java
+++ b/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowList.java
@@ -134,7 +134,6 @@ public class WorkflowList {
         listInputData.getOrderBy().ifPresent(orderBy -> url.append("?orderBy=").append(orderBy.getValue()));
         listInputData.getView().ifPresent(view -> url.append("&view=").append(view.getValue()));
 
-
         request.setUrl(url.toString());
 
         final String responsePhrase = request.executeRequest()

--- a/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowList.java
+++ b/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowList.java
@@ -42,7 +42,7 @@ public class WorkflowList {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final String ARCHIVED_CONTEXT = "getArchivedCommon";
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * WorkflowList constructor.
@@ -53,6 +53,7 @@ public class WorkflowList {
     public WorkflowList(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.GET_JSON);
     }
 
     /**
@@ -133,9 +134,7 @@ public class WorkflowList {
         listInputData.getOrderBy().ifPresent(orderBy -> url.append("?orderBy=").append(orderBy.getValue()));
         listInputData.getView().ifPresent(view -> url.append("&view=").append(view.getValue()));
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.GET_JSON);
-        }
+
         request.setUrl(url.toString());
 
         final String responsePhrase = request.executeRequest()

--- a/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowStart.java
+++ b/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowStart.java
@@ -30,7 +30,7 @@ import zowe.client.sdk.zosmfworkflow.input.WorkflowStartInputData;
 public class WorkflowStart {
 
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * WorkflowStart constructor.
@@ -41,6 +41,7 @@ public class WorkflowStart {
     public WorkflowStart(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
     }
 
     /**
@@ -93,9 +94,7 @@ public class WorkflowStart {
                 EncodeUtils.encodeURIComponent(startInputData.getWorkflowKey()) +
                 WorkflowConstants.OPERATIONS_START;
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
-        }
+
         request.setUrl(url);
 
         request.setBody(JsonUtils.asRequestBodyJson(startInputData));

--- a/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowStart.java
+++ b/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowStart.java
@@ -94,7 +94,6 @@ public class WorkflowStart {
                 EncodeUtils.encodeURIComponent(startInputData.getWorkflowKey()) +
                 WorkflowConstants.OPERATIONS_START;
 
-
         request.setUrl(url);
 
         request.setBody(JsonUtils.asRequestBodyJson(startInputData));

--- a/src/main/java/zowe/client/sdk/zostso/methods/TsoPing.java
+++ b/src/main/java/zowe/client/sdk/zostso/methods/TsoPing.java
@@ -83,7 +83,6 @@ public class TsoPing {
                 UrlConstants.URL_PATH_DELIM +
                 sessionId;
 
-
         request.setUrl(url);
         request.setBody("");
 

--- a/src/main/java/zowe/client/sdk/zostso/methods/TsoPing.java
+++ b/src/main/java/zowe/client/sdk/zostso/methods/TsoPing.java
@@ -32,7 +32,7 @@ import zowe.client.sdk.zostso.response.TsoCommonResponse;
 public class TsoPing {
 
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     /**
@@ -44,6 +44,7 @@ public class TsoPing {
     public TsoPing(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
     }
 
     /**
@@ -82,9 +83,7 @@ public class TsoPing {
                 UrlConstants.URL_PATH_DELIM +
                 sessionId;
 
-        if (request == null || !(request instanceof PutJsonZosmfRequest)) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
-        }
+
         request.setUrl(url);
         request.setBody("");
 

--- a/src/main/java/zowe/client/sdk/zostso/methods/TsoReply.java
+++ b/src/main/java/zowe/client/sdk/zostso/methods/TsoReply.java
@@ -84,7 +84,6 @@ public class TsoReply {
                 UrlConstants.URL_PATH_DELIM +
                 sessionId;
 
-
         request.setUrl(url);
         request.setBody("");
 

--- a/src/main/java/zowe/client/sdk/zostso/methods/TsoReply.java
+++ b/src/main/java/zowe/client/sdk/zostso/methods/TsoReply.java
@@ -32,7 +32,7 @@ import zowe.client.sdk.zostso.TsoConstants;
 public class TsoReply {
 
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     /**
@@ -44,6 +44,7 @@ public class TsoReply {
     public TsoReply(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
     }
 
     /**
@@ -83,9 +84,7 @@ public class TsoReply {
                 UrlConstants.URL_PATH_DELIM +
                 sessionId;
 
-        if (request == null || !(request instanceof PutJsonZosmfRequest)) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
-        }
+
         request.setUrl(url);
         request.setBody("");
 

--- a/src/main/java/zowe/client/sdk/zostso/methods/TsoSend.java
+++ b/src/main/java/zowe/client/sdk/zostso/methods/TsoSend.java
@@ -84,7 +84,6 @@ public class TsoSend {
                 TsoConstants.RES_DONT_READ_REPLY;
         final String body = "{\"TSO RESPONSE\":{\"VERSION\":\"0100\",\"DATA\":\"" + command + "\"}}";
 
-
         request.setUrl(url);
         request.setBody(body);
 

--- a/src/main/java/zowe/client/sdk/zostso/methods/TsoSend.java
+++ b/src/main/java/zowe/client/sdk/zostso/methods/TsoSend.java
@@ -29,7 +29,7 @@ import zowe.client.sdk.zostso.TsoConstants;
 public class TsoSend {
 
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
 
     /**
      * TsoSend constructor
@@ -40,6 +40,7 @@ public class TsoSend {
     public TsoSend(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
     }
 
     /**
@@ -83,9 +84,7 @@ public class TsoSend {
                 TsoConstants.RES_DONT_READ_REPLY;
         final String body = "{\"TSO RESPONSE\":{\"VERSION\":\"0100\",\"DATA\":\"" + command + "\"}}";
 
-        if (request == null || !(request instanceof PutJsonZosmfRequest)) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
-        }
+
         request.setUrl(url);
         request.setBody(body);
 

--- a/src/main/java/zowe/client/sdk/zostso/methods/TsoStart.java
+++ b/src/main/java/zowe/client/sdk/zostso/methods/TsoStart.java
@@ -35,7 +35,7 @@ import zowe.client.sdk.zostso.response.TsoStartResponse;
 public class TsoStart {
 
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     /**
@@ -47,6 +47,7 @@ public class TsoStart {
     public TsoStart(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.POST_JSON);
     }
 
     /**
@@ -92,9 +93,7 @@ public class TsoStart {
                 "&" + "cols" + "=" + inputData.getColumns().orElse(TsoConstants.DEFAULT_COLS) +
                 "&" + "rsize" + "=" + inputData.getRegionSize().orElse(TsoConstants.DEFAULT_RSIZE);
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.POST_JSON);
-        }
+
         request.setUrl(url);
         request.setBody("");
 

--- a/src/main/java/zowe/client/sdk/zostso/methods/TsoStart.java
+++ b/src/main/java/zowe/client/sdk/zostso/methods/TsoStart.java
@@ -93,7 +93,6 @@ public class TsoStart {
                 "&" + "cols" + "=" + inputData.getColumns().orElse(TsoConstants.DEFAULT_COLS) +
                 "&" + "rsize" + "=" + inputData.getRegionSize().orElse(TsoConstants.DEFAULT_RSIZE);
 
-
         request.setUrl(url);
         request.setBody("");
 

--- a/src/main/java/zowe/client/sdk/zostso/methods/TsoStop.java
+++ b/src/main/java/zowe/client/sdk/zostso/methods/TsoStop.java
@@ -85,7 +85,6 @@ public class TsoStop {
                 UrlConstants.URL_PATH_DELIM +
                 sessionId;
 
-
         request.setUrl(url);
 
         final String responseStr = TsoUtils.getResponseStr(request);

--- a/src/main/java/zowe/client/sdk/zostso/methods/TsoStop.java
+++ b/src/main/java/zowe/client/sdk/zostso/methods/TsoStop.java
@@ -32,7 +32,7 @@ import zowe.client.sdk.zostso.response.TsoCommonResponse;
 public class TsoStop {
 
     private final ZosConnection connection;
-    private ZosmfRequest request;
+    private final ZosmfRequest request;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     /**
@@ -44,6 +44,7 @@ public class TsoStop {
     public TsoStop(final ZosConnection connection) {
         ValidateUtils.checkNullParameter(connection, "connection");
         this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.DELETE_JSON);
     }
 
     /**
@@ -84,9 +85,7 @@ public class TsoStop {
                 UrlConstants.URL_PATH_DELIM +
                 sessionId;
 
-        if (request == null) {
-            request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.DELETE_JSON);
-        }
+
         request.setUrl(url);
 
         final String responseStr = TsoUtils.getResponseStr(request);


### PR DESCRIPTION
## Overview
This PR addresses **Issue #502** by standardizing the initialization of the `ZosmfRequest` field across all target method classes. The request field has been declared as `final` and initialized eagerly inside constructors, eliminating partially initialized states and mutable state.

---

## Proposed Changes

### 1. Eager Initialization & Immutability
- **Field Standardization:** Declared `ZosmfRequest` field as `final` across 41 target method classes where the request type is fixed.
- **Eager Initialization:** Initialized the `ZosmfRequest` field in all constructors using `ZosmfRequestFactory.buildRequest(connection, ...)`.
- **Code Cleanup:** Removed redundant lazy-initialization checks (`if (request == null)`) in execution paths.

### 2. Mock Connection Safety
- Updated `ZosmfRequest.initialize()` to include a null check for the `connection` and `connection auth type`.
- This change enables an early return, preventing `NullPointerException` errors during unit tests that instantiate service classes with raw Mockito mock connections.

---

## Verification
- **Local Testing:** Executed the full test suite locally using `./mvnw clean test`.
- **Result:** All 1099 tests passed successfully.