### PR TITLE
Encode volume in DsnGet#get URL (#596)

### DIFF
--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnGet.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnGet.java
@@ -129,7 +129,7 @@ public class DsnGet {
                 UrlConstants.URL_PATH_DELIM;
 
         if (downloadInputData.getVolume().isPresent()) {
-            url += "-(" + downloadInputData.getVolume().get() + ")/";
+            url += "-(" + EncodeUtils.encodeURIComponent(downloadInputData.getVolume().get()) + ")/";
         }
         url += EncodeUtils.encodeURIComponent(targetName);
 

--- a/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnGetTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnGetTest.java
@@ -78,6 +78,18 @@ public class DsnGetTest {
     }
 
     @Test
+    public void tstDsnGetWithVolumeSuccess() throws ZosmfRequestException, IOException {
+        final DsnGet dsnGet = new DsnGet(connection, mockGetRequest);
+        final DsnDownloadInputData downloadInputData = new DsnDownloadInputData.Builder()
+                .binary(true)
+                .volume("VOL001")
+                .build();
+        final InputStream inputStream = dsnGet.get("TEST.DATASET", downloadInputData);
+        assertEquals("test data", new String(inputStream.readAllBytes()));
+        assertEquals("https://1:443/zosmf/restfiles/ds/-(VOL001)/TEST.DATASET", mockGetRequest.getUrl());
+    }
+
+    @Test
     public void tstDsnGetTokenSuccess() throws ZosmfRequestException, IOException {
         final DsnGet dsnGet = new DsnGet(connection, mockGetRequestToken);
         final DsnDownloadInputData downloadInputData = new DsnDownloadInputData.Builder().binary(true).build();


### PR DESCRIPTION
## Description

This PR addresses #596 by URI-encoding the optional volume segment in `DsnGet#get()` when building the `-(vol)/` path prefix, matching the existing `DsnDelete` uncataloged-dataset pattern. `targetName` was already encoded.

## What changed

- **`DsnGet.java`**
  - Wrap `downloadInputData.getVolume().get()` with `EncodeUtils.encodeURIComponent` before appending to the URL.
- **`DsnGetTest.java`**
  - Add `tstDsnGetWithVolumeSuccess` asserting `https://1:443/zosmf/restfiles/ds/-(VOL001)/TEST.DATASET`.

## Validation

Ran:

```bash
JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home ./mvnw clean test
```

Result: 1189 tests run, 0 failures, 0 errors (JDK 21 Temurin).

## Closes
Closes #596