### PR TITLE
Add z/OSMF cancel workflow API method

### DIFF
--- a/src/main/java/zowe/client/sdk/zosmfworkflow/WorkflowConstants.java
+++ b/src/main/java/zowe/client/sdk/zosmfworkflow/WorkflowConstants.java
@@ -72,6 +72,11 @@ public final class WorkflowConstants {
     public static final String OPERATIONS_START = URL_PATH_DELIM + "operations" + URL_PATH_DELIM + "start";
 
     /**
+     * Operations cancel path segment for workflow cancel operation.
+     */
+    public static final String OPERATIONS_CANCEL = URL_PATH_DELIM + "operations" + URL_PATH_DELIM + "cancel";
+
+    /**
      * Default USS directory used to hold local workflow files temporarily uploaded for a local create.
      */
     public static final String TEMP_PATH = "/tmp";

--- a/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCancel.java
+++ b/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCancel.java
@@ -1,0 +1,100 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosmfworkflow.methods;
+
+import zowe.client.sdk.core.ZosConnection;
+import zowe.client.sdk.rest.*;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
+import zowe.client.sdk.rest.type.ZosmfRequestType;
+import zowe.client.sdk.utility.EncodeUtils;
+import zowe.client.sdk.utility.JsonUtils;
+import zowe.client.sdk.utility.ValidateUtils;
+import zowe.client.sdk.zosmfworkflow.WorkflowConstants;
+import zowe.client.sdk.zosmfworkflow.response.WorkflowCancelResponse;
+
+/**
+ * Provides cancel workflow functionality through the z/OSMF workflow REST API.
+ * <p>
+ * <a href="https://www.ibm.com/docs/en/zos/3.2.0?topic=services-cancel-workflow">z/OSMF REST API</a>
+ *
+ * @author Jorge Samaniego
+ * @author Ashish Kumar Dash
+ * @version 7.0
+ */
+public class WorkflowCancel {
+
+    private static final String CANCEL_CONTEXT = "cancel";
+    private final ZosConnection connection;
+    private final ZosmfRequest request;
+
+    /**
+     * WorkflowCancel constructor.
+     *
+     * @param connection for connection information, see ZosConnection object
+     * @author Jorge Samaniego
+     */
+    public WorkflowCancel(final ZosConnection connection) {
+        ValidateUtils.checkNullParameter(connection, "connection");
+        this.connection = connection;
+        this.request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
+    }
+
+    /**
+     * Alternative WorkflowCancel constructor with ZosmfRequest object.
+     * This is mainly used for internal code unit testing with Mockito,
+     * and it is not recommended to be used by the larger community.
+     * <p>
+     * This constructor is package-private.
+     *
+     * @param connection for connection information, see ZosConnection object
+     * @param request    compatible ZosmfRequest interface object
+     * @author Jorge Samaniego
+     */
+    WorkflowCancel(final ZosConnection connection, final ZosmfRequest request) {
+        ValidateUtils.checkNullParameter(connection, "connection");
+        ValidateUtils.checkNullParameter(request, "request");
+        this.connection = connection;
+        if (!(request instanceof PutJsonZosmfRequest)) {
+            throw new IllegalStateException("PUT_JSON request type required");
+        }
+        this.request = request;
+    }
+
+    /**
+     * Cancel a z/OSMF workflow on a z/OS system.
+     * <p>
+     * Canceling a workflow does not undo any actions already performed.
+     * A canceled workflow cannot be resumed.
+     *
+     * @param workflowKey workflow key identifying the workflow to cancel
+     * @return WorkflowCancelResponse object containing the canceled workflow name
+     * @throws ZosmfRequestException request error state
+     * @author Jorge Samaniego
+     */
+    public WorkflowCancelResponse cancel(final String workflowKey) throws ZosmfRequestException {
+        ValidateUtils.checkIllegalParameter(workflowKey, "workflowKey");
+
+        final String url = connection.getZosmfUrl() +
+                WorkflowConstants.WORKFLOWS_RESOURCE +
+                UrlConstants.URL_PATH_DELIM +
+                EncodeUtils.encodeURIComponent(workflowKey) +
+                WorkflowConstants.OPERATIONS_CANCEL;
+
+        request.setUrl(url);
+
+        final String responsePhrase = request.executeRequest()
+                .getResponsePhrase()
+                .orElseThrow(() -> new IllegalStateException("no workflow cancel response phrase"))
+                .toString();
+
+        return JsonUtils.parseResponse(responsePhrase, WorkflowCancelResponse.class, CANCEL_CONTEXT);
+    }
+
+}

--- a/src/main/java/zowe/client/sdk/zosmfworkflow/response/WorkflowCancelResponse.java
+++ b/src/main/java/zowe/client/sdk/zosmfworkflow/response/WorkflowCancelResponse.java
@@ -1,0 +1,66 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosmfworkflow.response;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * API response for cancel workflow.
+ * <p>
+ * <a href="https://www.ibm.com/docs/en/zos/3.2.0?topic=services-cancel-workflow">z/OSMF REST API</a>
+ *
+ * @author Jorge Samaniego
+ * @author Ashish Kumar Dash
+ * @version 7.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class WorkflowCancelResponse {
+
+    /**
+     * Descriptive name of the canceled workflow. The name is appended with the
+     * canceled state and a timestamp, for example:
+     * "AutomationExample|Canceled|1423679433714".
+     */
+    private final String workflowName;
+
+    /**
+     * WorkflowCancelResponse Jackson constructor.
+     *
+     * @param workflowName canceled workflow name
+     */
+    @JsonCreator
+    public WorkflowCancelResponse(@JsonProperty("workflowName") final String workflowName) {
+        this.workflowName = workflowName == null ? "" : workflowName;
+    }
+
+    /**
+     * Retrieve workflowName value.
+     *
+     * @return workflowName value
+     */
+    public String getWorkflowName() {
+        return workflowName;
+    }
+
+    /**
+     * Return a string value representing a WorkflowCancelResponse object.
+     *
+     * @return string representation of WorkflowCancelResponse
+     */
+    @Override
+    public String toString() {
+        return "WorkflowCancelResponse{" +
+                "workflowName='" + workflowName + '\'' +
+                '}';
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCancelTest.java
+++ b/src/test/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCancelTest.java
@@ -1,0 +1,191 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosmfworkflow.methods;
+
+import kong.unirest.core.Cookie;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import zowe.client.sdk.core.ZosConnection;
+import zowe.client.sdk.core.ZosConnectionFactory;
+import zowe.client.sdk.rest.PutJsonZosmfRequest;
+import zowe.client.sdk.rest.Response;
+import zowe.client.sdk.rest.ZosmfRequest;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
+import zowe.client.sdk.zosmfworkflow.response.WorkflowCancelResponse;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.withSettings;
+
+/**
+ * Class containing unit tests for WorkflowCancel.
+ *
+ * @author Jorge Samaniego
+ * @author Ashish Kumar Dash
+ * @version 7.0
+ */
+public class WorkflowCancelTest {
+
+    private static final String CANCEL_JSON =
+            "{\"workflowName\":\"AutomationExample|Canceled|1423679433714\"}";
+
+    private final ZosConnection connection = ZosConnectionFactory
+            .createBasicConnection("1", 443, "1", "1");
+    private final ZosConnection tokenConnection = ZosConnectionFactory
+            .createTokenConnection("1", 443, new Cookie("hello=hello"));
+
+    @Test
+    public void tstWorkflowCancelSecondaryConstructorWithValidRequestTypeSuccess() {
+        ZosmfRequest request = Mockito.mock(PutJsonZosmfRequest.class);
+        WorkflowCancel workflowCancel = new WorkflowCancel(connection, request);
+        assertNotNull(workflowCancel);
+    }
+
+    @Test
+    public void tstWorkflowCancelSecondaryConstructorWithNullConnectionFailure() {
+        ZosmfRequest request = Mockito.mock(PutJsonZosmfRequest.class);
+        NullPointerException exception = assertThrows(
+                NullPointerException.class,
+                () -> new WorkflowCancel(null, request)
+        );
+        assertEquals("connection is null", exception.getMessage());
+    }
+
+    @Test
+    public void tstWorkflowCancelSecondaryConstructorWithNullRequestFailure() {
+        NullPointerException exception = assertThrows(
+                NullPointerException.class,
+                () -> new WorkflowCancel(connection, null)
+        );
+        assertEquals("request is null", exception.getMessage());
+    }
+
+    @Test
+    public void tstWorkflowCancelSecondaryConstructorWithInvalidRequestTypeFailure() {
+        ZosmfRequest request = Mockito.mock(ZosmfRequest.class);
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> new WorkflowCancel(connection, request)
+        );
+        assertEquals("PUT_JSON request type required", exception.getMessage());
+    }
+
+    @Test
+    public void tstWorkflowCancelPrimaryConstructorWithValidConnectionSuccess() {
+        WorkflowCancel workflowCancel = new WorkflowCancel(connection);
+        assertNotNull(workflowCancel);
+    }
+
+    @Test
+    public void tstWorkflowCancelPrimaryConstructorWithNullConnectionFailure() {
+        NullPointerException exception = assertThrows(
+                NullPointerException.class,
+                () -> new WorkflowCancel(null)
+        );
+        assertEquals("connection is null", exception.getMessage());
+    }
+
+    @Test
+    public void tstWorkflowCancelSuccess() throws ZosmfRequestException {
+        ZosConnection mockConnection = Mockito.mock(ZosConnection.class);
+        Mockito.when(mockConnection.getZosmfUrl()).thenReturn("https://1:443");
+        PutJsonZosmfRequest mockPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
+        Mockito.when(mockPutRequest.executeRequest())
+                .thenReturn(new Response(CANCEL_JSON, 200, "success"));
+        doCallRealMethod().when(mockPutRequest).setUrl(any());
+        doCallRealMethod().when(mockPutRequest).getUrl();
+
+        WorkflowCancel workflowCancel = new WorkflowCancel(mockConnection, mockPutRequest);
+        WorkflowCancelResponse response = workflowCancel.cancel("TESTKEY");
+
+        assertEquals("AutomationExample|Canceled|1423679433714", response.getWorkflowName());
+        Mockito.verify(mockPutRequest, Mockito.never()).setBody(any());
+    }
+
+    @Test
+    public void tstWorkflowCancelWithNullWorkflowKeyFailure() {
+        WorkflowCancel workflowCancel = new WorkflowCancel(connection);
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> workflowCancel.cancel(null)
+        );
+        assertEquals("workflowKey is either null or empty", exception.getMessage());
+    }
+
+    @Test
+    public void tstWorkflowCancelSecondaryConstructorObjectCreateSuccess() {
+        PutJsonZosmfRequest request = Mockito.mock(PutJsonZosmfRequest.class);
+        boolean noError = false;
+        try {
+            new WorkflowCancel(connection, request);
+        } catch (IllegalStateException e) {
+            noError = true;
+        }
+        assertFalse(noError);
+    }
+
+    @Test
+    public void tstWorkflowCancelUrlGenerationSuccess() throws ZosmfRequestException {
+        ZosConnection mockConnection = Mockito.mock(ZosConnection.class);
+        Mockito.when(mockConnection.getZosmfUrl()).thenReturn("https://1:443/zosmf");
+        PutJsonZosmfRequest mockPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
+        Mockito.when(mockPutRequest.executeRequest())
+                .thenReturn(new Response(CANCEL_JSON, 200, "success"));
+        doCallRealMethod().when(mockPutRequest).setUrl(any());
+        doCallRealMethod().when(mockPutRequest).getUrl();
+
+        WorkflowCancel workflowCancel = new WorkflowCancel(mockConnection, mockPutRequest);
+        workflowCancel.cancel("TESTKEY");
+
+        assertEquals(
+                "https://1:443/zosmf/workflow/rest/1.0/workflows/TESTKEY/operations/cancel",
+                mockPutRequest.getUrl()
+        );
+    }
+
+    @Test
+    public void tstWorkflowCancelKeyEmptyFailure() {
+        ZosConnection mockConnection = Mockito.mock(ZosConnection.class);
+        Mockito.when(mockConnection.getZosmfUrl()).thenReturn("https://1:443/zosmf");
+        PutJsonZosmfRequest mockPutRequest = Mockito.mock(PutJsonZosmfRequest.class);
+
+        WorkflowCancel workflowCancel = new WorkflowCancel(mockConnection, mockPutRequest);
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> workflowCancel.cancel("")
+        );
+        assertEquals("workflowKey is either null or empty", exception.getMessage());
+    }
+
+    @Test
+    public void tstWorkflowCancelTokenSuccess() throws ZosmfRequestException {
+        PutJsonZosmfRequest mockPutRequestToken = Mockito.mock(PutJsonZosmfRequest.class,
+                withSettings().useConstructor(tokenConnection));
+        Mockito.when(mockPutRequestToken.executeRequest()).thenReturn(
+                new Response(CANCEL_JSON, 200, "success"));
+        doCallRealMethod().when(mockPutRequestToken).setHeaders(anyMap());
+        doCallRealMethod().when(mockPutRequestToken).setStandardHeaders();
+        doCallRealMethod().when(mockPutRequestToken).setUrl(any());
+        doCallRealMethod().when(mockPutRequestToken).getHeaders();
+        doCallRealMethod().when(mockPutRequestToken).getUrl();
+
+        WorkflowCancel workflowCancel = new WorkflowCancel(tokenConnection, mockPutRequestToken);
+        WorkflowCancelResponse response = workflowCancel.cancel("test-key");
+
+        assertEquals("{X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}",
+                mockPutRequestToken.getHeaders().toString());
+        assertEquals("AutomationExample|Canceled|1423679433714", response.getWorkflowName());
+        assertEquals("https://1:443/zosmf/workflow/rest/1.0/workflows/test-key/operations/cancel",
+                mockPutRequestToken.getUrl());
+    }
+
+}


### PR DESCRIPTION
## What

Adds a workflow API method to cancel a z/OSMF workflow on a z/OS system,
supporting the [Cancel Workflow REST API](https://www.ibm.com/docs/en/zos/3.2.0?topic=services-cancel-workflow).

`PUT /zosmf/workflow/rest/1.0/workflows/<workflowKey>/operations/cancel`

## Changes

- `WorkflowCancel.cancel(workflowKey)` — issues the cancel request and returns the canceled workflow name
- `WorkflowCancelResponse` — Jackson-mapped response model (`workflowName`)
- `WorkflowConstants.OPERATIONS_CANCEL` — new path segment
- `WorkflowCancelTest` — 12 unit tests (basic + token auth, URL generation, validation, constructor guards)

Resolves #472, takes #532 to the finish line, credit to @jsamaniego4 for the majority implementation.