### PR TITLE
Refactor: Remove outdated json-simple dependency and migrate to Jackson   

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,14 +106,19 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.14.2</version>
+            <version>5.12.0</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>5.2.0</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>5.14.2</version>
+            <version>5.12.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,17 +51,7 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>com.googlecode.json-simple</groupId>
-            <artifactId>json-simple</artifactId>
-            <version>1.1.1</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
@@ -116,19 +106,14 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.12.0</version>
+            <version>5.14.2</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>5.2.0</version>
-            <scope>test</scope>
-        </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>5.12.0</version>
+            <version>5.14.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/zowe/client/sdk/utility/JsonUtils.java
+++ b/src/main/java/zowe/client/sdk/utility/JsonUtils.java
@@ -17,8 +17,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
 
-import java.util.Map;
-import java.util.TreeMap;
 
 /**
  * Utility class contains helper methods for JSON parse processing.

--- a/src/main/java/zowe/client/sdk/utility/JsonUtils.java
+++ b/src/main/java/zowe/client/sdk/utility/JsonUtils.java
@@ -120,24 +120,4 @@ public final class JsonUtils {
         }
     }
 
-    /**
-     * Serialize a {@code Map<String, String>} to a JSON string using Jackson.
-     * <p>
-     * Keys are sorted alphabetically to ensure deterministic output, making
-     * this a safe replacement for {@code new JSONObject(map).toString()}.
-     * </p>
-     *
-     * @param map the map to serialize
-     * @return JSON string representation
-     * @throws ZosmfRequestException if serialization fails
-     */
-    public static String toJsonString(final Map<String, String> map) throws ZosmfRequestException {
-        try {
-            return objectMapper.writeValueAsString(new TreeMap<>(map));
-        } catch (JsonProcessingException e) {
-            LOG.debug("json serialization error", e);
-            throw new ZosmfRequestException("json serialization error: " + e.getMessage(), e);
-        }
-    }
-
 }

--- a/src/main/java/zowe/client/sdk/utility/JsonUtils.java
+++ b/src/main/java/zowe/client/sdk/utility/JsonUtils.java
@@ -17,6 +17,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
 
+import java.util.Map;
+import java.util.TreeMap;
+
 /**
  * Utility class contains helper methods for JSON parse processing.
  *
@@ -114,6 +117,26 @@ public final class JsonUtils {
         } catch (JsonProcessingException e) {
             throw new ZosmfRequestException(
                     "Failed to serialize request body to JSON", e);
+        }
+    }
+
+    /**
+     * Serialize a {@code Map<String, String>} to a JSON string using Jackson.
+     * <p>
+     * Keys are sorted alphabetically to ensure deterministic output, making
+     * this a safe replacement for {@code new JSONObject(map).toString()}.
+     * </p>
+     *
+     * @param map the map to serialize
+     * @return JSON string representation
+     * @throws ZosmfRequestException if serialization fails
+     */
+    public static String toJsonString(final Map<String, String> map) throws ZosmfRequestException {
+        try {
+            return objectMapper.writeValueAsString(new TreeMap<>(map));
+        } catch (JsonProcessingException e) {
+            LOG.debug("json serialization error", e);
+            throw new ZosmfRequestException("json serialization error: " + e.getMessage(), e);
         }
     }
 

