### PR TITLE
Fix WorkflowArchive.archive() NullPointerException on missing request body

### DIFF
--- a/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowArchive.java
+++ b/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowArchive.java
@@ -92,6 +92,7 @@ public class WorkflowArchive {
                 OPERATIONS_RESOURCE +
                 UrlConstants.URL_PATH_DELIM + ARCHIVE_RESOURCE;
 
+        request.setBody("{}");
         request.setUrl(url);
         return request.executeRequest();
     }


### PR DESCRIPTION
WorkflowArchive.archive() was throwing a NullPointerException on every call, since PostJsonZosmfRequest requires a request body to be set before executing, and this method never set one. The real z/OSMF archive endpoint itself needs no body at all, per IBM's documentation, so the fix adds an empty JSON body before sending the request.
Tested live against IBM Z Xplore: created a workflow, archived it successfully with a 201 response, confirmed it appears in the archived list, then deleted it cleanly.