### PR TITLE
feat: Add Recall Migrated Datasets API to zosfiles.dsn.methods (#566)

### DIFF
--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/README.md
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/README.md
@@ -493,6 +493,7 @@ import zowe.client.sdk.zosfiles.dsn.methods.DsnUpdate;
  *
  * @author Frank Giordano
  * @author Charishma1707
+ * @author Shaurya2k06
  * @version 7.0
  */
 public class DsnUpdateExp extends TstZosConnection {
@@ -515,6 +516,8 @@ public class DsnUpdateExp extends TstZosConnection {
         renameMember(datasetName, memberName, newMemberName);
         deleteMigratedDataSet(datasetName);
         deleteMigratedDataSetWithOptions(datasetName);
+        recallMigratedDataSet(datasetName);
+        recallMigratedDataSetWithWait(datasetName);
     }
 
     /**
@@ -592,6 +595,46 @@ public class DsnUpdateExp extends TstZosConnection {
         try {
             DsnUpdate dsnUpdate = new DsnUpdate(connection);
             response = dsnUpdate.deleteMigrated(dataSetName, true, true);
+        } catch (ZosmfRequestException e) {
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().hasTextResponsePhrase()) {
+                errMsg = e.getResponse().getResponsePhraseAsString().orElse(errMsg);
+            }
+            throw new RuntimeException(errMsg, e);
+        }
+        System.out.println(response.toString());
+    }
+
+    /**
+     * Recall a migrated dataset
+     *
+     * @param dataSetName name of a migrated dataset to recall
+     */
+    public static void recallMigratedDataSet(String dataSetName) {
+        Response response;
+        try {
+            DsnUpdate dsnUpdate = new DsnUpdate(connection);
+            response = dsnUpdate.recallMigrated(dataSetName);
+        } catch (ZosmfRequestException e) {
+            String errMsg = e.getMessage();
+            if (e.getResponse() != null && e.getResponse().hasTextResponsePhrase()) {
+                errMsg = e.getResponse().getResponsePhraseAsString().orElse(errMsg);
+            }
+            throw new RuntimeException(errMsg, e);
+        }
+        System.out.println(response.toString());
+    }
+
+    /**
+     * Recall a migrated dataset with wait option
+     *
+     * @param dataSetName name of a migrated dataset to recall
+     */
+    public static void recallMigratedDataSetWithWait(String dataSetName) {
+        Response response;
+        try {
+            DsnUpdate dsnUpdate = new DsnUpdate(connection);
+            response = dsnUpdate.recallMigrated(dataSetName, true);
         } catch (ZosmfRequestException e) {
             String errMsg = e.getMessage();
             if (e.getResponse() != null && e.getResponse().hasTextResponsePhrase()) {

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnUpdate.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnUpdate.java
@@ -169,4 +169,59 @@ public class DsnUpdate {
         return request.executeRequest();
     }
 
+    /**
+     * Recall a migrated dataset
+     *
+     * @param datasetName name of a dataset (e.g. 'DATASET.LIB')
+     * @return http response object
+     * @throws ZosmfRequestException request error state
+     * @author Shaurya2k06
+     */
+    public Response recallMigrated(final String datasetName) throws ZosmfRequestException {
+        return recallMigratedCommon(datasetName, null);
+    }
+
+    /**
+     * Recall a migrated dataset with wait option
+     *
+     * @param datasetName name of a dataset (e.g. 'DATASET.LIB')
+     * @param wait        if true, the function waits for completion of the request
+     * @return http response object
+     * @throws ZosmfRequestException request error state
+     * @author Shaurya2k06
+     */
+    public Response recallMigrated(final String datasetName, final boolean wait) throws ZosmfRequestException {
+        return recallMigratedCommon(datasetName, wait);
+    }
+
+    /**
+     * Common helper method to recall a migrated dataset
+     *
+     * @param datasetName name of a dataset
+     * @param wait        optional wait parameter
+     * @return http response object
+     * @throws ZosmfRequestException request error state
+     */
+    private Response recallMigratedCommon(final String datasetName, final Boolean wait)
+            throws ZosmfRequestException {
+        ValidateUtils.checkIllegalParameter(datasetName, "datasetName");
+
+        final String url = connection.getZosmfUrl() +
+                ZosFilesConstants.RESOURCE +
+                ZosFilesConstants.RES_DS_FILES +
+                UrlConstants.URL_PATH_DELIM +
+                EncodeUtils.encodeURIComponent(datasetName);
+
+        final Map<String, Object> recallMap = new HashMap<>();
+        recallMap.put("request", "hrecall");
+        if (wait != null) {
+            recallMap.put("wait", wait);
+        }
+
+        request.setUrl(url);
+        request.setBody(JsonUtils.asRequestBodyJson(recallMap));
+
+        return request.executeRequest();
+    }
+
 }

--- a/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnUpdateTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnUpdateTest.java
@@ -193,4 +193,36 @@ public class DsnUpdateTest {
         assertTrue(requestBody.get("purge").asBoolean());
     }
 
+    @Test
+    public void tstDsnUpdateRecallMigratedDatasetSuccess() throws ZosmfRequestException, JsonProcessingException {
+        final DsnUpdate dsnUpdate = new DsnUpdate(connection, mockJsonPutRequest);
+        final Response response = dsnUpdate.recallMigrated("TEST.MIGRATED.DATASET");
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
+        assertEquals("https://1:443/zosmf/restfiles/ds/TEST.MIGRATED.DATASET", mockJsonPutRequest.getUrl());
+
+        final ArgumentCaptor<Object> bodyCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(mockJsonPutRequest).setBody(bodyCaptor.capture());
+        final JsonNode requestBody = mapper.readTree(bodyCaptor.getValue().toString());
+        assertEquals("hrecall", requestBody.get("request").asText());
+        assertNull(requestBody.get("wait"));
+    }
+
+    @Test
+    public void tstDsnUpdateRecallMigratedDatasetWithWaitSuccess() throws ZosmfRequestException, JsonProcessingException {
+        final DsnUpdate dsnUpdate = new DsnUpdate(connection, mockJsonPutRequest);
+        final Response response = dsnUpdate.recallMigrated("TEST.MIGRATED.DATASET", true);
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
+        assertEquals("https://1:443/zosmf/restfiles/ds/TEST.MIGRATED.DATASET", mockJsonPutRequest.getUrl());
+
+        final ArgumentCaptor<Object> bodyCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(mockJsonPutRequest).setBody(bodyCaptor.capture());
+        final JsonNode requestBody = mapper.readTree(bodyCaptor.getValue().toString());
+        assertEquals("hrecall", requestBody.get("request").asText());
+        assertTrue(requestBody.get("wait").asBoolean());
+    }
+
 }


### PR DESCRIPTION
## Overview

This PR adds recall migrated dataset (`hrecall`) support to the centralized `DsnUpdate` class.

## Changes Made

- **`DsnUpdate.java`**
  - Added overloaded `recallMigrated` public APIs.
  - Added private `recallMigratedCommon(...)` helper.

- **`README.md`**
  - Extended the **Update dataset and member** section with `recallMigrated()` examples.

- **Tests**
  - Updated `DsnUpdateTest.java` to validate the new overloaded API.

## Verification

- Ran:

```bash
mvn clean test
``` 


## Closes
Closes #566