### PR TITLE
Improve z/OS variables GET input validation and request handling

### DIFF
--- a/src/main/java/zowe/client/sdk/zosvariables/input/factory/VariableGetInputData.java
+++ b/src/main/java/zowe/client/sdk/zosvariables/input/factory/VariableGetInputData.java
@@ -46,7 +46,7 @@ public class VariableGetInputData {
     private final List<String> variableNames;
 
     /**
-     * Optional variable type filter.
+     * Required variable type to retrieve.
      */
     private final VariableType variableType;
 
@@ -58,6 +58,8 @@ public class VariableGetInputData {
      * @param builder VariableGetInputData.Builder builder
      */
     VariableGetInputData(final Builder builder) {
+        ValidateUtils.checkNullParameter(builder.variableType, "variableType");
+        ValidateUtils.checkIllegalParameter(builder.variableType.getValue(), "variableType");
         this.local = builder.local;
         if (!builder.local) {
             ValidateUtils.checkIllegalParameter(builder.sysplexName, "sysplexName");
@@ -74,8 +76,8 @@ public class VariableGetInputData {
      *
      * @return sysplex name
      */
-    public Optional<String> getSysplexName() {
-        return Optional.ofNullable(sysplexName);
+    public String getSysplexName() {
+        return sysplexName;
     }
 
     /**
@@ -83,14 +85,14 @@ public class VariableGetInputData {
      *
      * @return system name
      */
-    public Optional<String> getSystemName() {
-        return Optional.ofNullable(systemName);
+    public String getSystemName() {
+        return systemName;
     }
 
     /**
-     * Determine whether the local system is requested.
+     * Returns whether variables are retrieved from the local system.
      *
-     * @return true if retrieving variables from the local system; false otherwise
+     * @return {@code true} if the local system is requested; {@code false} otherwise
      */
     public boolean isLocal() {
         return local;
@@ -108,10 +110,10 @@ public class VariableGetInputData {
     /**
      * Returns the requested variable type.
      *
-     * @return optional variable type
+     * @return variable type
      */
-    public Optional<VariableType> getVariableType() {
-        return Optional.ofNullable(variableType);
+    public VariableType getVariableType() {
+        return variableType;
     }
 
     /**

--- a/src/main/java/zowe/client/sdk/zosvariables/input/factory/VariableGetInputFactory.java
+++ b/src/main/java/zowe/client/sdk/zosvariables/input/factory/VariableGetInputFactory.java
@@ -34,7 +34,7 @@ public final class VariableGetInputFactory {
      * Create input for z/OS variables.
      *
      * @param sysplexName name of the target sysplex
-     * @param systemName name of the target z/OS system
+     * @param systemName  name of the target z/OS system
      * @return VariableGetInputData
      */
     public static VariableGetInputData createZosVariable(final String sysplexName,
@@ -50,8 +50,8 @@ public final class VariableGetInputFactory {
     /**
      * Create input for z/OS variables with filters.
      *
-     * @param sysplexName name of the target sysplex
-     * @param systemName name of the target z/OS system
+     * @param sysplexName   name of the target sysplex
+     * @param systemName    name of the target z/OS system
      * @param variableNames names of the variables to retrieve; if {@code null} or empty,
      *                      all variables are returned
      * @return VariableGetInputData
@@ -72,7 +72,7 @@ public final class VariableGetInputFactory {
      * Create input for z/OSMF system symbols.
      *
      * @param sysplexName name of the target sysplex (local sysplex only)
-     * @param systemName name of the target z/OS system
+     * @param systemName  name of the target z/OS system
      * @return VariableGetInputData
      */
     public static VariableGetInputData createZosmfSymbol(final String sysplexName,
@@ -88,8 +88,8 @@ public final class VariableGetInputFactory {
     /**
      * Create input for z/OSMF system symbols with filters.
      *
-     * @param sysplexName name of the target sysplex (local sysplex only)
-     * @param systemName name of the target z/OS system
+     * @param sysplexName   name of the target sysplex (local sysplex only)
+     * @param systemName    name of the target z/OS system
      * @param variableNames names of the variables to retrieve; if {@code null} or empty,
      *                      all variables are returned
      * @return VariableGetInputData

--- a/src/main/java/zowe/client/sdk/zosvariables/methods/VariableGet.java
+++ b/src/main/java/zowe/client/sdk/zosvariables/methods/VariableGet.java
@@ -59,7 +59,7 @@ public class VariableGet {
      * This constructor is package-private.
      *
      * @param connection for connection information, see ZosConnection object
-     * @param request any compatible ZosmfRequest Interface object
+     * @param request    any compatible ZosmfRequest Interface object
      */
     VariableGet(final ZosConnection connection, final ZosmfRequest request) {
         ValidateUtils.checkNullParameter(connection, "connection");
@@ -85,15 +85,14 @@ public class VariableGet {
     public VariableGetResponse get(final VariableGetInputData inputData) throws ZosmfRequestException {
         ValidateUtils.checkNullParameter(inputData, "inputData");
         final StringBuilder url = new StringBuilder(connection.getZosmfUrl() +
-                VariableConstants.RESOURCE +
-                UrlConstants.URL_PATH_DELIM);
+                VariableConstants.RESOURCE + UrlConstants.URL_PATH_DELIM);
 
         if (inputData.isLocal()) {
             url.append("local");
         } else {
-            inputData.getSysplexName().ifPresent(name -> url.append(EncodeUtils.encodeURIComponent(name)));
-            url.append(".");
-            inputData.getSystemName().ifPresent(name -> url.append(EncodeUtils.encodeURIComponent(name)));
+            final String sysplexName = EncodeUtils.encodeURIComponent(inputData.getSysplexName());
+            final String sysName = EncodeUtils.encodeURIComponent(inputData.getSystemName());
+            url.append(sysplexName).append(".").append(sysName);
         }
 
         final List<String> queryParams = new ArrayList<>();
@@ -102,18 +101,17 @@ public class VariableGet {
                 variableNames.forEach(name -> queryParams.add("var-name=" + EncodeUtils.encodeURIComponent(name)));
             }
         });
-        inputData.getVariableType().ifPresent(type -> queryParams.add("source=" + type.getValue()));
+        queryParams.add("source=" + inputData.getVariableType().getValue());
 
-        if (!queryParams.isEmpty()) {
-            url.append("?").append(String.join("&", queryParams));
-        }
+        url.append("?").append(String.join("&", queryParams));
         request.setUrl(url.toString());
 
-        return JsonUtils.parseResponse(request.executeRequest()
+        final String response =
+                request.executeRequest()
                         .getResponsePhrase().orElseThrow(() -> new IllegalStateException("no get variables response phrase"))
-                        .toString(),
-                VariableGetResponse.class, GET_CONTEXT
-        );
+                        .toString();
+
+        return JsonUtils.parseResponse(response, VariableGetResponse.class, GET_CONTEXT);
     }
 
 }

--- a/src/main/java/zowe/client/sdk/zosvariables/response/VariableGetResponse.java
+++ b/src/main/java/zowe/client/sdk/zosvariables/response/VariableGetResponse.java
@@ -41,7 +41,7 @@ public final class VariableGetResponse {
      * VariableGetResponse Jackson constructor.
      *
      * @param systemVariableList list of system variables
-     * @param systemSymbolList list of system symbols
+     * @param systemSymbolList   list of system symbols
      */
     @JsonCreator
     public VariableGetResponse(

--- a/src/main/java/zowe/client/sdk/zosvariables/response/VariableResponse.java
+++ b/src/main/java/zowe/client/sdk/zosvariables/response/VariableResponse.java
@@ -42,8 +42,8 @@ public final class VariableResponse {
     /**
      * VariableResponse Jackson constructor.
      *
-     * @param name variable name
-     * @param value variable value
+     * @param name        variable name
+     * @param value       variable value
      * @param description variable description
      */
     @JsonCreator

--- a/src/test/java/zowe/client/sdk/zosvariables/input/factory/VariableGetInputDataTest.java
+++ b/src/test/java/zowe/client/sdk/zosvariables/input/factory/VariableGetInputDataTest.java
@@ -32,21 +32,52 @@ public class VariableGetInputDataTest {
                 .setVariableType(VariableType.VARIABLE)
                 .setLocal(false)
                 .build();
-        assertEquals("PLEX1", input.getSysplexName().orElse(null));
-        assertEquals("SYS1", input.getSystemName().orElse(null));
+        assertEquals("PLEX1", input.getSysplexName());
+        assertEquals("SYS1", input.getSystemName());
         assertEquals(Arrays.asList("VAR1", "VAR2"), input.getVariableNames().orElse(null));
-        assertEquals(VariableType.VARIABLE, input.getVariableType().orElse(null));
+        assertEquals(VariableType.VARIABLE, input.getVariableType());
         assertFalse(input.isLocal());
     }
 
     @Test
-    public void tstVariableGetInputDataBuilderLocalSuccess() {
-        VariableGetInputData input = new VariableGetInputData.Builder().setLocal(true).build();
+    public void tstVariableGetInputDataBuilderLocalSystemSuccess() {
+        VariableGetInputData input = new VariableGetInputData.Builder()
+                .setLocal(true)
+                .setVariableType(VariableType.VARIABLE)
+                .build();
         assertTrue(input.isLocal());
-        assertFalse(input.getSysplexName().isPresent());
-        assertFalse(input.getSystemName().isPresent());
+        assertNull(input.getSysplexName());
+        assertNull(input.getSystemName());
         assertFalse(input.getVariableNames().isPresent());
-        assertFalse(input.getVariableType().isPresent());
+        assertEquals("variable", input.getVariableType().getValue());
+    }
+
+    @Test
+    public void tstVariableGetInputDataBuilderSymbolSuccess() {
+        VariableGetInputData input = new VariableGetInputData.Builder()
+                .setSysplexName("PLEX1").setSystemName("SYS1")
+                .setVariableNames(Arrays.asList("VAR1", "VAR2"))
+                .setVariableType(VariableType.SYMBOL)
+                .setLocal(false)
+                .build();
+        assertEquals("PLEX1", input.getSysplexName());
+        assertEquals("SYS1", input.getSystemName());
+        assertEquals(Arrays.asList("VAR1", "VAR2"), input.getVariableNames().orElse(null));
+        assertEquals(VariableType.SYMBOL, input.getVariableType());
+        assertFalse(input.isLocal());
+    }
+
+    @Test
+    public void tstVariableGetInputDataBuilderLocalSymbolSuccess() {
+        VariableGetInputData input = new VariableGetInputData.Builder()
+                .setLocal(true)
+                .setVariableType(VariableType.SYMBOL)
+                .build();
+        assertTrue(input.isLocal());
+        assertNull(input.getSysplexName());
+        assertNull(input.getSystemName());
+        assertFalse(input.getVariableNames().isPresent());
+        assertEquals("symbol", input.getVariableType().getValue());
     }
 
 }

--- a/src/test/java/zowe/client/sdk/zosvariables/input/factory/VariableGetInputFactoryTest.java
+++ b/src/test/java/zowe/client/sdk/zosvariables/input/factory/VariableGetInputFactoryTest.java
@@ -28,9 +28,9 @@ public class VariableGetInputFactoryTest {
     public void tstCreateSystemInputSuccess() {
         VariableGetInputData input =
                 VariableGetInputFactory.createZosVariable("PLEX1", "SYS1");
-        assertEquals("PLEX1", input.getSysplexName().orElse(null));
-        assertEquals("SYS1", input.getSystemName().orElse(null));
-        assertEquals(VariableType.VARIABLE, input.getVariableType().orElse(null));
+        assertEquals("PLEX1", input.getSysplexName());
+        assertEquals("SYS1", input.getSystemName());
+        assertEquals(VariableType.VARIABLE, input.getVariableType());
         assertFalse(input.isLocal());
     }
 
@@ -38,10 +38,10 @@ public class VariableGetInputFactoryTest {
     public void tstCreateSystemInputWithFiltersSuccess() {
         VariableGetInputData input = VariableGetInputFactory.createZosVariable(
                 "PLEX1", "SYS1", Arrays.asList("VAR1", "VAR2"));
-        assertEquals("PLEX1", input.getSysplexName().orElse(null));
-        assertEquals("SYS1", input.getSystemName().orElse(null));
+        assertEquals("PLEX1", input.getSysplexName());
+        assertEquals("SYS1", input.getSystemName());
         assertEquals(Arrays.asList("VAR1", "VAR2"), input.getVariableNames().orElse(null));
-        assertEquals(VariableType.VARIABLE, input.getVariableType().orElse(null));
+        assertEquals(VariableType.VARIABLE, input.getVariableType());
         assertFalse(input.isLocal());
     }
 
@@ -49,9 +49,9 @@ public class VariableGetInputFactoryTest {
     public void tstCreateLocalInputSuccess() {
         VariableGetInputData input = VariableGetInputFactory.createZosVariableLocal();
         assertTrue(input.isLocal());
-        assertFalse(input.getSysplexName().isPresent());
-        assertFalse(input.getSystemName().isPresent());
-        assertEquals(VariableType.VARIABLE, input.getVariableType().orElse(null));
+        assertNull(input.getSysplexName());
+        assertNull(input.getSystemName());
+        assertEquals(VariableType.VARIABLE, input.getVariableType());
     }
 
     @Test
@@ -60,16 +60,16 @@ public class VariableGetInputFactoryTest {
                 VariableGetInputFactory.createZosVariableLocal(Arrays.asList("VAR1", "VAR2"));
         assertTrue(input.isLocal());
         assertEquals(Arrays.asList("VAR1", "VAR2"), input.getVariableNames().orElse(null));
-        assertEquals(VariableType.VARIABLE, input.getVariableType().orElse(null));
+        assertEquals(VariableType.VARIABLE, input.getVariableType());
     }
 
     @Test
     public void tstCreateSymbolInputSuccess() {
         VariableGetInputData input =
                 VariableGetInputFactory.createZosmfSymbol("PLEX1", "SYS1");
-        assertEquals("PLEX1", input.getSysplexName().orElse(null));
-        assertEquals("SYS1", input.getSystemName().orElse(null));
-        assertEquals(VariableType.SYMBOL, input.getVariableType().orElse(null));
+        assertEquals("PLEX1", input.getSysplexName());
+        assertEquals("SYS1", input.getSystemName());
+        assertEquals(VariableType.SYMBOL, input.getVariableType());
         assertFalse(input.isLocal());
     }
 
@@ -77,7 +77,7 @@ public class VariableGetInputFactoryTest {
     public void tstCreateLocalSymbolInputSuccess() {
         VariableGetInputData input = VariableGetInputFactory.createZosmfSymbolLocal();
         assertTrue(input.isLocal());
-        assertEquals(VariableType.SYMBOL, input.getVariableType().orElse(null));
+        assertEquals(VariableType.SYMBOL, input.getVariableType());
     }
 
 }


### PR DESCRIPTION
Enhance z/OS system variables GET support by introducing a validated input model and improving request construction and handling.

Changes:

- Made VariableType a required field for VariableGetInputData
- Updated sysplexName and systemName getters to return String values since these fields are guaranteed when local is false.
- Simplified consumers by removing unnecessary Optional handling for required values.