### PR TITLE
Add uncataloged dataset delete support (#582)

### DIFF
--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/README.md
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/README.md
@@ -398,6 +398,7 @@ import zowe.client.sdk.core.ZosConnectionFactory;
 import zowe.client.sdk.examples.TstZosConnection;
 import zowe.client.sdk.rest.Response;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
+import zowe.client.sdk.zosfiles.dsn.input.DsnDeleteInputData;
 import zowe.client.sdk.zosfiles.dsn.methods.DsnDelete;
 
 /**
@@ -436,7 +437,7 @@ public class DsnDeleteExp extends TstZosConnection {
         Response response;
         try {
             DsnDelete zosDsn = new DsnDelete(connection);
-            response = zosDsn.delete(dataSetName);
+            response = zosDsn.delete(DsnDeleteInputData.forDataset(dataSetName));
         } catch (ZosmfRequestException e) {
             String errMsg = e.getMessage();
             if (e.getResponse() != null && e.getResponse().hasTextResponsePhrase()) {
@@ -459,7 +460,7 @@ public class DsnDeleteExp extends TstZosConnection {
         Response response;
         try {
             DsnDelete zosDsn = new DsnDelete(connection);
-            response = zosDsn.delete(dataSetName, member);
+            response = zosDsn.delete(DsnDeleteInputData.forMember(dataSetName, member));
         } catch (ZosmfRequestException e) {
             String errMsg = e.getMessage();
             if (e.getResponse() != null && e.getResponse().hasTextResponsePhrase()) {

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/input/DsnDeleteInputData.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/input/DsnDeleteInputData.java
@@ -1,0 +1,138 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosfiles.dsn.input;
+
+import zowe.client.sdk.utility.ValidateUtils;
+import zowe.client.sdk.zosfiles.dsn.types.DeleteType;
+
+/**
+ * Immutable input for dataset delete operations.
+ * <p>
+ * Supports deleting a cataloged dataset, a member within a partitioned dataset (PDS),
+ * or an uncataloged dataset residing on a specific volume.
+ *
+ * @author Jorge Samaniego
+ * @version 7.0
+ */
+public final class DsnDeleteInputData {
+
+    private final DeleteType type;
+    private final String datasetName;
+    private final String memberName;
+    private final String volume;
+
+    /**
+     * Private constructor.
+     */
+    private DsnDeleteInputData(
+            final DeleteType type,
+            final String datasetName,
+            final String memberName,
+            final String volume) {
+
+        this.type = type;
+        this.datasetName = datasetName;
+        this.memberName = memberName;
+        this.volume = volume;
+    }
+
+    /**
+     * Creates input for a dataset delete operation.
+     *
+     * @param datasetName name of a dataset (e.g. 'DATASET.LIB')
+     * @return DsnDeleteInputData
+     */
+    public static DsnDeleteInputData forDataset(final String datasetName) {
+        ValidateUtils.checkIllegalParameter(datasetName, "datasetName");
+
+        return new DsnDeleteInputData(
+                DeleteType.DATASET,
+                datasetName,
+                null,
+                null);
+    }
+
+    /**
+     * Creates input for a member delete operation.
+     *
+     * @param datasetName partitioned dataset containing the member
+     * @param memberName  name of member to delete
+     * @return DsnDeleteInputData
+     */
+    public static DsnDeleteInputData forMember(final String datasetName, final String memberName) {
+        ValidateUtils.checkIllegalParameter(datasetName, "datasetName");
+        ValidateUtils.checkIllegalParameter(memberName, "memberName");
+
+        return new DsnDeleteInputData(
+                DeleteType.MEMBER,
+                datasetName,
+                memberName,
+                null);
+    }
+
+    /**
+     * Creates input for an uncataloged dataset delete operation.
+     *
+     * @param datasetName name of a dataset (e.g. 'DATASET.LIB')
+     * @param volume      volume serial the dataset resides on (e.g. 'VOL001')
+     * @return DsnDeleteInputData
+     */
+    public static DsnDeleteInputData forUncataloged(final String datasetName, final String volume) {
+        ValidateUtils.checkIllegalParameter(datasetName, "datasetName");
+        ValidateUtils.checkIllegalParameter(volume, "volume");
+
+        return new DsnDeleteInputData(
+                DeleteType.UNCATALOGED,
+                datasetName,
+                null,
+                volume);
+    }
+
+    /**
+     * Returns the delete operation type.
+     *
+     * @return delete type
+     */
+    public DeleteType getType() {
+        return type;
+    }
+
+    /**
+     * Returns the dataset name.
+     *
+     * @return dataset name
+     */
+    public String getDatasetName() {
+        return datasetName;
+    }
+
+    /**
+     * Returns the member name.
+     * <p>
+     * This value is only applicable for member delete operations.
+     *
+     * @return member name or {@code null}
+     */
+    public String getMemberName() {
+        return memberName;
+    }
+
+    /**
+     * Returns the volume serial.
+     * <p>
+     * This value is only applicable for uncataloged dataset delete operations.
+     *
+     * @return volume serial or {@code null}
+     */
+    public String getVolume() {
+        return volume;
+    }
+
+}

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnDelete.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnDelete.java
@@ -26,7 +26,6 @@ import zowe.client.sdk.zosfiles.dsn.types.DeleteType;
  *
  * @author Leonid Baranov
  * @author Frank Giordano
- * @author Jorge Samaniego
  * @version 7.0
  */
 public class DsnDelete {
@@ -89,9 +88,7 @@ public class DsnDelete {
             url.append(datasetName).append("(").append(memberName).append(")");
         } else if (deleteInputData.getType() == DeleteType.UNCATALOGED) {
             final String volume = EncodeUtils.encodeURIComponent(deleteInputData.getVolume());
-            url.append("-(").append(volume).append(")")
-                    .append(UrlConstants.URL_PATH_DELIM)
-                    .append(datasetName);
+            url.append("-(").append(volume).append(")").append(UrlConstants.URL_PATH_DELIM).append(datasetName);
         }
 
         request.setUrl(url.toString());

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnDelete.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnDelete.java
@@ -16,18 +16,23 @@ import zowe.client.sdk.rest.type.ZosmfRequestType;
 import zowe.client.sdk.utility.EncodeUtils;
 import zowe.client.sdk.utility.ValidateUtils;
 import zowe.client.sdk.zosfiles.ZosFilesConstants;
+import zowe.client.sdk.zosfiles.dsn.input.DsnDeleteInputData;
+import zowe.client.sdk.zosfiles.dsn.types.DeleteType;
 
 /**
- * Provides delete dataset and member functionality
+ * Provides delete dataset, member and uncataloged dataset functionality
  * <p>
  * <a href="https://www.ibm.com/docs/en/zos/3.2.0?topic=interface-delete-sequential-partitioned-data-set">z/OSMF REST API</a>
  *
  * @author Leonid Baranov
  * @author Frank Giordano
+ * @author Jorge Samaniego
  * @version 7.0
  */
 public class DsnDelete {
 
+    private static final String BASE_RESOURCE =
+            ZosFilesConstants.RESOURCE + ZosFilesConstants.RES_DS_FILES + UrlConstants.URL_PATH_DELIM;
     private final ZosConnection connection;
     private final ZosmfRequest request;
 
@@ -64,39 +69,32 @@ public class DsnDelete {
     }
 
     /**
-     * Delete a dataset member
+     * Delete a dataset, a member of a dataset, or an uncataloged dataset on a specific volume
      *
-     * @param dataSetName name of a dataset (e.g. 'DATASET.LIB')
-     * @param memberName  name of member to delete
+     * @param deleteInputData delete parameters, see DsnDeleteInputData object
      * @return http response object
      * @throws ZosmfRequestException request error state
-     * @author Frank Giordano
+     * @author Jorge Samaniego
      */
-    public Response delete(final String dataSetName, final String memberName) throws ZosmfRequestException {
-        ValidateUtils.checkIllegalParameter(dataSetName, "dataSetName");
-        ValidateUtils.checkIllegalParameter(memberName, "memberName");
+    public Response delete(final DsnDeleteInputData deleteInputData) throws ZosmfRequestException {
+        ValidateUtils.checkNullParameter(deleteInputData, "deleteInputData");
 
-        return delete(String.format("%s(%s)", dataSetName, memberName));
-    }
+        final StringBuilder url = new StringBuilder(connection.getZosmfUrl() + BASE_RESOURCE);
+        final String datasetName = EncodeUtils.encodeURIComponent(deleteInputData.getDatasetName());
 
-    /**
-     * Delete a dataset
-     *
-     * @param dataSetName name of a dataset (e.g. 'DATASET.LIB')
-     * @return http response object
-     * @throws ZosmfRequestException request error state
-     * @author Leonid Baranov
-     */
-    public Response delete(final String dataSetName) throws ZosmfRequestException {
-        ValidateUtils.checkIllegalParameter(dataSetName, "dataSetName");
+        if (deleteInputData.getType() == DeleteType.DATASET) {
+            url.append(datasetName);
+        } else if (deleteInputData.getType() == DeleteType.MEMBER) {
+            final String memberName = EncodeUtils.encodeURIComponent(deleteInputData.getMemberName());
+            url.append(datasetName).append("(").append(memberName).append(")");
+        } else if (deleteInputData.getType() == DeleteType.UNCATALOGED) {
+            final String volume = EncodeUtils.encodeURIComponent(deleteInputData.getVolume());
+            url.append("-(").append(volume).append(")")
+                    .append(UrlConstants.URL_PATH_DELIM)
+                    .append(datasetName);
+        }
 
-        final String url = connection.getZosmfUrl() +
-                ZosFilesConstants.RESOURCE +
-                ZosFilesConstants.RES_DS_FILES +
-                UrlConstants.URL_PATH_DELIM +
-                EncodeUtils.encodeURIComponent(dataSetName);
-
-        request.setUrl(url);
+        request.setUrl(url.toString());
 
         return request.executeRequest();
     }

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/types/DeleteType.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/types/DeleteType.java
@@ -1,0 +1,35 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosfiles.dsn.types;
+
+/**
+ * Supported delete operation types.
+ *
+ * @author Jorge Samaniego
+ * @version 7.0
+ */
+public enum DeleteType {
+
+    /**
+     * Delete a cataloged dataset.
+     */
+    DATASET,
+
+    /**
+     * Delete a member within a partitioned dataset (PDS).
+     */
+    MEMBER,
+
+    /**
+     * Delete an uncataloged dataset residing on a specific volume.
+     */
+    UNCATALOGED
+
+}

--- a/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnDeleteTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnDeleteTest.java
@@ -19,6 +19,7 @@ import zowe.client.sdk.rest.DeleteJsonZosmfRequest;
 import zowe.client.sdk.rest.Response;
 import zowe.client.sdk.rest.ZosmfRequest;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
+import zowe.client.sdk.zosfiles.dsn.input.DsnDeleteInputData;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -63,7 +64,7 @@ public class DsnDeleteTest {
     @Test
     public void tstDsnDeleteDatasetSuccess() throws ZosmfRequestException {
         final DsnDelete dsnDelete = new DsnDelete(connection, mockDeleteRequest);
-        final Response response = dsnDelete.delete("TEST.DATASET");
+        final Response response = dsnDelete.delete(DsnDeleteInputData.forDataset("TEST.DATASET"));
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
         assertEquals("success", response.getStatusText().orElse("n\\a"));
@@ -73,7 +74,7 @@ public class DsnDeleteTest {
     @Test
     public void tstDsnDeleteTokenSuccess() throws ZosmfRequestException {
         final DsnDelete dsnDelete = new DsnDelete(connection, mockDeleteRequestToken);
-        final Response response = dsnDelete.delete("TEST.DATASET");
+        final Response response = dsnDelete.delete(DsnDeleteInputData.forDataset("TEST.DATASET"));
         assertEquals("{X-CSRF-ZOSMF-HEADER=true, Content-Type=application/json}", mockDeleteRequestToken.getHeaders().toString());
         assertEquals("{}", response.getResponsePhrase().orElse("n\\a").toString());
         assertEquals(200, response.getStatusCode().orElse(-1));
@@ -84,7 +85,7 @@ public class DsnDeleteTest {
     @Test
     public void tstDsnDeleteWithDatasetMemberNotationSuccess() throws ZosmfRequestException {
         final DsnDelete dsnDelete = new DsnDelete(connection, mockDeleteRequest);
-        final Response response = dsnDelete.delete("TEST.DATASET(MEMBER)");
+        final Response response = dsnDelete.delete(DsnDeleteInputData.forDataset("TEST.DATASET(MEMBER)"));
         assertEquals("https://1:443/zosmf/restfiles/ds/TEST.DATASET(MEMBER)", mockDeleteRequest.getUrl());
         assertEquals(200, response.getStatusCode().orElse(-1));
     }
@@ -92,7 +93,7 @@ public class DsnDeleteTest {
     @Test
     public void tstDsnDeleteWithDatasetMemberSeparateParametersSuccess() throws ZosmfRequestException {
         final DsnDelete dsnDelete = new DsnDelete(connection, mockDeleteRequest);
-        final Response response = dsnDelete.delete("TEST.DATASET", "MEMBER");
+        final Response response = dsnDelete.delete(DsnDeleteInputData.forMember("TEST.DATASET", "MEMBER"));
         assertEquals("https://1:443/zosmf/restfiles/ds/TEST.DATASET(MEMBER)", mockDeleteRequest.getUrl());
         assertEquals(200, response.getStatusCode().orElse(-1));
     }
@@ -150,5 +151,78 @@ public class DsnDeleteTest {
                 () -> new DsnDelete(null)
         );
         assertEquals("connection is null", exception.getMessage());
+    }
+
+    @Test
+    public void tstDsnDeleteUncatalogedSuccess() throws ZosmfRequestException {
+        final DsnDelete dsnDelete = new DsnDelete(connection, mockDeleteRequest);
+        final Response response = dsnDelete.delete(
+                DsnDeleteInputData.forUncataloged("TEST.DATASET", "VOL001"));
+        assertEquals("https://1:443/zosmf/restfiles/ds/-(VOL001)/TEST.DATASET", mockDeleteRequest.getUrl());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+    }
+
+    @Test
+    public void tstDsnDeleteUncatalogedTokenSuccess() throws ZosmfRequestException {
+        final DsnDelete dsnDelete = new DsnDelete(connection, mockDeleteRequestToken);
+        final Response response = dsnDelete.delete(
+                DsnDeleteInputData.forUncataloged("TEST.DATASET", "VOL001"));
+        assertEquals("https://1:443/zosmf/restfiles/ds/-(VOL001)/TEST.DATASET", mockDeleteRequestToken.getUrl());
+        assertEquals(200, response.getStatusCode().orElse(-1));
+    }
+
+    @Test
+    public void tstDsnDeleteWithNullInputDataFailure() {
+        final DsnDelete dsnDelete = new DsnDelete(connection, mockDeleteRequest);
+        NullPointerException exception = assertThrows(
+                NullPointerException.class,
+                () -> dsnDelete.delete(null)
+        );
+        assertEquals("deleteInputData is null", exception.getMessage());
+    }
+
+    @Test
+    public void tstDsnDeleteUncatalogedWithNullVolumeFailure() {
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> DsnDeleteInputData.forUncataloged("TEST.DATASET", null)
+        );
+        assertEquals("volume is either null or empty", exception.getMessage());
+    }
+
+    @Test
+    public void tstDsnDeleteUncatalogedWithEmptyVolumeFailure() {
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> DsnDeleteInputData.forUncataloged("TEST.DATASET", "")
+        );
+        assertEquals("volume is either null or empty", exception.getMessage());
+    }
+
+    @Test
+    public void tstDsnDeleteUncatalogedWithNullDatasetNameFailure() {
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> DsnDeleteInputData.forUncataloged(null, "VOL001")
+        );
+        assertEquals("datasetName is either null or empty", exception.getMessage());
+    }
+
+    @Test
+    public void tstDsnDeleteMemberWithNullMemberNameFailure() {
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> DsnDeleteInputData.forMember("TEST.DATASET", null)
+        );
+        assertEquals("memberName is either null or empty", exception.getMessage());
+    }
+
+    @Test
+    public void tstDsnDeleteDatasetWithNullDatasetNameFailure() {
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> DsnDeleteInputData.forDataset(null)
+        );
+        assertEquals("datasetName is either null or empty", exception.getMessage());
     }
 }


### PR DESCRIPTION
Resolves #582.

Extends dataset delete functionality to support uncataloged datasets bound to a specific volume serial, targeting the z/OSMF endpoint DELETE /zosmf/restfiles/ds/-(<volume>)/<dataset-name>. Refactors DsnDelete to mirror the DsnRename / DsnRenameInputData structure introduced in the recent rename refactor, keeping the two dataset operation classes consistent.

Design decisions (per Discord discussion with @frankgiordano):

Chose the input-data approach over three separate public methods (dataset / member / uncataloged) for symmetry with DsnRename New DeleteType enum introduced rather than reusing or renaming RenameType, keeping the rename type untouched Existing delete() overloads removed outright rather than deprecated, matching project convention Parens in the URI path are hardcoded string literals; dataset, member, and volume values are passed through EncodeUtils.encodeURIComponent the same way DsnUpdate.rename() handles the member path

New classes:

DsnDeleteInputData (in zosfiles.dsn.input) — immutable input carrier with static factories forDataset(datasetName), forMember(datasetName, memberName), and forUncataloged(datasetName, volume). Illegal field combinations are unconstructible by design (no way to pass a volume and a member together) DeleteType enum (in zosfiles.dsn.types) — DATASET, MEMBER, UNCATALOGED

Modified:

DsnDelete — old delete(String) and delete(String, String) overloads removed. Single delete(DsnDeleteInputData) method routes on DeleteType to build the appropriate path. Both constructors and their validation are unchanged DsnDeleteTest — existing coverage ported to the new API, six new tests added for the uncataloged path, null input data, and validation on each factory zosfiles/dsn/README.md — example snippets updated to the new API

Breaking change: direct callers of DsnDelete.delete(dsn) and DsnDelete.delete(dsn, member) must migrate to dsnDelete.delete(DsnDeleteInputData.forDataset(dsn)) and dsnDelete.delete(DsnDeleteInputData.forMember(dsn, member)) respectively.

Tests: 1188/1188 passing locally on JDK 21.