### PR TITLE
Clear HTTP headers in ZosmfRequest.initialize (#594)

### DIFF
--- a/src/main/java/zowe/client/sdk/rest/ZosmfRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/ZosmfRequest.java
@@ -84,6 +84,7 @@ public abstract class ZosmfRequest {
      * @author Frank Giordano
      */
     private void initialize() {
+        this.headers.clear();
         if (connection == null || connection.getAuthType() == null) {
             return;
         }
@@ -312,7 +313,6 @@ public abstract class ZosmfRequest {
      * @author Frank Giordano
      */
     public void setHeaders(final Map<String, String> headers) {
-        this.headers.clear();
         this.initialize();
         this.headers.putAll(headers);
     }

--- a/src/test/java/zowe/client/sdk/rest/ZoweRequestTest.java
+++ b/src/test/java/zowe/client/sdk/rest/ZoweRequestTest.java
@@ -20,6 +20,9 @@ import zowe.client.sdk.core.ZosConnectionFactory;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.rest.type.ZosmfRequestType;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -181,6 +184,29 @@ public class ZoweRequestTest {
                 .createTokenConnection("host", 443, new Cookie("hello", "world"));
         final ZosmfRequest request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
         assertNull(request.getHeaders().get("Authorization"));
+    }
+
+    @Test
+    public void tstZoweRequestSetHeadersClearsPreviousCustomHeadersSuccess() {
+        final ZosConnection connection = ZosConnectionFactory
+                .createBasicConnection("host", 443, "user", "password");
+        final ZosmfRequest request = ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
+
+        final Map<String, String> firstHeaders = new HashMap<>();
+        firstHeaders.put("X-Custom-First", "one");
+        request.setHeaders(firstHeaders);
+        assertEquals("one", request.getHeaders().get("X-Custom-First"));
+        assertNotNull(request.getHeaders().get("Authorization"));
+        assertNotNull(request.getHeaders().get("Content-Type"));
+
+        final Map<String, String> secondHeaders = new HashMap<>();
+        secondHeaders.put("X-Custom-Second", "two");
+        request.setHeaders(secondHeaders);
+
+        assertNull(request.getHeaders().get("X-Custom-First"));
+        assertEquals("two", request.getHeaders().get("X-Custom-Second"));
+        assertNotNull(request.getHeaders().get("Authorization"));
+        assertEquals("application/json", request.getHeaders().get("Content-Type"));
     }
 
     @Test


### PR DESCRIPTION
## Description

This PR addresses #594 by clearing the HTTP header map inside `ZosmfRequest.initialize()` instead of in `setHeaders()`. Every re-initialization (constructor and `setHeaders`) now starts from a clean header map within `initialize` only.

## What changed

- **`ZosmfRequest.java`**
  - Call `headers.clear()` at the start of `initialize()` (before the null-connection early return).
  - Remove the redundant `headers.clear()` from `setHeaders()`; it still calls `initialize()` then `putAll(headers)`.
- **`ZoweRequestTest.java`**
  - Add `tstZoweRequestSetHeadersClearsPreviousCustomHeadersSuccess` to assert prior custom headers are dropped while standard/auth headers remain after a second `setHeaders` call.

## Validation

Ran:

```bash
JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home ./mvnw clean test

``` 

Result: 1189 tests run, 0 failures, 0 errors (JDK 21 Temurin).

## Closes
Closes #594

