### PR TITLE
 Add Migrate Datasets API to zosfiles.dsn.methods 

### DIFF
--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnUpdate.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnUpdate.java
@@ -109,6 +109,61 @@ public class DsnUpdate {
     }
 
     /**
+     * Migrate a dataset
+     *
+     * @param datasetName name of a dataset (e.g. 'DATASET.LIB')
+     * @return http response object
+     * @throws ZosmfRequestException request error state
+     * @author Ashish-Kumar-Dash
+     */
+    public Response migrate(final String datasetName) throws ZosmfRequestException {
+        return migrateCommon(datasetName, null);
+    }
+
+    /**
+     * Migrate a dataset with wait option
+     *
+     * @param datasetName name of a dataset (e.g. 'DATASET.LIB')
+     * @param wait        if true, the function waits for completion of the request
+     * @return http response object
+     * @throws ZosmfRequestException request error state
+     * @author Ashish-Kumar-Dash
+     */
+    public Response migrate(final String datasetName, final boolean wait) throws ZosmfRequestException {
+        return migrateCommon(datasetName, wait);
+    }
+
+    /**
+     * Common helper method to migrate a dataset
+     *
+     * @param datasetName name of a dataset
+     * @param wait        optional wait parameter
+     * @return http response object
+     * @throws ZosmfRequestException request error state
+     */
+    private Response migrateCommon(final String datasetName, final Boolean wait)
+            throws ZosmfRequestException {
+        ValidateUtils.checkIllegalParameter(datasetName, "datasetName");
+
+        final String url = connection.getZosmfUrl() +
+                ZosFilesConstants.RESOURCE +
+                ZosFilesConstants.RES_DS_FILES +
+                UrlConstants.URL_PATH_DELIM +
+                EncodeUtils.encodeURIComponent(datasetName);
+
+        final Map<String, Object> migrateMap = new HashMap<>();
+        migrateMap.put("request", "hmigrate");
+        if (wait != null) {
+            migrateMap.put("wait", wait);
+        }
+
+        request.setUrl(url);
+        request.setBody(JsonUtils.asRequestBodyJson(migrateMap));
+
+        return request.executeRequest();
+    }
+
+    /**
      * Delete a migrated dataset
      *
      * @param datasetName name of a dataset (e.g. 'DATASET.LIB')

--- a/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnUpdateTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnUpdateTest.java
@@ -160,6 +160,38 @@ public class DsnUpdateTest {
     }
 
     @Test
+    public void tstDsnUpdateMigrateDatasetSuccess() throws ZosmfRequestException, JsonProcessingException {
+        final DsnUpdate dsnUpdate = new DsnUpdate(connection, mockJsonPutRequest);
+        final Response response = dsnUpdate.migrate("TEST.DATASET");
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
+        assertEquals("https://1:443/zosmf/restfiles/ds/TEST.DATASET", mockJsonPutRequest.getUrl());
+
+        final ArgumentCaptor<Object> bodyCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(mockJsonPutRequest).setBody(bodyCaptor.capture());
+        final JsonNode requestBody = mapper.readTree(bodyCaptor.getValue().toString());
+        assertEquals("hmigrate", requestBody.get("request").asText());
+        assertNull(requestBody.get("wait"));
+    }
+
+    @Test
+    public void tstDsnUpdateMigrateDatasetWithWaitSuccess() throws ZosmfRequestException, JsonProcessingException {
+        final DsnUpdate dsnUpdate = new DsnUpdate(connection, mockJsonPutRequest);
+        final Response response = dsnUpdate.migrate("TEST.DATASET", true);
+        assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+        assertEquals("success", response.getStatusText().orElse("n\\a"));
+        assertEquals("https://1:443/zosmf/restfiles/ds/TEST.DATASET", mockJsonPutRequest.getUrl());
+
+        final ArgumentCaptor<Object> bodyCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(mockJsonPutRequest).setBody(bodyCaptor.capture());
+        final JsonNode requestBody = mapper.readTree(bodyCaptor.getValue().toString());
+        assertEquals("hmigrate", requestBody.get("request").asText());
+        assertTrue(requestBody.get("wait").asBoolean());
+    }
+
+    @Test
     public void tstDsnUpdateDeleteMigratedDatasetSuccess() throws ZosmfRequestException, JsonProcessingException {
         final DsnUpdate dsnUpdate = new DsnUpdate(connection, mockJsonPutRequest);
         final Response response = dsnUpdate.deleteMigrated("TEST.MIGRATED.DATASET");


### PR DESCRIPTION
Closes #565 

Adds a `migrate` API to `DsnUpdate`, issuing the z/OSMF `hmigrate` request (PUT /zosmf/restfiles/ds/<dataset-name>).

- `migrate(String datasetName)` — migrate a dataset
- `migrate(String datasetName, boolean wait)` — migrate with the optional wait flag

Follows the existing `recallMigrated` / `deleteMigrated` conventions in the class.