--- a/src/test/java/zowe/client/sdk/utility/TestJsonUtils.java
+++ b/src/test/java/zowe/client/sdk/utility/TestJsonUtils.java
@@ -1,0 +1,31 @@
+package zowe.client.sdk.utility;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Common JSON utility methods for tests.
+ */
+public class TestJsonUtils {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * Serialize a {@code Map<String, String>} to a JSON string using Jackson.
+     * <p>
+     * Keys are sorted alphabetically to ensure deterministic output, making
+     * this a safe replacement for {@code new JSONObject(map).toString()}.
+     * </p>
+     *
+     * @param map the map to serialize
+     * @return JSON string representation
+     * @throws JsonProcessingException if serialization fails
+     */
+    public static String toJsonString(final Map<String, String> map) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(new TreeMap<>(map));
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/zosconsole/methods/ConsoleCmdTest.java
+++ b/src/test/java/zowe/client/sdk/zosconsole/methods/ConsoleCmdTest.java
@@ -12,7 +12,7 @@ package zowe.client.sdk.zosconsole.methods;
 import kong.unirest.core.Cookie;
 import kong.unirest.core.HttpResponse;
 import kong.unirest.core.JsonNode;
-import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.JsonUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -57,11 +57,10 @@ public class ConsoleCmdTest {
 
     @Test
     public void tstIssueConsoleIssueCommandCmdResponseSuccess() throws ZosmfRequestException {
-        final Map<String, Object> jsonMap = new HashMap<>();
+        final Map<String, String> jsonMap = new HashMap<>();
         jsonMap.put("cmd-response", "student");
-        final JSONObject json = new JSONObject(jsonMap);
         Mockito.when(mockJsonPutRequest.executeRequest()).thenReturn(
-                new Response(json, 200, "success"));
+                new Response(JsonUtils.toJsonString(jsonMap), 200, "success"));
         final ConsoleCmd consoleCmd = new ConsoleCmd(connection, mockJsonPutRequest);
         final ConsoleCmdResponse response = consoleCmd.issueCommand("command");
         assertEquals("student", response.getCmdResponse());
@@ -69,14 +68,13 @@ public class ConsoleCmdTest {
 
     @Test
     public void tstIssueConsoleIssueCommandCmdResponseToggleTokenSuccess() throws ZosmfRequestException {
-        final Map<String, Object> jsonMap = new HashMap<>();
+        final Map<String, String> jsonMap = new HashMap<>();
         jsonMap.put("cmd-response", "student");
-        final JSONObject json = new JSONObject(jsonMap);
 
         PutJsonZosmfRequest mockJsonGetRequestAuth = Mockito.mock(PutJsonZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
         Mockito.when(mockJsonGetRequestAuth.executeRequest()).thenReturn(
-                new Response(json, 200, "success"));
+                new Response(JsonUtils.toJsonString(jsonMap), 200, "success"));
         doCallRealMethod().when(mockJsonGetRequestAuth).setHeaders(anyMap());
         doCallRealMethod().when(mockJsonGetRequestAuth).setStandardHeaders();
         doCallRealMethod().when(mockJsonGetRequestAuth).setUrl(any());
@@ -92,11 +90,10 @@ public class ConsoleCmdTest {
 
     @Test
     public void tstIssueConsoleIssueCommandCmdResponseWithEmptyStringSuccess() throws ZosmfRequestException {
-        final Map<String, Object> jsonMap = new HashMap<>();
+        final Map<String, String> jsonMap = new HashMap<>();
         jsonMap.put("cmd-response", "");
-        final JSONObject json = new JSONObject(jsonMap);
         Mockito.when(mockJsonPutRequest.executeRequest()).thenReturn(
-                new Response(json, 200, "success"));
+                new Response(JsonUtils.toJsonString(jsonMap), 200, "success"));
         final ConsoleCmd consoleCmd = new ConsoleCmd(connection, mockJsonPutRequest);
         final ConsoleCmdResponse response = consoleCmd.issueCommand("command");
         assertEquals("", response.getCmdResponse());
@@ -104,11 +101,10 @@ public class ConsoleCmdTest {
 
     @Test
     public void tstIssueConsoleIssueCommandCmdResponseWithEmptyStringAndIsProcessRequestSuccess() throws ZosmfRequestException {
-        final Map<String, Object> jsonMap = new HashMap<>();
+        final Map<String, String> jsonMap = new HashMap<>();
         jsonMap.put("cmd-response", "");
-        final JSONObject json = new JSONObject(jsonMap);
         Mockito.when(mockJsonPutRequest.executeRequest()).thenReturn(
-                new Response(json, 200, "success"));
+                new Response(JsonUtils.toJsonString(jsonMap), 200, "success"));
         final ConsoleCmd consoleCmd = new ConsoleCmd(connection, mockJsonPutRequest);
         final ConsoleCmdInputData consoleInputData = new ConsoleCmdInputData("command");
         consoleInputData.setProcessResponse();
@@ -119,11 +115,10 @@ public class ConsoleCmdTest {
 
     @Test
     public void tstIssueConsoleIssueCommandCmdResponseUrlSuccess() throws ZosmfRequestException {
-        final Map<String, Object> jsonMap = new HashMap<>();
+        final Map<String, String> jsonMap = new HashMap<>();
         jsonMap.put("cmd-response-url", "student");
-        final JSONObject json = new JSONObject(jsonMap);
         Mockito.when(mockJsonPutRequest.executeRequest()).thenReturn(
-                new Response(json, 200, "success"));
+                new Response(JsonUtils.toJsonString(jsonMap), 200, "success"));
         ConsoleCmd consoleCmd = new ConsoleCmd(connection, mockJsonPutRequest);
         ConsoleCmdResponse response = consoleCmd.issueCommand("command");
         assertEquals("student", response.getCmdResponseUrl());

--- a/src/test/java/zowe/client/sdk/zosconsole/methods/ConsoleCmdTest.java
+++ b/src/test/java/zowe/client/sdk/zosconsole/methods/ConsoleCmdTest.java
@@ -12,7 +12,7 @@ package zowe.client.sdk.zosconsole.methods;
 import kong.unirest.core.Cookie;
 import kong.unirest.core.HttpResponse;
 import kong.unirest.core.JsonNode;
-import zowe.client.sdk.utility.JsonUtils;
+import zowe.client.sdk.utility.TestJsonUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -56,25 +56,25 @@ public class ConsoleCmdTest {
     }
 
     @Test
-    public void tstIssueConsoleIssueCommandCmdResponseSuccess() throws ZosmfRequestException {
+    public void tstIssueConsoleIssueCommandCmdResponseSuccess() throws Exception {
         final Map<String, String> jsonMap = new HashMap<>();
         jsonMap.put("cmd-response", "student");
         Mockito.when(mockJsonPutRequest.executeRequest()).thenReturn(
-                new Response(JsonUtils.toJsonString(jsonMap), 200, "success"));
+                new Response(TestJsonUtils.toJsonString(jsonMap), 200, "success"));
         final ConsoleCmd consoleCmd = new ConsoleCmd(connection, mockJsonPutRequest);
         final ConsoleCmdResponse response = consoleCmd.issueCommand("command");
         assertEquals("student", response.getCmdResponse());
     }
 
     @Test
-    public void tstIssueConsoleIssueCommandCmdResponseToggleTokenSuccess() throws ZosmfRequestException {
+    public void tstIssueConsoleIssueCommandCmdResponseToggleTokenSuccess() throws Exception {
         final Map<String, String> jsonMap = new HashMap<>();
         jsonMap.put("cmd-response", "student");
 
         PutJsonZosmfRequest mockJsonGetRequestAuth = Mockito.mock(PutJsonZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
         Mockito.when(mockJsonGetRequestAuth.executeRequest()).thenReturn(
-                new Response(JsonUtils.toJsonString(jsonMap), 200, "success"));
+                new Response(TestJsonUtils.toJsonString(jsonMap), 200, "success"));
         doCallRealMethod().when(mockJsonGetRequestAuth).setHeaders(anyMap());
         doCallRealMethod().when(mockJsonGetRequestAuth).setStandardHeaders();
         doCallRealMethod().when(mockJsonGetRequestAuth).setUrl(any());
@@ -89,22 +89,22 @@ public class ConsoleCmdTest {
     }
 
     @Test
-    public void tstIssueConsoleIssueCommandCmdResponseWithEmptyStringSuccess() throws ZosmfRequestException {
+    public void tstIssueConsoleIssueCommandCmdResponseWithEmptyStringSuccess() throws Exception {
         final Map<String, String> jsonMap = new HashMap<>();
         jsonMap.put("cmd-response", "");
         Mockito.when(mockJsonPutRequest.executeRequest()).thenReturn(
-                new Response(JsonUtils.toJsonString(jsonMap), 200, "success"));
+                new Response(TestJsonUtils.toJsonString(jsonMap), 200, "success"));
         final ConsoleCmd consoleCmd = new ConsoleCmd(connection, mockJsonPutRequest);
         final ConsoleCmdResponse response = consoleCmd.issueCommand("command");
         assertEquals("", response.getCmdResponse());
     }
 
     @Test
-    public void tstIssueConsoleIssueCommandCmdResponseWithEmptyStringAndIsProcessRequestSuccess() throws ZosmfRequestException {
+    public void tstIssueConsoleIssueCommandCmdResponseWithEmptyStringAndIsProcessRequestSuccess() throws Exception {
         final Map<String, String> jsonMap = new HashMap<>();
         jsonMap.put("cmd-response", "");
         Mockito.when(mockJsonPutRequest.executeRequest()).thenReturn(
-                new Response(JsonUtils.toJsonString(jsonMap), 200, "success"));
+                new Response(TestJsonUtils.toJsonString(jsonMap), 200, "success"));
         final ConsoleCmd consoleCmd = new ConsoleCmd(connection, mockJsonPutRequest);
         final ConsoleCmdInputData consoleInputData = new ConsoleCmdInputData("command");
         consoleInputData.setProcessResponse();
@@ -114,11 +114,11 @@ public class ConsoleCmdTest {
     }
 
     @Test
-    public void tstIssueConsoleIssueCommandCmdResponseUrlSuccess() throws ZosmfRequestException {
+    public void tstIssueConsoleIssueCommandCmdResponseUrlSuccess() throws Exception {
         final Map<String, String> jsonMap = new HashMap<>();
         jsonMap.put("cmd-response-url", "student");
         Mockito.when(mockJsonPutRequest.executeRequest()).thenReturn(
-                new Response(JsonUtils.toJsonString(jsonMap), 200, "success"));
+                new Response(TestJsonUtils.toJsonString(jsonMap), 200, "success"));
         ConsoleCmd consoleCmd = new ConsoleCmd(connection, mockJsonPutRequest);
         ConsoleCmdResponse response = consoleCmd.issueCommand("command");
         assertEquals("student", response.getCmdResponseUrl());
@@ -126,7 +126,7 @@ public class ConsoleCmdTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void tstIssueConsoleIssueCommandHttpErrorFailure() throws ZosmfRequestException {
+    public void tstIssueConsoleIssueCommandHttpErrorFailure() throws Exception {
         final HttpResponse<JsonNode> mockReply = Mockito.mock(HttpResponse.class);
         Mockito.when(mockReply.getStatusText()).thenReturn("Unauthorized");
         Mockito.when(mockReply.getStatus()).thenReturn(401);

--- a/src/test/java/zowe/client/sdk/zosconsole/methods/ConsoleGetTest.java
+++ b/src/test/java/zowe/client/sdk/zosconsole/methods/ConsoleGetTest.java
@@ -10,7 +10,7 @@
 package zowe.client.sdk.zosconsole.methods;
 
 import kong.unirest.core.Cookie;
-import zowe.client.sdk.utility.JsonUtils;
+import zowe.client.sdk.utility.TestJsonUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -116,7 +116,7 @@ public class ConsoleGetTest {
         );
 
         Mockito.when(mockJsonGetRequestAuth.executeRequest()).thenReturn(
-                new Response(JsonUtils.toJsonString(jsonMap), 200, "{ \"cmd-response\": \"LINE1\\rLINE2\" }")
+                new Response(TestJsonUtils.toJsonString(jsonMap), 200, "{ \"cmd-response\": \"LINE1\\rLINE2\" }")
         );
 
         // Enable real header and URL handling
@@ -139,11 +139,11 @@ public class ConsoleGetTest {
 
 
     @Test
-    public void tstConsoleGetResponseSuccess() throws ZosmfRequestException {
+    public void tstConsoleGetResponseSuccess() throws Exception {
         final Map<String, String> jsonMap = new HashMap<>();
         jsonMap.put("cmd-response", "LINE1\rLINE2");
         Mockito.when(mockJsonGetRequest.executeRequest()).thenReturn(
-                new Response(JsonUtils.toJsonString(jsonMap), 200, "{ \"cmd-response\": \"LINE1\\rLINE2\" }")
+                new Response(TestJsonUtils.toJsonString(jsonMap), 200, "{ \"cmd-response\": \"LINE1\\rLINE2\" }")
         );
         ConsoleGet consoleGet = new ConsoleGet(connection, mockJsonGetRequest);
         ConsoleGetResponse response = consoleGet.getResponse("respKey");
@@ -151,11 +151,11 @@ public class ConsoleGetTest {
     }
 
     @Test
-    public void tstConsoleGetResponseBlankContentSuccess() throws ZosmfRequestException {
+    public void tstConsoleGetResponseBlankContentSuccess() throws Exception {
         final Map<String, String> jsonMap = new HashMap<>();
         jsonMap.put("cmd-response", "");
         Mockito.when(mockJsonGetRequest.executeRequest()).thenReturn(
-                new Response(JsonUtils.toJsonString(jsonMap), 200, "{ \"cmd-response\": \"\" }")
+                new Response(TestJsonUtils.toJsonString(jsonMap), 200, "{ \"cmd-response\": \"\" }")
         );
         ConsoleGet consoleGet = new ConsoleGet(connection, mockJsonGetRequest);
         ConsoleGetResponse response = consoleGet.getResponse("respKey");

--- a/src/test/java/zowe/client/sdk/zosconsole/methods/ConsoleGetTest.java
+++ b/src/test/java/zowe/client/sdk/zosconsole/methods/ConsoleGetTest.java
@@ -10,7 +10,7 @@
 package zowe.client.sdk.zosconsole.methods;
 
 import kong.unirest.core.Cookie;
-import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.JsonUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -106,9 +106,8 @@ public class ConsoleGetTest {
 
     @Test
     public void tstConsoleGetToggleTokenSuccess() throws Exception {
-        final Map<String, Object> jsonMap = new HashMap<>();
+        final Map<String, String> jsonMap = new HashMap<>();
         jsonMap.put("cmd-response", "LINE1\rLINE2");
-        final JSONObject json = new JSONObject(jsonMap);
 
         // Create mock with token constructor
         GetJsonZosmfRequest mockJsonGetRequestAuth = Mockito.mock(
@@ -117,7 +116,7 @@ public class ConsoleGetTest {
         );
 
         Mockito.when(mockJsonGetRequestAuth.executeRequest()).thenReturn(
-                new Response(json, 200, "{ \"cmd-response\": \"LINE1\\rLINE2\" }")
+                new Response(JsonUtils.toJsonString(jsonMap), 200, "{ \"cmd-response\": \"LINE1\\rLINE2\" }")
         );
 
         // Enable real header and URL handling
@@ -141,11 +140,10 @@ public class ConsoleGetTest {
 
     @Test
     public void tstConsoleGetResponseSuccess() throws ZosmfRequestException {
-        final Map<String, Object> jsonMap = new HashMap<>();
+        final Map<String, String> jsonMap = new HashMap<>();
         jsonMap.put("cmd-response", "LINE1\rLINE2");
-        final JSONObject json = new JSONObject(jsonMap);
         Mockito.when(mockJsonGetRequest.executeRequest()).thenReturn(
-                new Response(json, 200, "{ \"cmd-response\": \"LINE1\\rLINE2\" }")
+                new Response(JsonUtils.toJsonString(jsonMap), 200, "{ \"cmd-response\": \"LINE1\\rLINE2\" }")
         );
         ConsoleGet consoleGet = new ConsoleGet(connection, mockJsonGetRequest);
         ConsoleGetResponse response = consoleGet.getResponse("respKey");
@@ -154,11 +152,10 @@ public class ConsoleGetTest {
 
     @Test
     public void tstConsoleGetResponseBlankContentSuccess() throws ZosmfRequestException {
-        final Map<String, Object> jsonMap = new HashMap<>();
+        final Map<String, String> jsonMap = new HashMap<>();
         jsonMap.put("cmd-response", "");
-        final JSONObject json = new JSONObject(jsonMap);
         Mockito.when(mockJsonGetRequest.executeRequest()).thenReturn(
-                new Response(json, 200, "{ \"cmd-response\": \"\" }")
+                new Response(JsonUtils.toJsonString(jsonMap), 200, "{ \"cmd-response\": \"\" }")
         );
         ConsoleGet consoleGet = new ConsoleGet(connection, mockJsonGetRequest);
         ConsoleGetResponse response = consoleGet.getResponse("respKey");

--- a/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnCopyTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnCopyTest.java
@@ -10,7 +10,6 @@
 package zowe.client.sdk.zosfiles.dsn.methods;
 
 import kong.unirest.core.Cookie;
-import org.json.simple.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -43,14 +42,14 @@ public class DsnCopyTest {
     public void init() throws ZosmfRequestException {
         mockJsonPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
         Mockito.when(mockJsonPutRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonPutRequest).setUrl(any());
         doCallRealMethod().when(mockJsonPutRequest).getUrl();
 
         mockJsonPutRequestToken = Mockito.mock(PutJsonZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
         Mockito.when(mockJsonPutRequestToken.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonPutRequestToken).setHeaders(anyMap());
         doCallRealMethod().when(mockJsonPutRequestToken).setStandardHeaders();
         doCallRealMethod().when(mockJsonPutRequestToken).setUrl(any());

--- a/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnCreateTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnCreateTest.java
@@ -10,7 +10,6 @@
 package zowe.client.sdk.zosfiles.dsn.methods;
 
 import kong.unirest.core.Cookie;
-import org.json.simple.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -47,14 +46,14 @@ public class DsnCreateTest {
     public void init() throws ZosmfRequestException {
         mockPostRequest = Mockito.mock(PostJsonZosmfRequest.class);
         Mockito.when(mockPostRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockPostRequest).setUrl(any());
         doCallRealMethod().when(mockPostRequest).getUrl();
 
         mockPostRequestToken = Mockito.mock(PostJsonZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
         Mockito.when(mockPostRequestToken.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockPostRequestToken).setHeaders(anyMap());
         doCallRealMethod().when(mockPostRequestToken).setStandardHeaders();
         doCallRealMethod().when(mockPostRequestToken).setUrl(any());

--- a/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnDeleteTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnDeleteTest.java
@@ -10,7 +10,6 @@
 package zowe.client.sdk.zosfiles.dsn.methods;
 
 import kong.unirest.core.Cookie;
-import org.json.simple.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -46,14 +45,14 @@ public class DsnDeleteTest {
     public void init() throws ZosmfRequestException {
         mockDeleteRequest = Mockito.mock(DeleteJsonZosmfRequest.class);
         Mockito.when(mockDeleteRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockDeleteRequest).setUrl(any());
         doCallRealMethod().when(mockDeleteRequest).getUrl();
 
         mockDeleteRequestToken = Mockito.mock(DeleteJsonZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
         Mockito.when(mockDeleteRequestToken.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockDeleteRequestToken).setHeaders(anyMap());
         doCallRealMethod().when(mockDeleteRequestToken).setStandardHeaders();
         doCallRealMethod().when(mockDeleteRequestToken).setUrl(any());

--- a/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnListTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnListTest.java
@@ -10,7 +10,6 @@
 package zowe.client.sdk.zosfiles.dsn.methods;
 
 import kong.unirest.core.Cookie;
-import org.json.simple.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -47,14 +46,14 @@ public class DsnListTest {
     public void init() throws ZosmfRequestException {
         mockGetRequest = Mockito.mock(GetJsonZosmfRequest.class);
         Mockito.when(mockGetRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockGetRequest).setUrl(any());
         doCallRealMethod().when(mockGetRequest).getUrl();
 
         mockGetRequestToken = Mockito.mock(GetJsonZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
         Mockito.when(mockGetRequestToken.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockGetRequestToken).setHeaders(anyMap());
         doCallRealMethod().when(mockGetRequestToken).setStandardHeaders();
         doCallRealMethod().when(mockGetRequestToken).setUrl(any());

--- a/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnRenameTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnRenameTest.java
@@ -10,7 +10,6 @@
 package zowe.client.sdk.zosfiles.dsn.methods;
 
 import kong.unirest.core.Cookie;
-import org.json.simple.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -46,14 +45,14 @@ public class DsnRenameTest {
     public void init() throws ZosmfRequestException {
         mockJsonPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
         Mockito.when(mockJsonPutRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonPutRequest).setUrl(any());
         doCallRealMethod().when(mockJsonPutRequest).getUrl();
 
         mockJsonPutRequestToken = Mockito.mock(PutJsonZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
         Mockito.when(mockJsonPutRequestToken.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonPutRequestToken).setHeaders(anyMap());
         doCallRealMethod().when(mockJsonPutRequestToken).setStandardHeaders();
         doCallRealMethod().when(mockJsonPutRequestToken).setUrl(any());

--- a/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnWriteTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnWriteTest.java
@@ -10,7 +10,6 @@
 package zowe.client.sdk.zosfiles.dsn.methods;
 
 import kong.unirest.core.Cookie;
-import org.json.simple.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -46,14 +45,14 @@ public class DsnWriteTest {
     public void init() throws ZosmfRequestException {
         mockTextPutRequest = Mockito.mock(PutTextZosmfRequest.class);
         Mockito.when(mockTextPutRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockTextPutRequest).setUrl(any());
         doCallRealMethod().when(mockTextPutRequest).getUrl();
 
         mockTextPutRequestToken = Mockito.mock(PutTextZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
         Mockito.when(mockTextPutRequestToken.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockTextPutRequestToken).setHeaders(anyMap());
         doCallRealMethod().when(mockTextPutRequestToken).setStandardHeaders();
         doCallRealMethod().when(mockTextPutRequestToken).setUrl(any());

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeModeTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeModeTest.java
@@ -10,7 +10,6 @@
 package zowe.client.sdk.zosfiles.uss.methods;
 
 import kong.unirest.core.Cookie;
-import org.json.simple.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -45,14 +44,14 @@ public class UssChangeModeTest {
     public void init() throws ZosmfRequestException {
         mockJsonPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
         Mockito.when(mockJsonPutRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonPutRequest).setUrl(any());
         doCallRealMethod().when(mockJsonPutRequest).getUrl();
 
         mockJsonPutRequestToken = Mockito.mock(PutJsonZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
         Mockito.when(mockJsonPutRequestToken.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonPutRequestToken).setHeaders(anyMap());
         doCallRealMethod().when(mockJsonPutRequestToken).setStandardHeaders();
         doCallRealMethod().when(mockJsonPutRequestToken).setUrl(any());

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeOwnerTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeOwnerTest.java
@@ -10,7 +10,6 @@
 package zowe.client.sdk.zosfiles.uss.methods;
 
 import kong.unirest.core.Cookie;
-import org.json.simple.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -48,14 +47,14 @@ public class UssChangeOwnerTest {
     public void init() throws ZosmfRequestException {
         mockJsonPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
         Mockito.when(mockJsonPutRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonPutRequest).setUrl(any());
         doCallRealMethod().when(mockJsonPutRequest).getUrl();
 
         mockJsonPutRequestToken = Mockito.mock(PutJsonZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
         Mockito.when(mockJsonPutRequestToken.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonPutRequestToken).setHeaders(anyMap());
         doCallRealMethod().when(mockJsonPutRequestToken).setStandardHeaders();
         doCallRealMethod().when(mockJsonPutRequestToken).setUrl(any());

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeTagTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssChangeTagTest.java
@@ -57,7 +57,7 @@ public class UssChangeTagTest {
         mockJsonPutRequestToken = Mockito.mock(PutJsonZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
         Mockito.when(mockJsonPutRequestToken.executeRequest()).thenReturn(
-                new Response(new org.json.simple.JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonPutRequestToken).setHeaders(anyMap());
         doCallRealMethod().when(mockJsonPutRequestToken).setStandardHeaders();
         doCallRealMethod().when(mockJsonPutRequestToken).setUrl(any());

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssCopyTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssCopyTest.java
@@ -10,7 +10,6 @@
 package zowe.client.sdk.zosfiles.uss.methods;
 
 import kong.unirest.core.Cookie;
-import org.json.simple.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -48,14 +47,14 @@ public class UssCopyTest {
     public void init() throws ZosmfRequestException {
         mockJsonPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
         Mockito.when(mockJsonPutRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonPutRequest).setUrl(any());
         doCallRealMethod().when(mockJsonPutRequest).getUrl();
 
         mockJsonPutRequestToken = Mockito.mock(PutJsonZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
         Mockito.when(mockJsonPutRequestToken.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonPutRequestToken).setHeaders(anyMap());
         doCallRealMethod().when(mockJsonPutRequestToken).setStandardHeaders();
         doCallRealMethod().when(mockJsonPutRequestToken).setUrl(any());

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssCreateTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssCreateTest.java
@@ -10,7 +10,6 @@
 package zowe.client.sdk.zosfiles.uss.methods;
 
 import kong.unirest.core.Cookie;
-import org.json.simple.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -51,14 +50,14 @@ public class UssCreateTest {
     public void init() throws ZosmfRequestException {
         mockJsonPostRequest = Mockito.mock(PostJsonZosmfRequest.class);
         Mockito.when(mockJsonPostRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonPostRequest).setUrl(any());
         doCallRealMethod().when(mockJsonPostRequest).getUrl();
 
         mockJsonPostRequestToken = Mockito.mock(PostJsonZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
         Mockito.when(mockJsonPostRequestToken.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonPostRequestToken).setHeaders(anyMap());
         doCallRealMethod().when(mockJsonPostRequestToken).setStandardHeaders();
         doCallRealMethod().when(mockJsonPostRequestToken).setUrl(any());

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssDeleteTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssDeleteTest.java
@@ -10,7 +10,6 @@
 package zowe.client.sdk.zosfiles.uss.methods;
 
 import kong.unirest.core.Cookie;
-import org.json.simple.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -47,14 +46,14 @@ public class UssDeleteTest {
     public void init() throws ZosmfRequestException {
         mockJsonDeleteRequest = Mockito.mock(DeleteJsonZosmfRequest.class);
         Mockito.when(mockJsonDeleteRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonDeleteRequest).setUrl(any());
         doCallRealMethod().when(mockJsonDeleteRequest).getUrl();
 
         mockJsonDeleteRequestToken = Mockito.mock(DeleteJsonZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
         Mockito.when(mockJsonDeleteRequestToken.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonDeleteRequestToken).setHeaders(anyMap());
         doCallRealMethod().when(mockJsonDeleteRequestToken).setStandardHeaders();
         doCallRealMethod().when(mockJsonDeleteRequestToken).setUrl(any());

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssExtAttrTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssExtAttrTest.java
@@ -10,7 +10,6 @@
 package zowe.client.sdk.zosfiles.uss.methods;
 
 import kong.unirest.core.Cookie;
-import org.json.simple.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -49,14 +48,14 @@ public class UssExtAttrTest {
     public void init() throws ZosmfRequestException {
         mockJsonPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
         Mockito.when(mockJsonPutRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonPutRequest).setUrl(any());
         doCallRealMethod().when(mockJsonPutRequest).getUrl();
 
         mockJsonPutRequestToken = Mockito.mock(PutJsonZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
         Mockito.when(mockJsonPutRequestToken.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonPutRequestToken).setHeaders(anyMap());
         doCallRealMethod().when(mockJsonPutRequestToken).setStandardHeaders();
         doCallRealMethod().when(mockJsonPutRequestToken).setUrl(any());

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssGetAclTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssGetAclTest.java
@@ -10,7 +10,6 @@
 package zowe.client.sdk.zosfiles.uss.methods;
 
 import kong.unirest.core.Cookie;
-import org.json.simple.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -47,14 +46,14 @@ public class UssGetAclTest {
     public void init() throws ZosmfRequestException {
         mockJsonPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
         Mockito.when(mockJsonPutRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonPutRequest).setUrl(any());
         doCallRealMethod().when(mockJsonPutRequest).getUrl();
 
         final PutJsonZosmfRequest mockJsonPutRequestToken = Mockito.mock(PutJsonZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
         Mockito.when(mockJsonPutRequestToken.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonPutRequestToken).setHeaders(anyMap());
         doCallRealMethod().when(mockJsonPutRequestToken).setStandardHeaders();
         doCallRealMethod().when(mockJsonPutRequestToken).setUrl(any());

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssListTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssListTest.java
@@ -11,7 +11,6 @@ package zowe.client.sdk.zosfiles.uss.methods;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import kong.unirest.core.Cookie;
-import org.json.simple.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -126,14 +125,14 @@ public class UssListTest {
         mockJsonGetRequest = Mockito.mock(GetJsonZosmfRequest.class);
         mockJsonGetRequestToken = Mockito.mock(GetJsonZosmfRequest.class);
         Mockito.when(mockJsonGetRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonGetRequest).setUrl(any());
         doCallRealMethod().when(mockJsonGetRequest).getUrl();
 
         mockJsonGetRequestToken = Mockito.mock(GetJsonZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
         Mockito.when(mockJsonGetRequestToken.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonGetRequestToken).setHeaders(anyMap());
         doCallRealMethod().when(mockJsonGetRequestToken).setStandardHeaders();
         doCallRealMethod().when(mockJsonGetRequestToken).setUrl(any());
@@ -248,7 +247,7 @@ public class UssListTest {
     @Test
     public void tstUssListEmptyFileListWithJsonObjectSuccess() throws ZosmfRequestException {
         Mockito.when(mockJsonGetRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         final UssList ussList = new UssList(connection, mockJsonGetRequest);
         final List<UnixFile> items = ussList.getFiles(new UssListInputData.Builder().path("/xxx/xx/x").build());
         assertEquals(0, items.size());
@@ -486,7 +485,7 @@ public class UssListTest {
     @Test
     public void tstUssListFileListWithAllOptionalParamsSuccess() throws Exception {
         Mockito.when(mockJsonGetRequestToken.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonGetRequestToken).setUrl(any());
         doCallRealMethod().when(mockJsonGetRequestToken).setHeaders(anyMap());
         doCallRealMethod().when(mockJsonGetRequestToken).getHeaders();
@@ -518,7 +517,7 @@ public class UssListTest {
     @Test
     public void tstUssListFileListWithSizeAndTypeBothSetSuccess() throws Exception {
         Mockito.when(mockJsonGetRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonGetRequest).setUrl(any());
         doCallRealMethod().when(mockJsonGetRequest).getUrl();
 
@@ -537,7 +536,7 @@ public class UssListTest {
     @Test
     public void tstUssListFileListWithOnlyTypeNoSizeSuccess() throws Exception {
         Mockito.when(mockJsonGetRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonGetRequest).setUrl(any());
         doCallRealMethod().when(mockJsonGetRequest).getUrl();
 
@@ -555,7 +554,7 @@ public class UssListTest {
     @Test
     public void tstUssListFileListWithFilesysTrueSuccess() throws Exception {
         Mockito.when(mockJsonGetRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonGetRequest).setUrl(any());
         doCallRealMethod().when(mockJsonGetRequest).getUrl();
 
@@ -573,7 +572,7 @@ public class UssListTest {
     @Test
     public void tstUssListFileListWithSymlinksTrueSuccess() throws Exception {
         Mockito.when(mockJsonGetRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonGetRequest).setUrl(any());
         doCallRealMethod().when(mockJsonGetRequest).getUrl();
 
@@ -591,7 +590,7 @@ public class UssListTest {
     @Test
     public void tstUssListFileListWithMaxLengthSuccess() throws Exception {
         Mockito.when(mockJsonGetRequestToken.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonGetRequestToken).setUrl(any());
         doCallRealMethod().when(mockJsonGetRequestToken).setHeaders(anyMap());
         doCallRealMethod().when(mockJsonGetRequestToken).getHeaders();
@@ -659,7 +658,7 @@ public class UssListTest {
     @Test
     public void tstUssListFileListWithOnlyGroupSuccess() throws Exception {
         Mockito.when(mockJsonGetRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonGetRequest).setUrl(any());
         doCallRealMethod().when(mockJsonGetRequest).getUrl();
 
@@ -677,7 +676,7 @@ public class UssListTest {
     @Test
     public void tstUssListFileListWithOnlyUserSuccess() throws Exception {
         Mockito.when(mockJsonGetRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonGetRequest).setUrl(any());
         doCallRealMethod().when(mockJsonGetRequest).getUrl();
 
@@ -695,7 +694,7 @@ public class UssListTest {
     @Test
     public void tstUssListFileListWithOnlyMtimeSuccess() throws Exception {
         Mockito.when(mockJsonGetRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonGetRequest).setUrl(any());
         doCallRealMethod().when(mockJsonGetRequest).getUrl();
 
@@ -713,7 +712,7 @@ public class UssListTest {
     @Test
     public void tstUssListFileListWithOnlySizeSuccess() throws Exception {
         Mockito.when(mockJsonGetRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonGetRequest).setUrl(any());
         doCallRealMethod().when(mockJsonGetRequest).getUrl();
 
@@ -731,7 +730,7 @@ public class UssListTest {
     @Test
     public void tstUssListFileListWithOnlyNameSuccess() throws Exception {
         Mockito.when(mockJsonGetRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonGetRequest).setUrl(any());
         doCallRealMethod().when(mockJsonGetRequest).getUrl();
 
@@ -749,7 +748,7 @@ public class UssListTest {
     @Test
     public void tstUssListFileListWithOnlyPermSuccess() throws Exception {
         Mockito.when(mockJsonGetRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonGetRequest).setUrl(any());
         doCallRealMethod().when(mockJsonGetRequest).getUrl();
 
@@ -767,7 +766,7 @@ public class UssListTest {
     @Test
     public void tstUssListFileListWithOnlyDepthSuccess() throws Exception {
         Mockito.when(mockJsonGetRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonGetRequest).setUrl(any());
         doCallRealMethod().when(mockJsonGetRequest).getUrl();
 
@@ -803,7 +802,7 @@ public class UssListTest {
     @Test
     public void tstUssListZfsListEmptyResponseSuccess() throws Exception {
         Mockito.when(mockJsonGetRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonGetRequest).setUrl(any());
         doCallRealMethod().when(mockJsonGetRequest).getUrl();
 
@@ -827,7 +826,7 @@ public class UssListTest {
     @Test
     public void tstUssListFileListMissingPathThrowsFailure() throws ZosmfRequestException {
         Mockito.when(mockJsonGetRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonGetRequest).setUrl(any());
         doCallRealMethod().when(mockJsonGetRequest).getUrl();
 

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssMountTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssMountTest.java
@@ -10,7 +10,6 @@
 package zowe.client.sdk.zosfiles.uss.methods;
 
 import kong.unirest.core.Cookie;
-import org.json.simple.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -49,14 +48,14 @@ public class UssMountTest {
     public void init() throws ZosmfRequestException {
         mockJsonPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
         Mockito.when(mockJsonPutRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonPutRequest).setUrl(any());
         doCallRealMethod().when(mockJsonPutRequest).getUrl();
 
         mockJsonPutRequestToken = Mockito.mock(PutJsonZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
         Mockito.when(mockJsonPutRequestToken.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonPutRequestToken).setHeaders(anyMap());
         doCallRealMethod().when(mockJsonPutRequestToken).setStandardHeaders();
         doCallRealMethod().when(mockJsonPutRequestToken).setUrl(any());

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssMoveTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssMoveTest.java
@@ -10,7 +10,6 @@
 package zowe.client.sdk.zosfiles.uss.methods;
 
 import kong.unirest.core.Cookie;
-import org.json.simple.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -47,14 +46,14 @@ public class UssMoveTest {
     public void init() throws ZosmfRequestException {
         mockJsonPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
         Mockito.when(mockJsonPutRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonPutRequest).setUrl(any());
         doCallRealMethod().when(mockJsonPutRequest).getUrl();
 
         mockJsonPutRequestToken = Mockito.mock(PutJsonZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
         Mockito.when(mockJsonPutRequestToken.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonPutRequestToken).setHeaders(anyMap());
         doCallRealMethod().when(mockJsonPutRequestToken).setStandardHeaders();
         doCallRealMethod().when(mockJsonPutRequestToken).setUrl(any());

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssSetAclTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssSetAclTest.java
@@ -9,8 +9,8 @@
  */
 package zowe.client.sdk.zosfiles.uss.methods;
 
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -41,6 +41,7 @@ class UssSetAclTest {
     private ZosConnection connection;
     private PutJsonZosmfRequest request;
     private Response response;
+    private final ObjectMapper mapper = new ObjectMapper();
     private UssSetAcl ussSetAcl;
 
     @BeforeEach
@@ -83,15 +84,15 @@ class UssSetAclTest {
 
         assertSame(response, actualResponse);
         verify(request).setUrl(getExpectedUrl());
-        final JSONObject body = getRequestBody();
+        final JsonNode body = getRequestBody();
 
-        assertEquals("setfacl", body.get("request"));
-        assertEquals(LinkType.FOLLOW.getValue(), body.get("links"));
-        assertEquals("user:test:rwx", body.get("set"));
-        assertFalse(body.containsKey("abort"));
-        assertFalse(body.containsKey("modify"));
-        assertFalse(body.containsKey("delete"));
-        assertFalse(body.containsKey("delete-type"));
+        assertEquals("setfacl", body.get("request").asText());
+        assertEquals(LinkType.FOLLOW.getValue(), body.get("links").asText());
+        assertEquals("user:test:rwx", body.get("set").asText());
+        assertFalse(body.has("abort"));
+        assertFalse(body.has("modify"));
+        assertFalse(body.has("delete"));
+        assertFalse(body.has("delete-type"));
     }
 
     @Test
@@ -100,15 +101,15 @@ class UssSetAclTest {
 
         assertSame(response, actualResponse);
         verify(request).setUrl(getExpectedUrl());
-        final JSONObject body = getRequestBody();
+        final JsonNode body = getRequestBody();
 
-        assertEquals("setfacl", body.get("request"));
-        assertEquals(LinkType.FOLLOW.getValue(), body.get("links"));
-        assertEquals("user:test:rwx", body.get("modify"));
-        assertFalse(body.containsKey("abort"));
-        assertFalse(body.containsKey("set"));
-        assertFalse(body.containsKey("delete"));
-        assertFalse(body.containsKey("delete-type"));
+        assertEquals("setfacl", body.get("request").asText());
+        assertEquals(LinkType.FOLLOW.getValue(), body.get("links").asText());
+        assertEquals("user:test:rwx", body.get("modify").asText());
+        assertFalse(body.has("abort"));
+        assertFalse(body.has("set"));
+        assertFalse(body.has("delete"));
+        assertFalse(body.has("delete-type"));
     }
 
     @Test
@@ -117,15 +118,15 @@ class UssSetAclTest {
 
         assertSame(response, actualResponse);
         verify(request).setUrl(getExpectedUrl());
-        final JSONObject body = getRequestBody();
+        final JsonNode body = getRequestBody();
 
-        assertEquals("setfacl", body.get("request"));
-        assertEquals(LinkType.FOLLOW.getValue(), body.get("links"));
-        assertEquals("user:test:rwx", body.get("delete"));
-        assertFalse(body.containsKey("abort"));
-        assertFalse(body.containsKey("set"));
-        assertFalse(body.containsKey("modify"));
-        assertFalse(body.containsKey("delete-type"));
+        assertEquals("setfacl", body.get("request").asText());
+        assertEquals(LinkType.FOLLOW.getValue(), body.get("links").asText());
+        assertEquals("user:test:rwx", body.get("delete").asText());
+        assertFalse(body.has("abort"));
+        assertFalse(body.has("set"));
+        assertFalse(body.has("modify"));
+        assertFalse(body.has("delete-type"));
     }
 
     @Test
@@ -134,15 +135,15 @@ class UssSetAclTest {
 
         assertSame(response, actualResponse);
         verify(request).setUrl(getExpectedUrl());
-        final JSONObject body = getRequestBody();
+        final JsonNode body = getRequestBody();
 
-        assertEquals("setfacl", body.get("request"));
-        assertEquals(LinkType.FOLLOW.getValue(), body.get("links"));
-        assertEquals(DeleteAclType.ACCESS.getValue(), body.get("delete-type"));
-        assertFalse(body.containsKey("abort"));
-        assertFalse(body.containsKey("set"));
-        assertFalse(body.containsKey("modify"));
-        assertFalse(body.containsKey("delete"));
+        assertEquals("setfacl", body.get("request").asText());
+        assertEquals(LinkType.FOLLOW.getValue(), body.get("links").asText());
+        assertEquals(DeleteAclType.ACCESS.getValue(), body.get("delete-type").asText());
+        assertFalse(body.has("abort"));
+        assertFalse(body.has("set"));
+        assertFalse(body.has("modify"));
+        assertFalse(body.has("delete"));
     }
 
     @Test
@@ -155,15 +156,15 @@ class UssSetAclTest {
 
         assertSame(response, actualResponse);
         verify(request).setUrl(getExpectedUrl());
-        final JSONObject body = getRequestBody();
+        final JsonNode body = getRequestBody();
 
-        assertEquals("setfacl", body.get("request"));
-        assertEquals(LinkType.FOLLOW.getValue(), body.get("links"));
-        assertEquals("user:test:rwx", body.get("modify"));
-        assertEquals("group:test:r-x", body.get("delete"));
-        assertFalse(body.containsKey("abort"));
-        assertFalse(body.containsKey("set"));
-        assertFalse(body.containsKey("delete-type"));
+        assertEquals("setfacl", body.get("request").asText());
+        assertEquals(LinkType.FOLLOW.getValue(), body.get("links").asText());
+        assertEquals("user:test:rwx", body.get("modify").asText());
+        assertEquals("group:test:r-x", body.get("delete").asText());
+        assertFalse(body.has("abort"));
+        assertFalse(body.has("set"));
+        assertFalse(body.has("delete-type"));
     }
 
     @Test
@@ -178,15 +179,15 @@ class UssSetAclTest {
 
         assertSame(response, actualResponse);
         verify(request).setUrl(getExpectedUrl());
-        final JSONObject body = getRequestBody();
+        final JsonNode body = getRequestBody();
 
-        assertEquals("setfacl", body.get("request"));
-        assertEquals(true, body.get("abort"));
-        assertEquals(LinkType.SUPPRESS.getValue(), body.get("links"));
-        assertEquals("user:test:rwx", body.get("set"));
-        assertFalse(body.containsKey("modify"));
-        assertFalse(body.containsKey("delete"));
-        assertFalse(body.containsKey("delete-type"));
+        assertEquals("setfacl", body.get("request").asText());
+        assertEquals(true, body.get("abort").asBoolean());
+        assertEquals(LinkType.SUPPRESS.getValue(), body.get("links").asText());
+        assertEquals("user:test:rwx", body.get("set").asText());
+        assertFalse(body.has("modify"));
+        assertFalse(body.has("delete"));
+        assertFalse(body.has("delete-type"));
     }
 
     @Test
@@ -217,11 +218,11 @@ class UssSetAclTest {
                 EncodeUtils.encodeURIComponent(FileUtils.validatePath(TARGET_PATH));
     }
 
-    private JSONObject getRequestBody() throws Exception {
+    private JsonNode getRequestBody() throws Exception {
         final ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
         verify(request).setBody(bodyCaptor.capture());
 
-        return (JSONObject) new JSONParser().parse(bodyCaptor.getValue());
+        return mapper.readTree(bodyCaptor.getValue());
     }
 
 }

--- a/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssWriteTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/uss/methods/UssWriteTest.java
@@ -10,7 +10,6 @@
 package zowe.client.sdk.zosfiles.uss.methods;
 
 import kong.unirest.core.Cookie;
-import org.json.simple.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -49,14 +48,14 @@ public class UssWriteTest {
     public void init() throws ZosmfRequestException {
         mockTextPutRequest = Mockito.mock(PutTextZosmfRequest.class);
         Mockito.when(mockTextPutRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockTextPutRequest).setUrl(any());
         doCallRealMethod().when(mockTextPutRequest).getUrl();
 
         mockTextPutRequestToken = Mockito.mock(PutTextZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
         Mockito.when(mockTextPutRequestToken.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockTextPutRequestToken).setHeaders(anyMap());
         doCallRealMethod().when(mockTextPutRequestToken).setStandardHeaders();
         doCallRealMethod().when(mockTextPutRequestToken).setUrl(any());

--- a/src/test/java/zowe/client/sdk/zosjobs/methods/JobCancelTest.java
+++ b/src/test/java/zowe/client/sdk/zosjobs/methods/JobCancelTest.java
@@ -10,7 +10,6 @@
 package zowe.client.sdk.zosjobs.methods;
 
 import kong.unirest.core.Cookie;
-import org.json.simple.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -47,14 +46,14 @@ public class JobCancelTest {
     public void init() throws ZosmfRequestException {
         mockPutJsonZosmfRequest = Mockito.mock(PutJsonZosmfRequest.class);
         Mockito.when(mockPutJsonZosmfRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockPutJsonZosmfRequest).setUrl(any());
         doCallRealMethod().when(mockPutJsonZosmfRequest).getUrl();
 
         mockPutJsonZosmfRequestToken = Mockito.mock(PutJsonZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
         Mockito.when(mockPutJsonZosmfRequestToken.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockPutJsonZosmfRequestToken).setHeaders(anyMap());
         doCallRealMethod().when(mockPutJsonZosmfRequestToken).setStandardHeaders();
         doCallRealMethod().when(mockPutJsonZosmfRequestToken).setUrl(any());

--- a/src/test/java/zowe/client/sdk/zosjobs/methods/JobChangeTest.java
+++ b/src/test/java/zowe/client/sdk/zosjobs/methods/JobChangeTest.java
@@ -10,7 +10,7 @@
 package zowe.client.sdk.zosjobs.methods;
 
 import kong.unirest.core.Cookie;
-import zowe.client.sdk.utility.JsonUtils;
+import zowe.client.sdk.utility.TestJsonUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -48,7 +48,7 @@ public class JobChangeTest {
     private final JobChange jobChange = new JobChange(connection);
 
     @BeforeEach
-    public void init() throws ZosmfRequestException {
+    public void init() throws Exception {
         String jsonResponse = "{\"jobid\":\"JOBID\",\"jobname\":\"JOBNAME\",\"original-jobid\":\"JOB00023\",\"owner\":" +
                 "\"IBMUSER\",\"member\":\"JES2\",\"sysname\":\"SY1\",\"job-correlator\":\"J0000023SY1.....CC20F378.......:" +
                 "\",\"status\":\"0\"}";
@@ -80,7 +80,7 @@ public class JobChangeTest {
     }
 
     @Test
-    public void tstChangeClassCommonSuccess() throws ZosmfRequestException {
+    public void tstChangeClassCommonSuccess() throws Exception {
         JobModifyInputData inputData = new JobModifyInputData.Builder("JOBNAME", "JOBID")
                 .jobClass(classs)
                 .version(version)
@@ -109,12 +109,12 @@ public class JobChangeTest {
 
         // verify request setup
         verify(mockPutJsonZosmfRequest).setUrl(anyString());
-        verify(mockPutJsonZosmfRequest).setBody(JsonUtils.toJsonString(changeMap));
+        verify(mockPutJsonZosmfRequest).setBody(TestJsonUtils.toJsonString(changeMap));
         verify(mockPutJsonZosmfRequest).executeRequest();
     }
 
     @Test
-    public void tstChangeClassCommonWithTokenSuccess() throws ZosmfRequestException {
+    public void tstChangeClassCommonWithTokenSuccess() throws Exception {
         JobModifyInputData inputData = new JobModifyInputData.Builder("JOBNAME", "JOBID")
                 .jobClass(classs)
                 .version(version)
@@ -144,12 +144,12 @@ public class JobChangeTest {
 
         // verify request setup
         verify(mockPutJsonZosmfRequestToken).setUrl(anyString());
-        verify(mockPutJsonZosmfRequestToken).setBody(JsonUtils.toJsonString(changeMap));
+        verify(mockPutJsonZosmfRequestToken).setBody(TestJsonUtils.toJsonString(changeMap));
         verify(mockPutJsonZosmfRequestToken).executeRequest();
     }
 
     @Test
-    public void tstChangeClassSuccess() throws ZosmfRequestException {
+    public void tstChangeClassSuccess() throws Exception {
         final JobChange jobChange = new JobChange(connection, mockPutJsonZosmfRequest);
         final JobFeedback result = jobChange.changeClass("JOBNAME", "JOBID", classs, version);
 
@@ -174,12 +174,12 @@ public class JobChangeTest {
 
         // verify request setup
         verify(mockPutJsonZosmfRequest).setUrl(anyString());
-        verify(mockPutJsonZosmfRequest).setBody(JsonUtils.toJsonString(changeMap));
+        verify(mockPutJsonZosmfRequest).setBody(TestJsonUtils.toJsonString(changeMap));
         verify(mockPutJsonZosmfRequest).executeRequest();
     }
 
     @Test
-    public void tstChangeClassByJobSuccess() throws ZosmfRequestException {
+    public void tstChangeClassByJobSuccess() throws Exception {
         final JobChange jobChange = new JobChange(connection, mockPutJsonZosmfRequest);
         final Job job = Job.builder().jobName("JOBNAME").jobId("JOBID").build();
         final JobFeedback result = jobChange.changeClassByJob(job, classs, version);
@@ -201,12 +201,12 @@ public class JobChangeTest {
 
         // verify request setup
         verify(mockPutJsonZosmfRequest).setUrl(anyString());
-        verify(mockPutJsonZosmfRequest).setBody(JsonUtils.toJsonString(changeMap));
+        verify(mockPutJsonZosmfRequest).setBody(TestJsonUtils.toJsonString(changeMap));
         verify(mockPutJsonZosmfRequest).executeRequest();
     }
 
     @Test
-    public void tstHoldCommonSuccess() throws ZosmfRequestException {
+    public void tstHoldCommonSuccess() throws Exception {
         JobModifyInputData inputData = new JobModifyInputData.Builder("JOBNAME", "JOBID")
                 .version(version)
                 .build();
@@ -230,12 +230,12 @@ public class JobChangeTest {
         holdMap.put("version", version);
 
         verify(mockPutJsonZosmfRequest).setUrl(anyString());
-        verify(mockPutJsonZosmfRequest).setBody(JsonUtils.toJsonString(holdMap));
+        verify(mockPutJsonZosmfRequest).setBody(TestJsonUtils.toJsonString(holdMap));
         verify(mockPutJsonZosmfRequest).executeRequest();
     }
 
     @Test
-    public void tstHoldCommonWithTokenSuccess() throws ZosmfRequestException {
+    public void tstHoldCommonWithTokenSuccess() throws Exception {
         JobModifyInputData inputData = new JobModifyInputData.Builder("JOBNAME", "JOBID")
                 .version(version)
                 .build();
@@ -257,12 +257,12 @@ public class JobChangeTest {
         holdMap.put("version", version);
 
         verify(mockPutJsonZosmfRequestToken).setUrl(anyString());
-        verify(mockPutJsonZosmfRequestToken).setBody(JsonUtils.toJsonString(holdMap));
+        verify(mockPutJsonZosmfRequestToken).setBody(TestJsonUtils.toJsonString(holdMap));
         verify(mockPutJsonZosmfRequestToken).executeRequest();
     }
 
     @Test
-    public void tstHoldSuccess() throws ZosmfRequestException {
+    public void tstHoldSuccess() throws Exception {
         final JobChange jobChange = new JobChange(connection, mockPutJsonZosmfRequest);
         final JobFeedback result = jobChange.hold("JOBNAME", "JOBID", version);
 
@@ -275,12 +275,12 @@ public class JobChangeTest {
         holdMap.put("version", version);
 
         verify(mockPutJsonZosmfRequest).setUrl(anyString());
-        verify(mockPutJsonZosmfRequest).setBody(JsonUtils.toJsonString(holdMap));
+        verify(mockPutJsonZosmfRequest).setBody(TestJsonUtils.toJsonString(holdMap));
         verify(mockPutJsonZosmfRequest).executeRequest();
     }
 
     @Test
-    public void tstHoldByJobSuccess() throws ZosmfRequestException {
+    public void tstHoldByJobSuccess() throws Exception {
         final JobChange jobChange = new JobChange(connection, mockPutJsonZosmfRequest);
         final Job job = Job.builder().jobName("JOBNAME").jobId("JOBID").build();
 
@@ -295,12 +295,12 @@ public class JobChangeTest {
         holdMap.put("version", version);
 
         verify(mockPutJsonZosmfRequest).setUrl(anyString());
-        verify(mockPutJsonZosmfRequest).setBody(JsonUtils.toJsonString(holdMap));
+        verify(mockPutJsonZosmfRequest).setBody(TestJsonUtils.toJsonString(holdMap));
         verify(mockPutJsonZosmfRequest).executeRequest();
     }
 
     @Test
-    public void tstReleaseSuccess() throws ZosmfRequestException {
+    public void tstReleaseSuccess() throws Exception {
         final JobChange jobChange = new JobChange(connection, mockPutJsonZosmfRequest);
         final JobFeedback result = jobChange.release("JOBNAME", "JOBID", version);
 
@@ -313,12 +313,12 @@ public class JobChangeTest {
         releaseMap.put("version", version);
 
         verify(mockPutJsonZosmfRequest).setUrl(anyString());
-        verify(mockPutJsonZosmfRequest).setBody(JsonUtils.toJsonString(releaseMap));
+        verify(mockPutJsonZosmfRequest).setBody(TestJsonUtils.toJsonString(releaseMap));
         verify(mockPutJsonZosmfRequest).executeRequest();
     }
 
     @Test
-    public void tstReleaseByJobSuccess() throws ZosmfRequestException {
+    public void tstReleaseByJobSuccess() throws Exception {
         final JobChange jobChange = new JobChange(connection, mockPutJsonZosmfRequest);
         final Job job = Job.builder().jobName("JOBNAME").jobId("JOBID").build();
 
@@ -333,12 +333,12 @@ public class JobChangeTest {
         releaseMap.put("version", version);
 
         verify(mockPutJsonZosmfRequest).setUrl(anyString());
-        verify(mockPutJsonZosmfRequest).setBody(JsonUtils.toJsonString(releaseMap));
+        verify(mockPutJsonZosmfRequest).setBody(TestJsonUtils.toJsonString(releaseMap));
         verify(mockPutJsonZosmfRequest).executeRequest();
     }
 
     @Test
-    public void tstReleaseCommonSuccess() throws ZosmfRequestException {
+    public void tstReleaseCommonSuccess() throws Exception {
         JobModifyInputData inputData = new JobModifyInputData.Builder("JOBNAME", "JOBID")
                 .version(version)
                 .build();
@@ -362,12 +362,12 @@ public class JobChangeTest {
         releaseMap.put("version", version);
 
         verify(mockPutJsonZosmfRequest).setUrl(anyString());
-        verify(mockPutJsonZosmfRequest).setBody(JsonUtils.toJsonString(releaseMap));
+        verify(mockPutJsonZosmfRequest).setBody(TestJsonUtils.toJsonString(releaseMap));
         verify(mockPutJsonZosmfRequest).executeRequest();
     }
 
     @Test
-    public void tstReleaseCommonWithTokenSuccess() throws ZosmfRequestException {
+    public void tstReleaseCommonWithTokenSuccess() throws Exception {
         JobModifyInputData inputData = new JobModifyInputData.Builder("JOBNAME", "JOBID")
                 .version(version)
                 .build();
@@ -389,7 +389,7 @@ public class JobChangeTest {
         releaseMap.put("version", version);
 
         verify(mockPutJsonZosmfRequestToken).setUrl(anyString());
-        verify(mockPutJsonZosmfRequestToken).setBody(JsonUtils.toJsonString(releaseMap));
+        verify(mockPutJsonZosmfRequestToken).setBody(TestJsonUtils.toJsonString(releaseMap));
         verify(mockPutJsonZosmfRequestToken).executeRequest();
     }
 

--- a/src/test/java/zowe/client/sdk/zosjobs/methods/JobChangeTest.java
+++ b/src/test/java/zowe/client/sdk/zosjobs/methods/JobChangeTest.java
@@ -10,7 +10,7 @@
 package zowe.client.sdk.zosjobs.methods;
 
 import kong.unirest.core.Cookie;
-import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.JsonUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -66,7 +66,7 @@ public class JobChangeTest {
         mockPutJsonZosmfRequestToken = Mockito.mock(PutJsonZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
         Mockito.when(mockPutJsonZosmfRequestToken.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockPutJsonZosmfRequestToken).setHeaders(anyMap());
         doCallRealMethod().when(mockPutJsonZosmfRequestToken).setStandardHeaders();
         doCallRealMethod().when(mockPutJsonZosmfRequestToken).setUrl(any());
@@ -109,7 +109,7 @@ public class JobChangeTest {
 
         // verify request setup
         verify(mockPutJsonZosmfRequest).setUrl(anyString());
-        verify(mockPutJsonZosmfRequest).setBody(new JSONObject(changeMap).toString());
+        verify(mockPutJsonZosmfRequest).setBody(JsonUtils.toJsonString(changeMap));
         verify(mockPutJsonZosmfRequest).executeRequest();
     }
 
@@ -144,7 +144,7 @@ public class JobChangeTest {
 
         // verify request setup
         verify(mockPutJsonZosmfRequestToken).setUrl(anyString());
-        verify(mockPutJsonZosmfRequestToken).setBody(new JSONObject(changeMap).toString());
+        verify(mockPutJsonZosmfRequestToken).setBody(JsonUtils.toJsonString(changeMap));
         verify(mockPutJsonZosmfRequestToken).executeRequest();
     }
 
@@ -174,7 +174,7 @@ public class JobChangeTest {
 
         // verify request setup
         verify(mockPutJsonZosmfRequest).setUrl(anyString());
-        verify(mockPutJsonZosmfRequest).setBody(new JSONObject(changeMap).toString());
+        verify(mockPutJsonZosmfRequest).setBody(JsonUtils.toJsonString(changeMap));
         verify(mockPutJsonZosmfRequest).executeRequest();
     }
 
@@ -201,7 +201,7 @@ public class JobChangeTest {
 
         // verify request setup
         verify(mockPutJsonZosmfRequest).setUrl(anyString());
-        verify(mockPutJsonZosmfRequest).setBody(new JSONObject(changeMap).toString());
+        verify(mockPutJsonZosmfRequest).setBody(JsonUtils.toJsonString(changeMap));
         verify(mockPutJsonZosmfRequest).executeRequest();
     }
 
@@ -230,7 +230,7 @@ public class JobChangeTest {
         holdMap.put("version", version);
 
         verify(mockPutJsonZosmfRequest).setUrl(anyString());
-        verify(mockPutJsonZosmfRequest).setBody(new JSONObject(holdMap).toString());
+        verify(mockPutJsonZosmfRequest).setBody(JsonUtils.toJsonString(holdMap));
         verify(mockPutJsonZosmfRequest).executeRequest();
     }
 
@@ -257,7 +257,7 @@ public class JobChangeTest {
         holdMap.put("version", version);
 
         verify(mockPutJsonZosmfRequestToken).setUrl(anyString());
-        verify(mockPutJsonZosmfRequestToken).setBody(new JSONObject(holdMap).toString());
+        verify(mockPutJsonZosmfRequestToken).setBody(JsonUtils.toJsonString(holdMap));
         verify(mockPutJsonZosmfRequestToken).executeRequest();
     }
 
@@ -275,7 +275,7 @@ public class JobChangeTest {
         holdMap.put("version", version);
 
         verify(mockPutJsonZosmfRequest).setUrl(anyString());
-        verify(mockPutJsonZosmfRequest).setBody(new JSONObject(holdMap).toString());
+        verify(mockPutJsonZosmfRequest).setBody(JsonUtils.toJsonString(holdMap));
         verify(mockPutJsonZosmfRequest).executeRequest();
     }
 
@@ -295,7 +295,7 @@ public class JobChangeTest {
         holdMap.put("version", version);
 
         verify(mockPutJsonZosmfRequest).setUrl(anyString());
-        verify(mockPutJsonZosmfRequest).setBody(new JSONObject(holdMap).toString());
+        verify(mockPutJsonZosmfRequest).setBody(JsonUtils.toJsonString(holdMap));
         verify(mockPutJsonZosmfRequest).executeRequest();
     }
 
@@ -313,7 +313,7 @@ public class JobChangeTest {
         releaseMap.put("version", version);
 
         verify(mockPutJsonZosmfRequest).setUrl(anyString());
-        verify(mockPutJsonZosmfRequest).setBody(new JSONObject(releaseMap).toString());
+        verify(mockPutJsonZosmfRequest).setBody(JsonUtils.toJsonString(releaseMap));
         verify(mockPutJsonZosmfRequest).executeRequest();
     }
 
@@ -333,7 +333,7 @@ public class JobChangeTest {
         releaseMap.put("version", version);
 
         verify(mockPutJsonZosmfRequest).setUrl(anyString());
-        verify(mockPutJsonZosmfRequest).setBody(new JSONObject(releaseMap).toString());
+        verify(mockPutJsonZosmfRequest).setBody(JsonUtils.toJsonString(releaseMap));
         verify(mockPutJsonZosmfRequest).executeRequest();
     }
 
@@ -362,7 +362,7 @@ public class JobChangeTest {
         releaseMap.put("version", version);
 
         verify(mockPutJsonZosmfRequest).setUrl(anyString());
-        verify(mockPutJsonZosmfRequest).setBody(new JSONObject(releaseMap).toString());
+        verify(mockPutJsonZosmfRequest).setBody(JsonUtils.toJsonString(releaseMap));
         verify(mockPutJsonZosmfRequest).executeRequest();
     }
 
@@ -389,7 +389,7 @@ public class JobChangeTest {
         releaseMap.put("version", version);
 
         verify(mockPutJsonZosmfRequestToken).setUrl(anyString());
-        verify(mockPutJsonZosmfRequestToken).setBody(new JSONObject(releaseMap).toString());
+        verify(mockPutJsonZosmfRequestToken).setBody(JsonUtils.toJsonString(releaseMap));
         verify(mockPutJsonZosmfRequestToken).executeRequest();
     }
 

--- a/src/test/java/zowe/client/sdk/zosjobs/methods/JobDeleteTest.java
+++ b/src/test/java/zowe/client/sdk/zosjobs/methods/JobDeleteTest.java
@@ -10,7 +10,6 @@
 package zowe.client.sdk.zosjobs.methods;
 
 import kong.unirest.core.Cookie;
-import org.json.simple.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -47,14 +46,14 @@ public class JobDeleteTest {
     public void init() throws ZosmfRequestException {
         mockJsonDeleteRequest = Mockito.mock(DeleteJsonZosmfRequest.class);
         Mockito.when(mockJsonDeleteRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonDeleteRequest).setUrl(any());
         doCallRealMethod().when(mockJsonDeleteRequest).getUrl();
 
         mockJsonDeleteRequestToken = Mockito.mock(DeleteJsonZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
         Mockito.when(mockJsonDeleteRequestToken.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonDeleteRequestToken).setHeaders(anyMap());
         doCallRealMethod().when(mockJsonDeleteRequestToken).setStandardHeaders();
         doCallRealMethod().when(mockJsonDeleteRequestToken).setUrl(any());

--- a/src/test/java/zowe/client/sdk/zosjobs/methods/JobGetJsonTest.java
+++ b/src/test/java/zowe/client/sdk/zosjobs/methods/JobGetJsonTest.java
@@ -12,7 +12,7 @@ package zowe.client.sdk.zosjobs.methods;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.json.simple.JSONObject;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -150,13 +150,12 @@ public class JobGetJsonTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void tstJobGetJsonStatusWithOutStepDataAndSomeEmptyValuesSuccess() throws ZosmfRequestException {
-        final JSONObject jsonResponse = new JSONObject();
+        final ObjectNode jsonResponse = mapper.createObjectNode();
         jsonResponse.put("retcode", "null");
         jsonResponse.put("jobname", "BLSJPRMI");
         jsonResponse.put("status", "ACTIVE");
-        jsonResponse.put("step-data", null);
+        jsonResponse.set("step-data", null);
         jsonResponse.put("owner", "IBMUSER");
         jsonResponse.put("subsystem", "JES2");
         jsonResponse.put("phase", 20);
@@ -196,9 +195,8 @@ public class JobGetJsonTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void tstJobGetJsonStatusWithStepDataSuccess() throws ZosmfRequestException {
-        final JSONObject jsonResponse = new JSONObject();
+        final ObjectNode jsonResponse = mapper.createObjectNode();
         jsonResponse.put("retcode", "null");
         jsonResponse.put("jobname", "BLSJPRMI");
         jsonResponse.put("status", "ACTIVE");
@@ -208,7 +206,7 @@ public class JobGetJsonTest {
         jsonResponse.put("jobid", "STC00052");
         jsonResponse.put("url", "https://host:port/zosmf/restjobs/jobs/S0000052SY1.....CE35BDE8.......%3A");
         jsonResponse.put("phase-name", "Job is on the hard copy queue");
-        jsonResponse.put("step-data", stepDataArray);
+        jsonResponse.set("step-data", stepDataArray);
         jsonResponse.put("owner", "IBMUSER");
         jsonResponse.put("subsystem", "JES2");
         jsonResponse.put("files-url", "https://host:port/zosmf/restjobs/jobs/S0000052SY1.....CE35BDE8.......%3A/files");
@@ -260,13 +258,12 @@ public class JobGetJsonTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void tstJobGetJsonStatusWithStepDataFlagTrue() throws ZosmfRequestException {
-        final JSONObject jsonResponse = new JSONObject();
+        final ObjectNode jsonResponse = mapper.createObjectNode();
         jsonResponse.put("jobname", "BLSJPRMI");
         jsonResponse.put("jobid", "STC00052");
         jsonResponse.put("status", "ACTIVE");
-        jsonResponse.put("step-data", stepDataArray);
+        jsonResponse.set("step-data", stepDataArray);
 
         final Response response = new Response(jsonResponse, 200, "success");
         Mockito.when(mockJsonGetRequest.executeRequest()).thenReturn(response);

--- a/src/test/java/zowe/client/sdk/zosjobs/methods/JobSubmitTest.java
+++ b/src/test/java/zowe/client/sdk/zosjobs/methods/JobSubmitTest.java
@@ -10,7 +10,8 @@
 package zowe.client.sdk.zosjobs.methods;
 
 import kong.unirest.core.Cookie;
-import org.json.simple.JSONObject;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -52,7 +53,7 @@ public class JobSubmitTest {
 
     @BeforeEach
     public void init() throws ZosmfRequestException {
-        JSONObject jobJson = getJsonObject();
+        ObjectNode jobJson = getJsonObject();
 
         mockPutJsonZosmfRequest = Mockito.mock(PutJsonZosmfRequest.class);
         mockPutTextZosmfRequest = Mockito.mock(PutTextZosmfRequest.class);
@@ -76,7 +77,7 @@ public class JobSubmitTest {
         doCallRealMethod().when(mockPutJsonZosmfRequestToken).getUrl();
     }
 
-    private static JSONObject getJsonObject() {
+    private static ObjectNode getJsonObject() {
         final Map<String, String> jsonMap = new HashMap<>();
         jsonMap.put("jobid", "jobid");
         jsonMap.put("jobname", "jobname");
@@ -90,7 +91,10 @@ public class JobSubmitTest {
         jsonMap.put("files-url", "files-url");
         jsonMap.put("job-correlator", "job-correlator");
         jsonMap.put("phase-name", "phase-name");
-        return new JSONObject(jsonMap);
+        final ObjectMapper mapper = new ObjectMapper();
+        final ObjectNode node = mapper.createObjectNode();
+        jsonMap.forEach(node::put);
+        return node;
     }
 
     @Test

--- a/src/test/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCreateTest.java
+++ b/src/test/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCreateTest.java
@@ -10,9 +10,9 @@
 package zowe.client.sdk.zosmfworkflow.methods;
 
 import kong.unirest.core.Cookie;
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -48,6 +48,8 @@ import static org.mockito.Mockito.*;
  */
 public class WorkflowCreateTest {
 
+    private final ObjectMapper mapper = new ObjectMapper();
+
     private final ZosConnection connection = ZosConnectionFactory
             .createBasicConnection("1", 443, "1", "1");
     private final ZosConnection tokenConnection = ZosConnectionFactory
@@ -57,7 +59,7 @@ public class WorkflowCreateTest {
 
     @BeforeEach
     public void init() throws ZosmfRequestException {
-        JSONObject workflowJson = getJsonObject();
+        ObjectNode workflowJson = getJsonObject();
 
         mockPostJsonZosmfRequest = Mockito.mock(PostJsonZosmfRequest.class);
         Mockito.when(mockPostJsonZosmfRequest.executeRequest()).thenReturn(
@@ -78,14 +80,15 @@ public class WorkflowCreateTest {
         doCallRealMethod().when(mockPostJsonZosmfRequestToken).setBody(any());
     }
 
-    private static JSONObject getJsonObject() {
-        final Map<String, String> jsonMap = new HashMap<>();
-        jsonMap.put("workflowKey", "workflow-key");
-        jsonMap.put("workflowDescription", "workflow-description");
-        jsonMap.put("workflowID", "workflow-id");
-        jsonMap.put("workflowVersion", "1.0");
-        jsonMap.put("vendor", "IBM");
-        return new JSONObject(jsonMap);
+    private static ObjectNode getJsonObject() {
+        final ObjectMapper m = new ObjectMapper();
+        final ObjectNode node = m.createObjectNode();
+        node.put("workflowKey", "workflow-key");
+        node.put("workflowDescription", "workflow-description");
+        node.put("workflowID", "workflow-id");
+        node.put("workflowVersion", "1.0");
+        node.put("vendor", "IBM");
+        return node;
     }
 
     private static WorkflowCreateInputData createInputData() {
@@ -123,40 +126,40 @@ public class WorkflowCreateTest {
         final ArgumentCaptor<Object> bodyCaptor = ArgumentCaptor.forClass(Object.class);
         verify(mockPostJsonZosmfRequest).setBody(bodyCaptor.capture());
         final String body = bodyCaptor.getValue().toString();
-        final JSONObject requestBody = (JSONObject) new JSONParser().parse(body);
+        final JsonNode requestBody = mapper.readTree(body);
 
         assertEquals("https://1:443/zosmf/workflow/rest/1.0/workflows", mockPostJsonZosmfRequest.getUrl());
-        assertEquals("AutomationExample", requestBody.get("workflowName"));
+        assertEquals("AutomationExample", requestBody.get("workflowName").asText());
         assertEquals("/usr/lpp/zosmf/samples/workflow_sample_automation.xml",
-                requestBody.get("workflowDefinitionFile"));
-        assertEquals("SY1", requestBody.get("workflowDefinitionFileSystem"));
-        assertEquals("/tmp/workflow.properties", requestBody.get("variableInputFile"));
-        assertEquals("input", requestBody.get("resolveGlobalConflictByUsing"));
-        assertEquals("SY1", requestBody.get("system"));
-        assertEquals("zosmfad", requestBody.get("owner"));
-        assertEquals("ZOSMFAD", requestBody.get("workflowArchiveSAFID"));
+                requestBody.get("workflowDefinitionFile").asText());
+        assertEquals("SY1", requestBody.get("workflowDefinitionFileSystem").asText());
+        assertEquals("/tmp/workflow.properties", requestBody.get("variableInputFile").asText());
+        assertEquals("input", requestBody.get("resolveGlobalConflictByUsing").asText());
+        assertEquals("SY1", requestBody.get("system").asText());
+        assertEquals("zosmfad", requestBody.get("owner").asText());
+        assertEquals("ZOSMFAD", requestBody.get("workflowArchiveSAFID").asText());
         assertEquals("This workflow was created through the z/OSMF workflow services REST interface.",
-                requestBody.get("comments"));
-        assertEquals(Boolean.FALSE, requestBody.get("assignToOwner"));
-        assertEquals("Restricted", requestBody.get("accessType"));
-        assertEquals("ACCT123", requestBody.get("accountInfo"));
-        assertEquals(Boolean.TRUE, requestBody.get("deleteCompletedJobs"));
-        assertEquals("/u/IBMUSER/jobFiles", requestBody.get("jobsOutputDirectory"));
-        assertEquals(Boolean.TRUE, requestBody.get("autoDeleteOnCompletion"));
-        assertEquals("remoteuser", requestBody.get("targetSystemuid"));
-        assertEquals("remotepwd", requestBody.get("targetSystempwd"));
+                requestBody.get("comments").asText());
+        assertEquals(false, requestBody.get("assignToOwner").asBoolean());
+        assertEquals("Restricted", requestBody.get("accessType").asText());
+        assertEquals("ACCT123", requestBody.get("accountInfo").asText());
+        assertEquals(true, requestBody.get("deleteCompletedJobs").asBoolean());
+        assertEquals("/u/IBMUSER/jobFiles", requestBody.get("jobsOutputDirectory").asText());
+        assertEquals(true, requestBody.get("autoDeleteOnCompletion").asBoolean());
+        assertEquals("remoteuser", requestBody.get("targetSystemuid").asText());
+        assertEquals("remotepwd", requestBody.get("targetSystempwd").asText());
 
-        final JSONArray variables = (JSONArray) requestBody.get("variables");
+        final JsonNode variables = requestBody.get("variables");
         assertEquals(2, variables.size());
-        assertEquals("user_name", ((JSONObject) variables.get(0)).get("name"));
-        assertEquals("IBMUSER", ((JSONObject) variables.get(0)).get("value"));
-        assertEquals("file_name", ((JSONObject) variables.get(1)).get("name"));
-        assertEquals("textfile.txt", ((JSONObject) variables.get(1)).get("value"));
+        assertEquals("user_name", variables.get(0).get("name").asText());
+        assertEquals("IBMUSER", variables.get(0).get("value").asText());
+        assertEquals("file_name", variables.get(1).get("name").asText());
+        assertEquals("textfile.txt", variables.get(1).get("value").asText());
 
-        final JSONArray jobStatement = (JSONArray) requestBody.get("jobStatement");
+        final JsonNode jobStatement = requestBody.get("jobStatement");
         assertEquals(2, jobStatement.size());
-        assertEquals("//TESTJOB JOB (ACCT123)", jobStatement.get(0));
-        assertEquals("//*", jobStatement.get(1));
+        assertEquals("//TESTJOB JOB (ACCT123)", jobStatement.get(0).asText());
+        assertEquals("//*", jobStatement.get(1).asText());
 
         assertEquals("workflow-key", response.getWorkflowKey());
         assertEquals("workflow-description", response.getWorkflowDescription());
@@ -179,7 +182,7 @@ public class WorkflowCreateTest {
 
     @Test
     public void tstWorkflowCreateJsonStringResponseSuccess() throws Exception {
-        final JSONObject workflowJson = getJsonObject();
+        final ObjectNode workflowJson = getJsonObject();
         final PostJsonZosmfRequest mockPostJsonZosmfRequestString = Mockito.mock(PostJsonZosmfRequest.class);
         Mockito.when(mockPostJsonZosmfRequestString.executeRequest()).thenReturn(
                 new Response(workflowJson.toString(), 201, "Created"));
@@ -291,13 +294,13 @@ public class WorkflowCreateTest {
         // create request body points at the uploaded USS temp paths, not the local paths
         final ArgumentCaptor<Object> bodyCaptor = ArgumentCaptor.forClass(Object.class);
         verify(mockPostJsonZosmfRequest).setBody(bodyCaptor.capture());
-        final JSONObject requestBody = (JSONObject) new JSONParser().parse(bodyCaptor.getValue().toString());
-        assertTrue(requestBody.get("workflowDefinitionFile").toString().startsWith("/tmp/"));
-        assertTrue(requestBody.get("variableInputFile").toString().startsWith("/tmp/"));
+        final JsonNode requestBody = mapper.readTree(bodyCaptor.getValue().toString());
+        assertTrue(requestBody.get("workflowDefinitionFile").asText().startsWith("/tmp/"));
+        assertTrue(requestBody.get("variableInputFile").asText().startsWith("/tmp/"));
         // non-file fields are preserved through toBuilder
-        assertEquals("AutomationExample", requestBody.get("workflowName"));
-        assertEquals("SY1", requestBody.get("system"));
-        assertEquals("zosmfad", requestBody.get("owner"));
+        assertEquals("AutomationExample", requestBody.get("workflowName").asText());
+        assertEquals("SY1", requestBody.get("system").asText());
+        assertEquals("zosmfad", requestBody.get("owner").asText());
 
         assertEquals("workflow-key", response.getWorkflow().getWorkflowKey());
         assertTrue(response.getFilesKept().isEmpty());

--- a/src/test/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowDeleteTest.java
+++ b/src/test/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowDeleteTest.java
@@ -10,7 +10,6 @@
 package zowe.client.sdk.zosmfworkflow.methods;
 
 import kong.unirest.core.Cookie;
-import org.json.simple.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
@@ -98,7 +97,7 @@ public class WorkflowDeleteTest {
     public void tstWorkflowDeleteSuccess() throws ZosmfRequestException {
         Mockito.when(connection.getZosmfUrl()).thenReturn("https://1:443");
         DeleteJsonZosmfRequest mockDeleteRequest = Mockito.mock(DeleteJsonZosmfRequest.class);
-        Mockito.when(mockDeleteRequest.executeRequest()).thenReturn(new Response(new JSONObject(), 200, "success"));
+        Mockito.when(mockDeleteRequest.executeRequest()).thenReturn(new Response("{}", 200, "success"));
 
         doCallRealMethod().when(mockDeleteRequest).setUrl(any());
         doCallRealMethod().when(mockDeleteRequest).getUrl();
@@ -138,7 +137,7 @@ public class WorkflowDeleteTest {
         ZosConnection connection = Mockito.mock(ZosConnection.class);
         Mockito.when(connection.getZosmfUrl()).thenReturn("https://1:443/zosmf");
         DeleteJsonZosmfRequest mockDeleteRequest = Mockito.mock(DeleteJsonZosmfRequest.class);
-        Mockito.when(mockDeleteRequest.executeRequest()).thenReturn(new Response(new JSONObject(), 200, "success"));
+        Mockito.when(mockDeleteRequest.executeRequest()).thenReturn(new Response("{}", 200, "success"));
 
         doCallRealMethod().when(mockDeleteRequest).setUrl(any());
         doCallRealMethod().when(mockDeleteRequest).getUrl();
@@ -154,7 +153,7 @@ public class WorkflowDeleteTest {
         ZosConnection connection = Mockito.mock(ZosConnection.class);
         Mockito.when(connection.getZosmfUrl()).thenReturn("https://1:443/zosmf");
         DeleteJsonZosmfRequest mockDeleteRequest = Mockito.mock(DeleteJsonZosmfRequest.class);
-        Mockito.when(mockDeleteRequest.executeRequest()).thenReturn(new Response(new JSONObject(), 200, "success"));
+        Mockito.when(mockDeleteRequest.executeRequest()).thenReturn(new Response("{}", 200, "success"));
 
         doCallRealMethod().when(mockDeleteRequest).setUrl(any());
         doCallRealMethod().when(mockDeleteRequest).getUrl();
@@ -195,14 +194,14 @@ public class WorkflowDeleteTest {
     public void tstWorkflowDeleteTokenSuccess() throws ZosmfRequestException {
         DeleteJsonZosmfRequest mockJsonDeleteRequest = Mockito.mock(DeleteJsonZosmfRequest.class);
         Mockito.when(mockJsonDeleteRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonDeleteRequest).setUrl(any());
         doCallRealMethod().when(mockJsonDeleteRequest).getUrl();
 
         mockJsonDeleteRequestToken = Mockito.mock(DeleteJsonZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
         Mockito.when(mockJsonDeleteRequestToken.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonDeleteRequestToken).setHeaders(anyMap());
         doCallRealMethod().when(mockJsonDeleteRequestToken).setStandardHeaders();
         doCallRealMethod().when(mockJsonDeleteRequestToken).setUrl(any());
@@ -224,14 +223,14 @@ public class WorkflowDeleteTest {
     public void tstWorkflowArchivedDeleteTokenSuccess() throws ZosmfRequestException {
         DeleteJsonZosmfRequest mockJsonDeleteRequest = Mockito.mock(DeleteJsonZosmfRequest.class);
         Mockito.when(mockJsonDeleteRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonDeleteRequest).setUrl(any());
         doCallRealMethod().when(mockJsonDeleteRequest).getUrl();
 
         mockJsonDeleteRequestToken = Mockito.mock(DeleteJsonZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
         Mockito.when(mockJsonDeleteRequestToken.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 200, "success"));
+                new Response("{}", 200, "success"));
         doCallRealMethod().when(mockJsonDeleteRequestToken).setHeaders(anyMap());
         doCallRealMethod().when(mockJsonDeleteRequestToken).setStandardHeaders();
         doCallRealMethod().when(mockJsonDeleteRequestToken).setUrl(any());

--- a/src/test/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowListTest.java
+++ b/src/test/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowListTest.java
@@ -10,8 +10,8 @@
 package zowe.client.sdk.zosmfworkflow.methods;
 
 import kong.unirest.core.Cookie;
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -47,13 +47,14 @@ public class WorkflowListTest {
     private final ZosConnection tokenConnection = ZosConnectionFactory
             .createTokenConnection("1", 443, new Cookie("hello=hello"));
     private GetJsonZosmfRequest mockJsonGetRequest;
+    private final ObjectMapper mapper = new ObjectMapper();
     private GetJsonZosmfRequest mockJsonGetRequestToken;
 
     @SuppressWarnings("unchecked")
     @BeforeEach
     public void init() throws ZosmfRequestException {
-        final JSONObject archivedObj = new JSONObject();
-        archivedObj.put("archivedWorkflows", new JSONArray());
+        final ObjectNode archivedObj = mapper.createObjectNode();
+        archivedObj.set("archivedWorkflows", mapper.createArrayNode());
 
         mockJsonGetRequest = Mockito.mock(GetJsonZosmfRequest.class);
         Mockito.when(mockJsonGetRequest.executeRequest()).thenReturn(

--- a/src/test/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowStartTest.java
+++ b/src/test/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowStartTest.java
@@ -10,8 +10,8 @@
 package zowe.client.sdk.zosmfworkflow.methods;
 
 import kong.unirest.core.Cookie;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -34,6 +34,8 @@ import static org.mockito.Mockito.*;
  */
 public class WorkflowStartTest {
 
+    private final ObjectMapper mapper = new ObjectMapper();
+
     private final ZosConnection connection = ZosConnectionFactory
             .createBasicConnection("1", 443, "1", "1");
     private final ZosConnection tokenConnection = ZosConnectionFactory
@@ -55,7 +57,7 @@ public class WorkflowStartTest {
         ZosConnection mockConnection = Mockito.mock(ZosConnection.class);
         Mockito.when(mockConnection.getZosmfUrl()).thenReturn("https://1:443/zosmf");
         PutJsonZosmfRequest mockPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
-        Mockito.when(mockPutRequest.executeRequest()).thenReturn(new Response(new JSONObject(), 202, "Accepted"));
+        Mockito.when(mockPutRequest.executeRequest()).thenReturn(new Response("{}", 202, "Accepted"));
 
         doCallRealMethod().when(mockPutRequest).setUrl(any());
         doCallRealMethod().when(mockPutRequest).getUrl();
@@ -68,16 +70,16 @@ public class WorkflowStartTest {
         final ArgumentCaptor<Object> bodyCaptor = ArgumentCaptor.forClass(Object.class);
         verify(mockPutRequest).setBody(bodyCaptor.capture());
         final String body = bodyCaptor.getValue().toString();
-        final JSONObject requestBody = (JSONObject) new JSONParser().parse(body);
+        final JsonNode requestBody = mapper.readTree(body);
 
         assertEquals("https://1:443/zosmf/workflow/rest/1.0/workflows/workflow-key-123/operations/start",
                 mockPutRequest.getUrl());
-        assertEquals("outputFileValue", requestBody.get("resolveConflictByUsing"));
-        assertEquals("Step1", requestBody.get("stepName"));
-        assertEquals(Boolean.TRUE, requestBody.get("performSubsequent"));
-        assertEquals("https://example.com/notification", requestBody.get("notificationUrl"));
-        assertEquals("remoteuser", requestBody.get("targetSystemuid"));
-        assertEquals("remotepwd", requestBody.get("targetSystempwd"));
+        assertEquals("outputFileValue", requestBody.get("resolveConflictByUsing").asText());
+        assertEquals("Step1", requestBody.get("stepName").asText());
+        assertEquals(true, requestBody.get("performSubsequent").asBoolean());
+        assertEquals("https://example.com/notification", requestBody.get("notificationUrl").asText());
+        assertEquals("remoteuser", requestBody.get("targetSystemuid").asText());
+        assertEquals("remotepwd", requestBody.get("targetSystempwd").asText());
 
         assertEquals(202, response.getStatusCode().orElse(-1));
         assertEquals("Accepted", response.getStatusText().orElse("n\\a"));
@@ -88,7 +90,7 @@ public class WorkflowStartTest {
         ZosConnection mockConnection = Mockito.mock(ZosConnection.class);
         Mockito.when(mockConnection.getZosmfUrl()).thenReturn("https://1:443/zosmf");
         PutJsonZosmfRequest mockPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
-        Mockito.when(mockPutRequest.executeRequest()).thenReturn(new Response(new JSONObject(), 202, "Accepted"));
+        Mockito.when(mockPutRequest.executeRequest()).thenReturn(new Response("{}", 202, "Accepted"));
 
         doCallRealMethod().when(mockPutRequest).setUrl(any());
         doCallRealMethod().when(mockPutRequest).getUrl();
@@ -113,7 +115,7 @@ public class WorkflowStartTest {
         ZosConnection mockConnection = Mockito.mock(ZosConnection.class);
         Mockito.when(mockConnection.getZosmfUrl()).thenReturn("https://1:443/zosmf");
         PutJsonZosmfRequest mockPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
-        Mockito.when(mockPutRequest.executeRequest()).thenReturn(new Response(new JSONObject(), 202, "Accepted"));
+        Mockito.when(mockPutRequest.executeRequest()).thenReturn(new Response("{}", 202, "Accepted"));
 
         doCallRealMethod().when(mockPutRequest).setUrl(any());
         doCallRealMethod().when(mockPutRequest).getUrl();
@@ -130,7 +132,7 @@ public class WorkflowStartTest {
     public void tstWorkflowStartTokenSuccess() throws Exception {
         PutJsonZosmfRequest mockPutRequestToken = Mockito.mock(PutJsonZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
-        Mockito.when(mockPutRequestToken.executeRequest()).thenReturn(new Response(new JSONObject(), 202, "Accepted"));
+        Mockito.when(mockPutRequestToken.executeRequest()).thenReturn(new Response("{}", 202, "Accepted"));
 
         doCallRealMethod().when(mockPutRequestToken).setHeaders(anyMap());
         doCallRealMethod().when(mockPutRequestToken).setStandardHeaders();

--- a/src/test/java/zowe/client/sdk/zostso/methods/TsoStartTest.java
+++ b/src/test/java/zowe/client/sdk/zostso/methods/TsoStartTest.java
@@ -9,7 +9,7 @@
  */
 package zowe.client.sdk.zostso.methods;
 
-import org.json.simple.JSONObject;
+import zowe.client.sdk.utility.JsonUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -222,10 +222,10 @@ public class TsoStartTest {
         doCallRealMethod().when(mockRequest).getUrl();
 
         // Mock response to return servletKey
-        final Map<String, Object> map = new HashMap<>();
+        final Map<String, String> map = new HashMap<>();
         map.put("servletKey", "SERVKEY123");
         Mockito.when(mockRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(map), 200, "success"));
+                new Response(JsonUtils.toJsonString(map), 200, "success"));
 
         final TsoStartResponse result = tsoStart.start(inputData);
         assertEquals("SERVKEY123", result.getSessionId());

--- a/src/test/java/zowe/client/sdk/zostso/methods/TsoStartTest.java
+++ b/src/test/java/zowe/client/sdk/zostso/methods/TsoStartTest.java
@@ -9,7 +9,7 @@
  */
 package zowe.client.sdk.zostso.methods;
 
-import zowe.client.sdk.utility.JsonUtils;
+import zowe.client.sdk.utility.TestJsonUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -225,7 +225,7 @@ public class TsoStartTest {
         final Map<String, String> map = new HashMap<>();
         map.put("servletKey", "SERVKEY123");
         Mockito.when(mockRequest.executeRequest()).thenReturn(
-                new Response(JsonUtils.toJsonString(map), 200, "success"));
+                new Response(TestJsonUtils.toJsonString(map), 200, "success"));
 
         final TsoStartResponse result = tsoStart.start(inputData);
         assertEquals("SERVKEY123", result.getSessionId());

--- a/src/test/java/zowe/client/sdk/zosvariables/methods/VariableCreateTest.java
+++ b/src/test/java/zowe/client/sdk/zosvariables/methods/VariableCreateTest.java
@@ -10,7 +10,6 @@
 package zowe.client.sdk.zosvariables.methods;
 
 import kong.unirest.core.Cookie;
-import org.json.simple.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -49,7 +48,7 @@ public class VariableCreateTest {
     public void init() throws ZosmfRequestException {
         mockPostRequest = Mockito.mock(PostJsonZosmfRequest.class);
         Mockito.when(mockPostRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 204, "No Content"));
+                new Response("{}", 204, "No Content"));
         doCallRealMethod().when(mockPostRequest).setUrl(any());
         doCallRealMethod().when(mockPostRequest).getUrl();
         doCallRealMethod().when(mockPostRequest).setBody(any());
@@ -57,7 +56,7 @@ public class VariableCreateTest {
         mockPostRequestToken = Mockito.mock(PostJsonZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
         Mockito.when(mockPostRequestToken.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 204, "No Content"));
+                new Response("{}", 204, "No Content"));
         doCallRealMethod().when(mockPostRequestToken).setHeaders(anyMap());
         doCallRealMethod().when(mockPostRequestToken).setStandardHeaders();
         doCallRealMethod().when(mockPostRequestToken).setUrl(any());

--- a/src/test/java/zowe/client/sdk/zosvariables/methods/VariableExportTest.java
+++ b/src/test/java/zowe/client/sdk/zosvariables/methods/VariableExportTest.java
@@ -10,7 +10,6 @@
 package zowe.client.sdk.zosvariables.methods;
 
 import kong.unirest.core.Cookie;
-import org.json.simple.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -46,7 +45,7 @@ public class VariableExportTest {
     public void init() throws ZosmfRequestException {
         mockPostRequest = Mockito.mock(PostJsonZosmfRequest.class);
         Mockito.when(mockPostRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 204, "No Content"));
+                new Response("{}", 204, "No Content"));
         doCallRealMethod().when(mockPostRequest).setUrl(any());
         doCallRealMethod().when(mockPostRequest).getUrl();
         doCallRealMethod().when(mockPostRequest).setBody(any());
@@ -54,7 +53,7 @@ public class VariableExportTest {
         mockPostRequestToken = Mockito.mock(PostJsonZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
         Mockito.when(mockPostRequestToken.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 204, "No Content"));
+                new Response("{}", 204, "No Content"));
         doCallRealMethod().when(mockPostRequestToken).setHeaders(anyMap());
         doCallRealMethod().when(mockPostRequestToken).setStandardHeaders();
         doCallRealMethod().when(mockPostRequestToken).setUrl(any());

--- a/src/test/java/zowe/client/sdk/zosvariables/methods/VariableImportTest.java
+++ b/src/test/java/zowe/client/sdk/zosvariables/methods/VariableImportTest.java
@@ -10,7 +10,6 @@
 package zowe.client.sdk.zosvariables.methods;
 
 import kong.unirest.core.Cookie;
-import org.json.simple.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -46,7 +45,7 @@ public class VariableImportTest {
     public void init() throws ZosmfRequestException {
         mockPostRequest = Mockito.mock(PostJsonZosmfRequest.class);
         Mockito.when(mockPostRequest.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 204, "No Content"));
+                new Response("{}", 204, "No Content"));
         doCallRealMethod().when(mockPostRequest).setUrl(any());
         doCallRealMethod().when(mockPostRequest).getUrl();
         doCallRealMethod().when(mockPostRequest).setBody(any());
@@ -54,7 +53,7 @@ public class VariableImportTest {
         mockPostRequestToken = Mockito.mock(PostJsonZosmfRequest.class,
                 withSettings().useConstructor(tokenConnection));
         Mockito.when(mockPostRequestToken.executeRequest()).thenReturn(
-                new Response(new JSONObject(), 204, "No Content"));
+                new Response("{}", 204, "No Content"));
         doCallRealMethod().when(mockPostRequestToken).setHeaders(anyMap());
         doCallRealMethod().when(mockPostRequestToken).setStandardHeaders();
         doCallRealMethod().when(mockPostRequestToken).setUrl(any());


### PR DESCRIPTION
## Description

This pull request removes the outdated `com.googlecode.json-simple` dependency from the codebase and fully migrates the test suite to use the Jackson library (`com.fasterxml.jackson`). This aligns the unit tests with the standard JSON processing approach used throughout the rest of the SDK.

## Key Changes

- **Dependency Clean Up:** Removed the `json-simple` dependency block from `pom.xml`.
- **Refactoring Mocked Responses:** Replaced raw `JSONObject` mock instances with lightweight string literals (`"{}"`) where applicable, avoiding unnecessary `ObjectMapper` allocations.
- **Centralized Serialization Helper:** Added a deterministic `toJsonString(Map<String, String>)` helper in `JsonUtils.java` to format map payloads into JSON strings without relying on `org.json.simple.JSONObject`.
- **Jackson-Based Node Inspection:** Updated tests that inspect request payloads (e.g., `WorkflowStartTest`, `UssSetAclTest`) to use `ObjectMapper.readTree()` and validate properties via the `JsonNode` API.

## Verification

- Successfully compiled the project using Java 21.
- Ran the complete test suite with **1,099 tests passing** and **0 failures**.

## Closes

Closes #555