### PR TITLE
Set Empty Body for Workflow Cancel Request 

### DIFF
--- a/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCancel.java
+++ b/src/main/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCancel.java
@@ -93,6 +93,7 @@ public class WorkflowCancel {
             request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
         }
         request.setUrl(url);
+        request.setBody("{}");
 
         final String responsePhrase = request.executeRequest()
                 .getResponsePhrase()

--- a/src/test/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCancelTest.java
+++ b/src/test/java/zowe/client/sdk/zosmfworkflow/methods/WorkflowCancelTest.java
@@ -108,8 +108,6 @@ public class WorkflowCancelTest {
         WorkflowCancelResponse response = workflowCancel.cancel("TESTKEY");
 
         assertEquals("AutomationExample|Canceled|1423679433714", response.getWorkflowName());
-        Mockito.verify(mockPutRequest, Mockito.never()).setBody(any());
-
         assertEquals(
                 "https://1:443/workflow/rest/1.0/workflows/TESTKEY/operations/cancel",
                 mockPutRequest.getUrl()


### PR DESCRIPTION
PUT HTTP verb requires a body to be set for the workflow cancel. As such, provide it an empty body JSON string. 