### PR TITLE
CI: Implement Automated Release Workflow for Maven Central Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g., 7.0.0). Leave empty to use the current pom.xml version.'
+        required: false
+        type: string
+      skip-tests:
+        description: 'Skip running the test suite before deploying'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      # 1. Checkout the repository
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # 2. Set up JDK 11 and register Maven Central / GPG credentials
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: GPG_PASSPHRASE
+
+      # 3. Grant execute permission to Maven Wrapper
+      - name: Grant execute permission to mvnw
+        run: chmod +x ./mvnw
+
+      # 4. Cache Maven dependencies
+      - name: Cache Maven packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-release-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-release-
+
+      # 5. Bump version in pom.xml (only if a version was provided)
+      - name: Set release version
+        if: ${{ inputs.version != '' }}
+        run: ./mvnw versions:set -DnewVersion=${{ inputs.version }} -DgenerateBackupPoms=false
+
+      # 6. Run test suite (unless skipped)
+      - name: Build and test
+        if: ${{ !inputs.skip-tests }}
+        run: ./mvnw clean package
+
+      # 7. Deploy to Maven Central
+      - name: Deploy to Maven Central
+        run: ./mvnw clean deploy -Pci-cd -DskipTests
+        env:
+          MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          MAVEN_OPTS: -Dgpg.keyname=${{ secrets.GPG_KEYID }}
+
+      # 8. Determine the released version
+      - name: Determine release version
+        id: release_version
+        run: echo "version=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)" >> "$GITHUB_OUTPUT"
+
+      # 9. Tag the release commit
+      - name: Create git tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${{ steps.release_version.outputs.version }}" -m "Release v${{ steps.release_version.outputs.version }}"
+          git push origin "v${{ steps.release_version.outputs.version }}"
+
+      # 10. Create the GitHub Release
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.release_version.outputs.version }}
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,28 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # 2. Set up JDK 11 and register Maven Central / GPG credentials
+      # 2. Fail fast if required secrets are not configured
+      - name: Verify required secrets are configured
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          GPG_KEYID: ${{ secrets.GPG_KEYID }}
+        run: |
+          missing=()
+          [ -z "$SONATYPE_USERNAME" ] && missing+=("SONATYPE_USERNAME")
+          [ -z "$SONATYPE_PASSWORD" ] && missing+=("SONATYPE_PASSWORD")
+          [ -z "$GPG_PRIVATE_KEY" ] && missing+=("GPG_PRIVATE_KEY")
+          [ -z "$GPG_PASSPHRASE" ] && missing+=("GPG_PASSPHRASE")
+          [ -z "$GPG_KEYID" ] && missing+=("GPG_KEYID")
+          if [ ${#missing[@]} -ne 0 ]; then
+            echo "::error::Missing required secrets: ${missing[*]}. See CONTRIBUTING.md for setup instructions."
+            exit 1
+          fi
+          echo "All required secrets are configured."
+
+      # 3. Set up JDK 11 and register Maven Central / GPG credentials
       - name: Set up JDK 11
         uses: actions/setup-java@v4
         with:
@@ -34,11 +55,11 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: GPG_PASSPHRASE
 
-      # 3. Grant execute permission to Maven Wrapper
+      # 4. Grant execute permission to Maven Wrapper
       - name: Grant execute permission to mvnw
         run: chmod +x ./mvnw
 
-      # 4. Cache Maven dependencies
+      # 5. Cache Maven dependencies
       - name: Cache Maven packages
         uses: actions/cache@v3
         with:
@@ -47,17 +68,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-release-
 
-      # 5. Bump version in pom.xml (only if a version was provided)
+      # 6. Bump version in pom.xml (only if a version was provided)
       - name: Set release version
         if: ${{ inputs.version != '' }}
         run: ./mvnw versions:set -DnewVersion=${{ inputs.version }} -DgenerateBackupPoms=false
 
-      # 6. Run test suite (unless skipped)
+      # 7. Run test suite (unless skipped)
       - name: Build and test
         if: ${{ !inputs.skip-tests }}
         run: ./mvnw clean package
 
-      # 7. Deploy to Maven Central
+      # 8. Deploy to Maven Central
       - name: Deploy to Maven Central
         run: ./mvnw clean deploy -Pci-cd -DskipTests
         env:
@@ -66,12 +87,12 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           MAVEN_OPTS: -Dgpg.keyname=${{ secrets.GPG_KEYID }}
 
-      # 8. Determine the released version
+      # 9. Determine the released version
       - name: Determine release version
         id: release_version
         run: echo "version=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)" >> "$GITHUB_OUTPUT"
 
-      # 9. Tag the release commit
+      # 10. Tag the release commit
       - name: Create git tag
         run: |
           git config user.name "github-actions[bot]"
@@ -79,7 +100,7 @@ jobs:
           git tag -a "v${{ steps.release_version.outputs.version }}" -m "Release v${{ steps.release_version.outputs.version }}"
           git push origin "v${{ steps.release_version.outputs.version }}"
 
-      # 10. Create the GitHub Release
+      # 11. Create the GitHub Release
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version (e.g., 7.0.0). Leave empty to use the current pom.xml version.'
+        description: 'Release version (e.g., 7.0.5). Leave empty to use the current pom.xml version.'
         required: false
         type: string
       skip-tests:
@@ -13,16 +13,19 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
 
     steps:
-      # 1. Checkout the repository
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      # 2. Fail fast if required secrets are not configured
       - name: Verify required secrets are configured
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
@@ -32,75 +35,112 @@ jobs:
           GPG_KEYID: ${{ secrets.GPG_KEYID }}
         run: |
           missing=()
+
           [ -z "$SONATYPE_USERNAME" ] && missing+=("SONATYPE_USERNAME")
           [ -z "$SONATYPE_PASSWORD" ] && missing+=("SONATYPE_PASSWORD")
           [ -z "$GPG_PRIVATE_KEY" ] && missing+=("GPG_PRIVATE_KEY")
           [ -z "$GPG_PASSPHRASE" ] && missing+=("GPG_PASSPHRASE")
           [ -z "$GPG_KEYID" ] && missing+=("GPG_KEYID")
+
           if [ ${#missing[@]} -ne 0 ]; then
-            echo "::error::Missing required secrets: ${missing[*]}. See CONTRIBUTING.md for setup instructions."
+            echo "::error::Missing required secrets: ${missing[*]}"
             exit 1
           fi
+
           echo "All required secrets are configured."
 
-      # 3. Set up JDK 11 and register Maven Central / GPG credentials
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
-          distribution: 'temurin'
+          distribution: temurin
           java-version: '11'
           server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: GPG_PASSPHRASE
+          gpg-passphrase-env-var: GPG_PASSPHRASE
 
-      # 4. Grant execute permission to Maven Wrapper
       - name: Grant execute permission to mvnw
         run: chmod +x ./mvnw
 
-      # 5. Cache Maven dependencies
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-release-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-release-
 
-      # 6. Bump version in pom.xml (only if a version was provided)
       - name: Set release version
         if: ${{ inputs.version != '' }}
-        run: ./mvnw versions:set -DnewVersion=${{ inputs.version }} -DgenerateBackupPoms=false
+        run: |
+          ./mvnw versions:set \
+            -DnewVersion="${{ inputs.version }}" \
+            -DgenerateBackupPoms=false
 
-      # 7. Run test suite (unless skipped)
+      - name: Determine release version
+        id: release_version
+        run: |
+          VERSION=$(./mvnw help:evaluate \
+            -Dexpression=project.version \
+            -q \
+            -DforceStdout)
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Releasing version: $VERSION"
+
+      - name: Check release tag does not already exist
+        env:
+          VERSION: ${{ steps.release_version.outputs.version }}
+        run: |
+          if git ls-remote --exit-code --tags origin "refs/tags/v$VERSION" >/dev/null 2>&1; then
+            echo "::error::Git tag v$VERSION already exists."
+            exit 1
+          fi
+
       - name: Build and test
         if: ${{ !inputs.skip-tests }}
-        run: ./mvnw clean package
+        run: ./mvnw clean verify -Pci-cd
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          GPG_KEYID: ${{ secrets.GPG_KEYID }}
 
-      # 8. Deploy to Maven Central
       - name: Deploy to Maven Central
         run: ./mvnw clean deploy -Pci-cd -DskipTests
         env:
           MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          MAVEN_OPTS: -Dgpg.keyname=${{ secrets.GPG_KEYID }}
+          GPG_KEYID: ${{ secrets.GPG_KEYID }}
 
-      # 9. Determine the released version
-      - name: Determine release version
-        id: release_version
-        run: echo "version=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)" >> "$GITHUB_OUTPUT"
-
-      # 10. Tag the release commit
-      - name: Create git tag
+      - name: Commit release version
+        if: ${{ inputs.version != '' }}
+        env:
+          VERSION: ${{ steps.release_version.outputs.version }}
         run: |
           git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "v${{ steps.release_version.outputs.version }}" -m "Release v${{ steps.release_version.outputs.version }}"
-          git push origin "v${{ steps.release_version.outputs.version }}"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      # 11. Create the GitHub Release
+          git add pom.xml
+
+          if git diff --cached --quiet; then
+            echo "No pom.xml changes to commit."
+          else
+            git commit -m "Release v$VERSION"
+            git push origin HEAD:${{ github.ref_name }}
+          fi
+
+      - name: Create git tag
+        env:
+          VERSION: ${{ steps.release_version.outputs.version }}
+        run: |
+          git fetch --tags
+
+          git tag -a "v$VERSION" \
+            -m "Release v$VERSION"
+
+          git push origin "v$VERSION"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## Description
This PR adds a complete GitHub Actions release workflow that automates Maven Central
publishing. The workflow is triggered manually via workflow_dispatch, supports optional
version bumping, enforces required secrets validation, and creates GitHub Releases
with auto-generated release notes. No deployment occurs without all 5 secrets configured.

## What changed
Added .github/workflows/release.yml (11 steps: verify secrets → build → deploy → tag → release)
Enforced fail-fast secrets validation to prevent cryptic Sonatype errors

## Implementation Notes
- Trigger: Actions → Release → Run workflow (optional inputs: version, skip-tests)
- Secrets required (to be configured by maintainers): SONATYPE_USERNAME, SONATYPE_PASSWORD,
  GPG_PRIVATE_KEY, GPG_PASSPHRASE, GPG_KEYID
- JDK 11 (aligns with project target version)
- Workflow runs full test suite before deploy (unless skip-tests is checked)
- Git tag and GitHub Release auto-created from pom.xml version

## Validation
Local testing confirmed:
  - mvnw versions:set correctly bumps pom.xml
  - mvnw help:evaluate correctly reads final version
  - mvnw clean verify -Pci-cd succeeds (build, source-jar, GPG sign)
  - mvnw clean deploy -Pci-cd fails at expected Sonatype auth boundary (not config error)
  - Secrets check bash logic validates all 5 secrets; fails with clear error message if any missing
  - YAML syntax valid
  - Git tag/push logic works locally (test-then-cleanup)

## Dry-run Test
<img width="1182" height="693" alt="Screenshot 2026-07-02 at 6 26 10 AM" src="https://github.com/user-attachments/assets/f51cef94-2368-4e41-a26b-66d08b2a1d28" />
<img width="802" height="593" alt="image" src="https://github.com/user-attachments/assets/4649ccb7-77d6-466d-8598-4e7fff5f1c63" />


This demonstrates the workflow correctly fails fast when secrets are unconfigured,
rather than silently continuing or failing deep in the deploy step. It also demonstrates how CI successfully passes when secret check is skipped.

## Closes
#542 
