### PR TITLE
feat: Add Delete Migrated Datasets API to zosfiles.dsn.methods (#567)

### DIFF
--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/README.md
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/README.md
@@ -398,6 +398,7 @@ import zowe.client.sdk.core.ZosConnectionFactory;
 import zowe.client.sdk.examples.TstZosConnection;
 import zowe.client.sdk.rest.Response;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
+import zowe.client.sdk.zosfiles.dsn.input.DeleteMigratedInputData;
 import zowe.client.sdk.zosfiles.dsn.methods.DsnDelete;
 
 /**
@@ -424,6 +425,7 @@ public class DsnDeleteExp extends TstZosConnection {
         connection = ZosConnectionFactory.createBasicConnection(hostName, zosmfPort, userName, password);
         deleteDataSet(dataSetName);
         deleteMember(dataSetName, member);
+        deleteMigratedDataSet(dataSetName);
     }
 
     /**
@@ -460,6 +462,31 @@ public class DsnDeleteExp extends TstZosConnection {
         try {
             DsnDelete zosDsn = new DsnDelete(connection);
             response = zosDsn.delete(dataSetName, member);
+        } catch (ZosmfRequestException e) {
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().hasTextResponsePhrase()) {
+                errMsg = e.getResponse().getResponsePhraseAsString().orElse(errMsg);
+            }
+            throw new RuntimeException(errMsg, e);
+        }
+
+        System.out.println(response.toString());
+    }
+
+    /**
+     * Delete a migrated dataset
+     *
+     * @param dataSetName name of a dataset to delete (e.g. 'DATASET.LIB')
+     */
+    public static void deleteMigratedDataSet(String dataSetName) {
+        Response response;
+        try {
+            DsnDelete zosDsn = new DsnDelete(connection);
+            DeleteMigratedInputData inputData = new DeleteMigratedInputData.Builder()
+                    .wait(true)
+                    .purge(true)
+                    .build();
+            response = zosDsn.deleteMigrated(dataSetName, inputData);
         } catch (ZosmfRequestException e) {
             String errMsg = e.getMessage();
             if (e.getResponse() != null && e.getResponse().hasTextResponsePhrase()) {

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/input/DeleteMigratedInputData.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/input/DeleteMigratedInputData.java
@@ -1,0 +1,115 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+package zowe.client.sdk.zosfiles.dsn.input;
+
+import java.util.Optional;
+
+/**
+ * Parameter container class for the delete migrated dataset function
+ *
+ * @version 6.0
+ */
+public class DeleteMigratedInputData {
+
+    /**
+     * If true, the function waits for completion of the request.
+     * If false (default) the request is queued.
+     */
+    private final Boolean wait;
+
+    /**
+     * If true, the function uses the PURGE=YES on ARCHDEL request.
+     * If false (default) the function uses the PURGE=NO on ARCHDEL request.
+     */
+    private final Boolean purge;
+
+    /**
+     * DeleteMigratedInputData constructor
+     *
+     * @param builder DeleteMigratedInputData.Builder object
+     */
+    private DeleteMigratedInputData(final Builder builder) {
+        this.wait = builder.wait;
+        this.purge = builder.purge;
+    }
+
+    /**
+     * Retrieve wait value
+     *
+     * @return wait value
+     */
+    public Optional<Boolean> getWait() {
+        return Optional.ofNullable(wait);
+    }
+
+    /**
+     * Retrieve purge value
+     *
+     * @return purge value
+     */
+    public Optional<Boolean> getPurge() {
+        return Optional.ofNullable(purge);
+    }
+
+    @Override
+    public String toString() {
+        return "DeleteMigratedInputData{" +
+                "wait=" + wait +
+                ", purge=" + purge +
+                '}';
+    }
+
+    /**
+     * Builder class for DeleteMigratedInputData
+     */
+    public static class Builder {
+
+        private Boolean wait;
+        private Boolean purge;
+
+        /**
+         * Builder constructor
+         */
+        public Builder() {
+        }
+
+        /**
+         * Set wait value
+         *
+         * @param wait wait value
+         * @return Builder this object
+         */
+        public Builder wait(final Boolean wait) {
+            this.wait = wait;
+            return this;
+        }
+
+        /**
+         * Set purge value
+         *
+         * @param purge purge value
+         * @return Builder this object
+         */
+        public Builder purge(final Boolean purge) {
+            this.purge = purge;
+            return this;
+        }
+
+        /**
+         * Return DeleteMigratedInputData object based on Builder this object
+         *
+         * @return DeleteMigratedInputData this object
+         */
+        public DeleteMigratedInputData build() {
+            return new DeleteMigratedInputData(this);
+        }
+    }
+}

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnDelete.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnDelete.java
@@ -9,8 +9,10 @@
  */
 package zowe.client.sdk.zosfiles.dsn.methods;
 
+import org.json.simple.JSONObject;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.DeleteJsonZosmfRequest;
+import zowe.client.sdk.rest.PutJsonZosmfRequest;
 import zowe.client.sdk.rest.Response;
 import zowe.client.sdk.rest.ZosmfRequest;
 import zowe.client.sdk.rest.ZosmfRequestFactory;
@@ -19,6 +21,10 @@ import zowe.client.sdk.rest.type.ZosmfRequestType;
 import zowe.client.sdk.utility.EncodeUtils;
 import zowe.client.sdk.utility.ValidateUtils;
 import zowe.client.sdk.zosfiles.ZosFilesConstants;
+import zowe.client.sdk.zosfiles.dsn.input.DeleteMigratedInputData;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Provides delete dataset and member functionality
@@ -31,6 +37,7 @@ public class DsnDelete {
 
     private final ZosConnection connection;
     private ZosmfRequest request;
+    private ZosmfRequest putRequest;
 
     /**
      * DsnDelete Constructor
@@ -61,6 +68,32 @@ public class DsnDelete {
             throw new IllegalStateException("DELETE_JSON request type required");
         }
         this.request = request;
+    }
+
+    /**
+     * Alternative DsnDelete constructor with ZoweRequest objects. This is mainly used for internal code unit testing
+     * with Mockito, and it is not recommended to be used by the larger community.
+     * <p>
+     * This constructor is package-private
+     *
+     * @param connection for connection information, see ZosConnection object
+     * @param request    any compatible ZoweRequest Interface object for delete
+     * @param putRequest any compatible ZoweRequest Interface object for put
+     * @author Frank Giordano
+     */
+    DsnDelete(final ZosConnection connection, final ZosmfRequest request, final ZosmfRequest putRequest) {
+        ValidateUtils.checkNullParameter(connection, "connection");
+        ValidateUtils.checkNullParameter(request, "request");
+        ValidateUtils.checkNullParameter(putRequest, "putRequest");
+        this.connection = connection;
+        if (!(request instanceof DeleteJsonZosmfRequest)) {
+            throw new IllegalStateException("DELETE_JSON request type required");
+        }
+        if (!(putRequest instanceof PutJsonZosmfRequest)) {
+            throw new IllegalStateException("PUT_JSON request type required");
+        }
+        this.request = request;
+        this.putRequest = putRequest;
     }
 
     /**
@@ -101,6 +134,50 @@ public class DsnDelete {
         request.setUrl(url);
 
         return request.executeRequest();
+    }
+
+    /**
+     * Delete a migrated dataset
+     *
+     * @param dataSetName name of a dataset (e.g. 'DATASET.LIB')
+     * @return http response object
+     * @throws ZosmfRequestException request error state
+     */
+    public Response deleteMigrated(final String dataSetName) throws ZosmfRequestException {
+        return deleteMigrated(dataSetName, null);
+    }
+
+    /**
+     * Delete a migrated dataset with optional parameters
+     *
+     * @param dataSetName             name of a dataset (e.g. 'DATASET.LIB')
+     * @param deleteMigratedInputData delete migrated input parameters, see DeleteMigratedInputData object
+     * @return http response object
+     * @throws ZosmfRequestException request error state
+     */
+    public Response deleteMigrated(final String dataSetName, final DeleteMigratedInputData deleteMigratedInputData)
+            throws ZosmfRequestException {
+        ValidateUtils.checkIllegalParameter(dataSetName, "dataSetName");
+
+        final String url = connection.getZosmfUrl() +
+                ZosFilesConstants.RESOURCE +
+                ZosFilesConstants.RES_DS_FILES + "/" +
+                EncodeUtils.encodeURIComponent(dataSetName);
+
+        final Map<String, Object> deleteMap = new HashMap<>();
+        deleteMap.put("request", "hdelete");
+        if (deleteMigratedInputData != null) {
+            deleteMigratedInputData.getWait().ifPresent(v -> deleteMap.put("wait", v));
+            deleteMigratedInputData.getPurge().ifPresent(v -> deleteMap.put("purge", v));
+        }
+
+        if (putRequest == null) {
+            putRequest = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
+        }
+        putRequest.setUrl(url);
+        putRequest.setBody(new JSONObject(deleteMap).toString());
+
+        return putRequest.executeRequest();
     }
 
 }

--- a/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnDeleteTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnDeleteTest.java
@@ -16,12 +16,16 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.core.ZosConnectionFactory;
+import org.mockito.ArgumentCaptor;
 import zowe.client.sdk.rest.DeleteJsonZosmfRequest;
+import zowe.client.sdk.rest.PutJsonZosmfRequest;
 import zowe.client.sdk.rest.Response;
 import zowe.client.sdk.rest.ZosmfRequest;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
+import zowe.client.sdk.zosfiles.dsn.input.DeleteMigratedInputData;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -41,6 +45,8 @@ public class DsnDeleteTest {
             .createTokenConnection("1", 443, new Cookie("hello=hello"));
     private DeleteJsonZosmfRequest mockDeleteRequest;
     private DeleteJsonZosmfRequest mockDeleteRequestToken;
+    private PutJsonZosmfRequest mockPutRequest;
+    private PutJsonZosmfRequest mockPutRequestToken;
 
     @BeforeEach
     public void init() throws ZosmfRequestException {
@@ -59,6 +65,22 @@ public class DsnDeleteTest {
         doCallRealMethod().when(mockDeleteRequestToken).setUrl(any());
         doCallRealMethod().when(mockDeleteRequestToken).getHeaders();
         doCallRealMethod().when(mockDeleteRequestToken).getUrl();
+
+        mockPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
+        Mockito.when(mockPutRequest.executeRequest()).thenReturn(
+                new Response(new JSONObject(), 200, "success"));
+        doCallRealMethod().when(mockPutRequest).setUrl(any());
+        doCallRealMethod().when(mockPutRequest).getUrl();
+
+        mockPutRequestToken = Mockito.mock(PutJsonZosmfRequest.class,
+                withSettings().useConstructor(tokenConnection));
+        Mockito.when(mockPutRequestToken.executeRequest()).thenReturn(
+                new Response(new JSONObject(), 200, "success"));
+        doCallRealMethod().when(mockPutRequestToken).setHeaders(anyMap());
+        doCallRealMethod().when(mockPutRequestToken).setStandardHeaders();
+        doCallRealMethod().when(mockPutRequestToken).setUrl(any());
+        doCallRealMethod().when(mockPutRequestToken).getHeaders();
+        doCallRealMethod().when(mockPutRequestToken).getUrl();
     }
 
     @Test
@@ -152,4 +174,52 @@ public class DsnDeleteTest {
         );
         assertEquals("connection is null", exception.getMessage());
     }
+
+    @Test
+    public void tstDsnDeleteMigratedDatasetSuccess() throws ZosmfRequestException {
+        final DsnDelete dsnDelete = new DsnDelete(connection, mockDeleteRequest, mockPutRequest);
+        final Response response = dsnDelete.deleteMigrated("TEST.MIGRATED.DATASET");
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
+        assertEquals("https://1:443/zosmf/restfiles/ds/TEST.MIGRATED.DATASET", mockPutRequest.getUrl());
+
+        final ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockPutRequest).setBody(bodyCaptor.capture());
+        assertTrue(bodyCaptor.getValue().contains("\"request\":\"hdelete\""));
+    }
+
+    @Test
+    public void tstDsnDeleteMigratedDatasetWithOptionsSuccess() throws ZosmfRequestException {
+        final DsnDelete dsnDelete = new DsnDelete(connection, mockDeleteRequest, mockPutRequest);
+        final DeleteMigratedInputData inputData = new DeleteMigratedInputData.Builder()
+                .wait(true)
+                .purge(true)
+                .build();
+        final Response response = dsnDelete.deleteMigrated("TEST.MIGRATED.DATASET", inputData);
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
+        assertEquals("https://1:443/zosmf/restfiles/ds/TEST.MIGRATED.DATASET", mockPutRequest.getUrl());
+
+        final ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockPutRequest).setBody(bodyCaptor.capture());
+        final String body = bodyCaptor.getValue();
+        assertTrue(body.contains("\"request\":\"hdelete\""));
+        assertTrue(body.contains("\"wait\":true"));
+        assertTrue(body.contains("\"purge\":true"));
+    }
+
+    @Test
+    public void tstDsnDeleteSecondaryConstructorWithInvalidPutRequestType() {
+        ZosConnection connection = Mockito.mock(ZosConnection.class);
+        ZosmfRequest request = Mockito.mock(DeleteJsonZosmfRequest.class);
+        ZosmfRequest invalidPutRequest = Mockito.mock(ZosmfRequest.class); // Not a PutJsonZosmfRequest
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> new DsnDelete(connection, request, invalidPutRequest)
+        );
+        assertEquals("PUT_JSON request type required", exception.getMessage());
+    }
+
 }


### PR DESCRIPTION
# Description
Implement support for deleting migrated datasets (hdelete operation) on MVS. This allows users to delete migrated datasets .

Ref: #567

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Proposed Changes
*   **Added `DeleteMigratedInputData`**: Input parameter container with Builder pattern to hold options like `wait` and `purge`.
*   **Updated `DsnDelete`**:
    *   Added new package-private constructor to accept a mocked `PutJsonZosmfRequest`.
    *   Implemented `deleteMigrated(String)` and `deleteMigrated(String, DeleteMigratedInputData)` methods to invoke `PUT` requests with the `hdelete` payload.
*   **Updated `DsnDeleteTest`**: Added test cases covering simple deletion, parameterized deletion, and input verification.
*   **Updated `README.md`**: Added example code snippet to help users get started with the new method.

## Verification & Testing
*   Successfully ran Maven test-compile and test suite locally:
    ```bash
    .\mvnw.cmd clean test
    ```
*   **Test Results**: 773 tests run, 0 failures, 0 errors.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added unit tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
