### PR TITLE
Release 7.0.1: Security Hardening, Reliability Improvements, and Maintenance Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Thin JAR (recommended):
         <dependency>
           <groupId>org.zowe.client.java.sdk</groupId>
           <artifactId>zowe-client-java-sdk</artifactId>
-          <version>7.0.0</version>
+          <version>7.0.1</version>
         </dependency>
   
 Fat JAR (with dependencies):
@@ -289,7 +289,7 @@ Fat JAR (with dependencies):
         <dependency>
           <groupId>org.zowe.client.java.sdk</groupId>
           <artifactId>zowe-client-java-sdk</artifactId>
-          <version>7.0.0</version>
+          <version>7.0.1</version>
           <classifier>jar-with-dependencies</classifier>
         </dependency>  
   
@@ -297,11 +297,11 @@ For a Gradle project add the SDK as a dependency by updating your `build.gradle`
 
 Thin JAR (recommended):  
   
-    implementation group: 'org.zowe.client.java.sdk', name: 'zowe-client-java-sdk', version: '7.0.0'    
+    implementation group: 'org.zowe.client.java.sdk', name: 'zowe-client-java-sdk', version: '7.0.1'    
 
 Fat JAR (with dependencies):  
   
-    implementation group: 'org.zowe.client.java.sdk', name: 'zowe-client-java-sdk', version: '7.0.0', classifier: 'jar-with-dependencies'
+    implementation group: 'org.zowe.client.java.sdk', name: 'zowe-client-java-sdk', version: '7.0.1', classifier: 'jar-with-dependencies'
   
 ## Publishing to Maven Central  
   

--- a/README.md
+++ b/README.md
@@ -213,8 +213,18 @@ For a self-signed certificate, you will need to enable inSecure processing by se
 to true value.  
       
 See [README.md](https://github.com/zowe/zowe-client-java-sdk/blob/main/src/main/java/zowe/client/sdk/zosmfauth/README.md) in zosmfauth package for further details.    
-  
-## Requirements  
+
+This same `zowe.sdk.allow.insecure.connection` system property also controls SSH host key verification for the zosuss package (see below). By default, both are verified/enforced; setting this property to `true` disables verification for both and is logged as a warning each time it happens, so only use it when the risk (a man-in-the-middle presenting a forged certificate or host key) is understood and accepted, such as in isolated test environments.
+
+BASIC and TOKEN authentication always verify the server's TLS certificate using the JVM's default trust store and have no insecure opt-out - self-signed certificates are only a concern for SSL (client-certificate) authentication, so the opt-out above only applies there and to SSH host key checking.
+
+## SSH Connections (USS Commands)
+
+The zosuss package (see [README.md](https://github.com/zowe/zowe-client-java-sdk/blob/main/src/main/java/zowe/client/sdk/zosuss/README.md)) executes commands over SSH using SshConnection/UssCmd. By default, the target host's SSH host key is verified against the current user's `~/.ssh/known_hosts` file (StrictHostKeyChecking=yes), and unknown or changed host keys cause the connection to fail. Populate that file first, for example by connecting once with a standard ssh client or via `ssh-keyscan`.
+
+To bypass host key verification, set the `zowe.sdk.allow.insecure.connection` system property described above to `true`. This should only be done when the risk is understood, since it allows any host key, including one presented by a man-in-the-middle attacker.
+
+## Requirements
 
     Compatible with all Java versions 11 and above.
     z/OSMF installed on your backend z/OS instance.  

--- a/README.md
+++ b/README.md
@@ -178,45 +178,71 @@ With three types of authentication available, the AuthType enum class was introd
   
 This enum is used to send it to the ZosConnection constructor denoting the type of authentication to perform.  
 
-For BASIC, the following ZosConnection object is specified to perform BASIC authentication:  
-  
-    ZosConnection connection = ZosConnectionFactory.createBasicConnection("host", "zosmfPort", "user", "password");
-  
-Basic authentication means that the http request contains a BASIC header representing the username and password encrypted.   
-  
-For web TOKEN, the following ZosConnection object is specified:  
-  
-    ZosConnection connection = ZosConnectionFactory.createTokenConnection("host", "port", new Cookie("xxx", "xxx")));
-  
-With the zosmfauth package, ZosmfAuth provides an API (zosmfLogin) to retrieve authentication tokens (a JSON Web and an LTPA TOKEN) on a BASIC authentication request. This package contains an API that can also be used to delete the current store of JSON Web and LPTA tokens.  
-  
-See the README.MD in the zosmfauth package for code examples on retrieving an initial token and then using it for further requests without needing user and password information.  
-  
-Web TOKEN support must be enabled on your z/OSMF system. For more information, see Enabling JSON Web TOKEN support in the IBM z/OS Management Facility Configuration Guide.  
+For BASIC, the following ZosConnection object is specified to perform BASIC authentication:
 
-See [README.md](https://github.com/zowe/zowe-client-java-sdk/blob/main/src/main/java/zowe/client/sdk/zosmfauth/README.md) in zosmfauth package for further details.     
-  
-For SSL, the following ZosConnection object is specified:  
+```java
+ZosConnection connection = ZosConnectionFactory.createBasicConnection("host", "zosmfPort", "user", "password");
+```
 
-    ZosConnection connection = ZosConnectionFactory.createSslConnection("host", "port", "c:\file.p12", "certpassword"));
+Basic authentication means that the http request contains a BASIC header representing the username and password encrypted.
+
+For web TOKEN, the following ZosConnection object is specified:
+
+```java 
+ZosConnection connection = ZosConnectionFactory.createTokenConnection("host", "port", new Cookie("xxx", "xxx"));
+```
+
+With the zosmfauth package, ZosmfAuth provides an API (zosmfLogin) to retrieve authentication tokens (a JSON Web and an LTPA TOKEN) on a BASIC authentication request. This package contains an API that can also be used to delete the current store of JSON Web and LPTA tokens.
+
+See the README.MD in the zosmfauth package for code examples on retrieving an initial token and then using it for further requests without needing user and password information.
+
+Web TOKEN support must be enabled on your z/OSMF system. For more information, see Enabling JSON Web TOKEN support in the IBM z/OS Management Facility Configuration Guide.
+
+See [README.md](https://github.com/zowe/zowe-client-java-sdk/blob/main/src/main/java/zowe/client/sdk/zosmfauth/README.md) in zosmfauth package for further details.
+
+For SSL/TLS client certificate authentication (mTLS), create a `ZosConnection` object using a PKCS12 (`.p12`) key store file:
+
+```java
+ZosConnection connection = ZosConnectionFactory.createSslConnection("host", 443, "c:/file.p12", "certpassword");
+```
+
+The `.p12` file houses your client certificate and private key, which z/OSMF uses to authenticate your client application.
+
+For `certFilePath`, specify the location and file name of the `.p12` file. For `certPassword`, specify the password/passphrase for the key store.
+
+### Server Certificate Validation Modes
+
+When validating the z/OSMF server's SSL certificate during an SSL connection, the SDK supports three modes:
+
+**Default Mode (Standard Certificate Authority Validation)**
+  - **How it works**: By default (when no system properties are set), the SDK validates the z/OSMF server certificate against the JVM's standard CA truststore (`cacerts`) and enforces standard hostname verification.
+  - **When to use**: Production or standard enterprise environments where z/OSMF uses a certificate issued by a public CA or an enterprise Root CA installed in your Java runtime's `cacerts`.
+
+**Custom TrustStore (`zowe.sdk.truststore.path`)**
+  - **How it works**: To support self-signed z/OSMF servers securely without using `TRUST_ALL_CERTS`, the SDK allows users to specify a separate TrustStore file (`.p12` or `.jks`) that contains the server's certificate or CA, rather than reusing the client's mTLS `.p12` file (which contains client credentials). Set system property `zowe.sdk.truststore.path` to the path of the server TrustStore and optionally `zowe.sdk.truststore.password`. The SDK loads this TrustStore into a `TrustManagerFactory` to validate the server certificate against it while disabling hostname verification.
+  - **How to set**:    
+
+
+    System.setProperty("zowe.sdk.truststore.path", "/path/to/server-truststore.p12");
+    System.setProperty("zowe.sdk.truststore.password", "truststorePassword"); // Optional
   
-The SDK supports .p12 file format that represents a key-store that houses a certificate.  
+Or via JVM launch argument: `-Dzowe.sdk.truststore.path=/path/to/server-truststore.p12`
+
+  - **When to use**: Staging, testing, or enterprise environments where z/OSMF uses a self-signed or internal CA certificate and you want strict certificate validation without modifying global JVM `cacerts` or disabling TLS verification.
+
+**Insecure Mode (`zowe.sdk.allow.insecure.connection=true`)**
+  - **How it works**: Insecure mode is an explicit, optional developer opt-in (disabled by default) designed specifically to bypass server TLS certificate checks for self-signed test environments when users do not have the server certificate or CA in a truststore file. Setting system property `zowe.sdk.allow.insecure.connection` to `"true"` uses `TRUST_ALL_CERTS` to bypass server certificate validation (similar to `curl -k` or `git config http.sslVerify false`) and disables hostname verification. A prominent warning is logged on connection setup.
+  - **How to set**:  
   
-In the example above, for certFilePath specify a path with a file name representing the location and file name of the .p12 file.  
+
+    System.setProperty("zowe.sdk.allow.insecure.connection", "true");
   
-For certPassword, specify the paraphrase/password used for the key store.  
-  
-For a self-signed certificate, you will need to enable inSecure processing by setting the following system property:  
-  
-    zowe.sdk.allow.insecure.connection  
-  
-to true value.  
-      
-See [README.md](https://github.com/zowe/zowe-client-java-sdk/blob/main/src/main/java/zowe/client/sdk/zosmfauth/README.md) in zosmfauth package for further details.    
+Or via JVM launch argument: `-Dzowe.sdk.allow.insecure.connection=true`
+  - **When to use**: Isolated test, local sandbox, or lab environments when connecting to self-signed z/OSMF servers without a truststore file.
 
 This same `zowe.sdk.allow.insecure.connection` system property also controls SSH host key verification for the zosuss package (see below). By default, both are verified/enforced; setting this property to `true` disables verification for both and is logged as a warning each time it happens, so only use it when the risk (a man-in-the-middle presenting a forged certificate or host key) is understood and accepted, such as in isolated test environments.
 
-BASIC and TOKEN authentication always verify the server's TLS certificate using the JVM's default trust store and have no insecure opt-out - self-signed certificates are only a concern for SSL (client-certificate) authentication, so the opt-out above only applies there and to SSH host key checking.
+BASIC and TOKEN authentication always verify the server's TLS certificate using the JVM's default trust store and have no insecure opt-out - self-signed certificates are only a concern for SSL (client-certificate) authentication, so the options above apply specifically to SSL authentication and SSH host key checking.
 
 ## SSH Connections (USS Commands)
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>com.konghq</groupId>
             <artifactId>unirest-java-core</artifactId>
-            <version>4.4.5</version>
+            <version>4.5.1</version>
         </dependency>
         <dependency>
             <groupId>com.konghq</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.zowe.client.java.sdk</groupId>
     <artifactId>zowe-client-java-sdk</artifactId>
-    <version>7.0.0</version>
+    <version>7.0.1</version>
 
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/zowe/client/sdk/core/AuthType.java
+++ b/src/main/java/zowe/client/sdk/core/AuthType.java
@@ -29,8 +29,8 @@ public enum AuthType {
      */
     TOKEN,
     /**
-     * Authentication ssl type. This case represents using a certificate file for
-     * authentication for the http request.
+     * Authentication SSL/TLS (mTLS) type. Represents using a PKCS12 certificate file (.p12) containing
+     * the client certificate and private key for HTTPS requests.
      */
     SSL
 

--- a/src/main/java/zowe/client/sdk/core/ZosConnection.java
+++ b/src/main/java/zowe/client/sdk/core/ZosConnection.java
@@ -128,7 +128,7 @@ public final class ZosConnection {
     /**
      * Set user value
      * <p>
-     * This method's access level is private-package
+     * Package-private. Intended for use only by ZosConnectionFactory during construction.
      *
      * @param user string value
      */
@@ -148,7 +148,7 @@ public final class ZosConnection {
     /**
      * Set the password value
      * <p>
-     * This method's access level is private-package
+     * Package-private. Intended for use only by ZosConnectionFactory during construction.
      *
      * @param password string value
      */
@@ -168,7 +168,7 @@ public final class ZosConnection {
     /**
      * Set token value
      * <p>
-     * This method's access level is private-package
+     * Package-private. Intended for use only by ZosConnectionFactory during construction.
      *
      * @param token Cookie object
      */
@@ -188,7 +188,7 @@ public final class ZosConnection {
     /**
      * Set certificate path value
      * <p>
-     * This method's access level is private-package
+     * Package-private. Intended for use only by ZosConnectionFactory during construction.
      *
      * @param certFilePath string value
      */
@@ -208,7 +208,7 @@ public final class ZosConnection {
     /**
      * Set the certificate password value
      * <p>
-     * This method's access level is private-package
+     * Package-private. Intended for use only by ZosConnectionFactory during construction.
      *
      * @param certPassword string value
      */

--- a/src/main/java/zowe/client/sdk/core/ZosConnection.java
+++ b/src/main/java/zowe/client/sdk/core/ZosConnection.java
@@ -47,11 +47,11 @@ public final class ZosConnection {
      */
     private Cookie token;
     /**
-     * Path with filename denoting the certificate for SSL authentication usage
+     * Path with filename denoting the PKCS12 certificate file (.p12) for SSL client authentication
      */
     private String certFilePath;
     /**
-     * The certificate password for SSL authentication
+     * Password for the PKCS12 certificate file (.p12)
      */
     private String certPassword;
     /**

--- a/src/main/java/zowe/client/sdk/core/ZosConnectionFactory.java
+++ b/src/main/java/zowe/client/sdk/core/ZosConnectionFactory.java
@@ -154,11 +154,32 @@ public class ZosConnectionFactory {
     }
 
     /**
-     * Creates a ZosConnection with SSL/TLS (mTLS) certificate authentication using a PKCS12 file (.p12)
+     * Creates a ZosConnection with SSL/TLS (mTLS) certificate authentication using a PKCS12 file (.p12).
+     * <p>
+     * The specified PKCS12 file (.p12) houses the client certificate and private key used to authenticate
+     * the client application with z/OSMF.
+     * <p>
+     * Server certificate validation during HTTPS requests supports three modes:
+     * <ul>
+     *   <li><b>Default Mode (Standard CA Validation):</b> When no system properties are set (`zowe.sdk.allow.insecure.connection = false`),
+     *       the client .p12 certificate file is used solely for client authentication (mTLS). Server certificate
+     *       verification relies on the JVM's standard default truststore ({@code cacerts}) with standard
+     *       hostname verification. When the z/OSMF server presents a certificate signed by a CA trusted by Java,
+     *       server verification succeeds automatically. Recommended for production.</li>
+     *   <li><b>Option 1 (Custom TrustStore):</b> To support self-signed z/OSMF servers securely without using
+     *       {@code TRUST_ALL_CERTS}, set system property {@code "zowe.sdk.truststore.path"} (and optional
+     *       {@code "zowe.sdk.truststore.password"}) to load a separate TrustStore (.p12 or .jks) containing the
+     *       server's certificate/CA, rather than reusing the client's mTLS .p12 file. Disables hostname verification.</li>
+     *   <li><b>Option 2 (Insecure Mode):</b> Set system property {@code "zowe.sdk.allow.insecure.connection"}
+     *       to {@code "true"} as an explicit, optional developer opt-in (disabled by default) designed specifically
+     *       to bypass server TLS certificate validation using {@code TRUST_ALL_CERTS} (similar to {@code curl -k})
+     *       and disable hostname verification when users do not have the server certificate in a truststore.
+     *       Accompanied by prominent log warnings. Intended for isolated test/sandbox environments only.</li>
+     * </ul>
      *
      * @param host         Host address of the z/OSMF server
      * @param port         Port number of the z/OSMF server
-     * @param certFilePath Path to the PKCS12 certificate file (.p12)
+     * @param certFilePath Path to the PKCS12 certificate file (.p12) containing client key and cert
      * @param certPassword Password for the PKCS12 certificate file (.p12)
      * @return ZosConnection configured for SSL authentication
      * @author Frank Giordano
@@ -172,11 +193,32 @@ public class ZosConnectionFactory {
     }
 
     /**
-     * Creates a ZosConnection with SSL certificate authentication
+     * Creates a ZosConnection with SSL/TLS (mTLS) certificate authentication using a PKCS12 file (.p12).
+     * <p>
+     * The specified PKCS12 file (.p12) houses the client certificate and private key used to authenticate
+     * the client application with z/OSMF.
+     * <p>
+     * Server certificate validation during HTTPS requests supports three modes:
+     * <ul>
+     *   <li><b>Default Mode (Standard CA Validation):</b> When no system properties are set (`zowe.sdk.allow.insecure.connection = false`),
+     *       the client .p12 certificate file is used solely for client authentication (mTLS). Server certificate
+     *       verification relies on the JVM's standard default truststore ({@code cacerts}) with standard
+     *       hostname verification. When the z/OSMF server presents a certificate signed by a CA trusted by Java,
+     *       server verification succeeds automatically. Recommended for production.</li>
+     *   <li><b>Option 1 (Custom TrustStore):</b> To support self-signed z/OSMF servers securely without using
+     *       {@code TRUST_ALL_CERTS}, set system property {@code "zowe.sdk.truststore.path"} (and optional
+     *       {@code "zowe.sdk.truststore.password"}) to load a separate TrustStore (.p12 or .jks) containing the
+     *       server's certificate/CA, rather than reusing the client's mTLS .p12 file. Disables hostname verification.</li>
+     *   <li><b>Option 2 (Insecure Mode):</b> Set system property {@code "zowe.sdk.allow.insecure.connection"}
+     *       to {@code "true"} as an explicit, optional developer opt-in (disabled by default) designed specifically
+     *       to bypass server TLS certificate validation using {@code TRUST_ALL_CERTS} (similar to {@code curl -k})
+     *       and disable hostname verification when users do not have the server certificate in a truststore.
+     *       Accompanied by prominent log warnings. Intended for isolated test/sandbox environments only.</li>
+     * </ul>
      *
      * @param host         Host address of the z/OSMF server
      * @param port         Port number of the z/OSMF server
-     * @param certFilePath Path to the PKCS12 certificate file (.p12)
+     * @param certFilePath Path to the PKCS12 certificate file (.p12) containing client key and cert
      * @param certPassword Password for the PKCS12 certificate file (.p12)
      * @param basePath     base path for z/OSMF REST endpoints
      * @return ZosConnection configured for SSL authentication

--- a/src/main/java/zowe/client/sdk/core/ZosConnectionFactory.java
+++ b/src/main/java/zowe/client/sdk/core/ZosConnectionFactory.java
@@ -154,12 +154,12 @@ public class ZosConnectionFactory {
     }
 
     /**
-     * Creates a ZosConnection with SSL certificate authentication
+     * Creates a ZosConnection with SSL/TLS (mTLS) certificate authentication using a PKCS12 file (.p12)
      *
      * @param host         Host address of the z/OSMF server
      * @param port         Port number of the z/OSMF server
-     * @param certFilePath Path to the certificate file (.p12)
-     * @param certPassword Password for the certificate
+     * @param certFilePath Path to the PKCS12 certificate file (.p12)
+     * @param certPassword Password for the PKCS12 certificate file (.p12)
      * @return ZosConnection configured for SSL authentication
      * @author Frank Giordano
      * @author Shabaz Kowthalam
@@ -176,8 +176,8 @@ public class ZosConnectionFactory {
      *
      * @param host         Host address of the z/OSMF server
      * @param port         Port number of the z/OSMF server
-     * @param certFilePath Path to the certificate file (.p12)
-     * @param certPassword Password for the certificate
+     * @param certFilePath Path to the PKCS12 certificate file (.p12)
+     * @param certPassword Password for the PKCS12 certificate file (.p12)
      * @param basePath     base path for z/OSMF REST endpoints
      * @return ZosConnection configured for SSL authentication
      * @author Frank Giordano

--- a/src/main/java/zowe/client/sdk/rest/DeleteJsonZosmfRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/DeleteJsonZosmfRequest.java
@@ -11,7 +11,6 @@ package zowe.client.sdk.rest;
 
 import kong.unirest.core.HttpResponse;
 import kong.unirest.core.JsonNode;
-import kong.unirest.core.Unirest;
 import kong.unirest.core.UnirestException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,11 +56,11 @@ public class DeleteJsonZosmfRequest extends ZosmfRequest {
         HttpResponse<JsonNode> reply;
         try {
             if (body == null) {
-                reply = token != null ? Unirest.delete(url).cookie(token).headers(headers).asJson() :
-                        Unirest.delete(url).headers(headers).asJson();
+                reply = token != null ? unirest.delete(url).cookie(token).headers(headers).asJson() :
+                        unirest.delete(url).headers(headers).asJson();
             } else {
-                reply = token != null ? Unirest.delete(url).cookie(token).headers(headers).body(body).asJson() :
-                        Unirest.delete(url).headers(headers).body(body).asJson();
+                reply = token != null ? unirest.delete(url).cookie(token).headers(headers).body(body).asJson() :
+                        unirest.delete(url).headers(headers).body(body).asJson();
             }
         } catch (UnirestException e) {
             throw new ZosmfRequestException(e.getMessage(), e);

--- a/src/main/java/zowe/client/sdk/rest/GetJsonZosmfRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/GetJsonZosmfRequest.java
@@ -11,7 +11,6 @@ package zowe.client.sdk.rest;
 
 import kong.unirest.core.HttpResponse;
 import kong.unirest.core.JsonNode;
-import kong.unirest.core.Unirest;
 import kong.unirest.core.UnirestException;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
@@ -47,8 +46,8 @@ public class GetJsonZosmfRequest extends ZosmfRequest {
         ValidateUtils.checkNullParameter(url, "url");
         HttpResponse<JsonNode> reply;
         try {
-            reply = token != null ? Unirest.get(url).cookie(token).headers(headers).asJson() :
-                    Unirest.get(url).headers(headers).asJson();
+            reply = token != null ? unirest.get(url).cookie(token).headers(headers).asJson() :
+                    unirest.get(url).headers(headers).asJson();
         } catch (UnirestException e) {
             throw new ZosmfRequestException(e.getMessage(), e);
         }

--- a/src/main/java/zowe/client/sdk/rest/GetStreamZosmfRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/GetStreamZosmfRequest.java
@@ -10,7 +10,6 @@
 package zowe.client.sdk.rest;
 
 import kong.unirest.core.HttpResponse;
-import kong.unirest.core.Unirest;
 import kong.unirest.core.UnirestException;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
@@ -46,8 +45,8 @@ public class GetStreamZosmfRequest extends ZosmfRequest {
         ValidateUtils.checkNullParameter(url, "url");
         HttpResponse<byte[]> reply;
         try {
-            reply = token != null ? Unirest.get(url).cookie(token).headers(headers).asBytes() :
-                    Unirest.get(url).headers(headers).asBytes();
+            reply = token != null ? unirest.get(url).cookie(token).headers(headers).asBytes() :
+                    unirest.get(url).headers(headers).asBytes();
         } catch (UnirestException e) {
             throw new ZosmfRequestException(e.getMessage(), e);
         }

--- a/src/main/java/zowe/client/sdk/rest/GetTextZosmfRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/GetTextZosmfRequest.java
@@ -10,7 +10,6 @@
 package zowe.client.sdk.rest;
 
 import kong.unirest.core.HttpResponse;
-import kong.unirest.core.Unirest;
 import kong.unirest.core.UnirestException;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
@@ -46,8 +45,8 @@ public class GetTextZosmfRequest extends ZosmfRequest {
         ValidateUtils.checkNullParameter(url, "url");
         HttpResponse<String> reply;
         try {
-            reply = token != null ? Unirest.get(url).cookie(token).headers(headers).asString() :
-                    Unirest.get(url).headers(headers).asString();
+            reply = token != null ? unirest.get(url).cookie(token).headers(headers).asString() :
+                    unirest.get(url).headers(headers).asString();
         } catch (UnirestException e) {
             throw new ZosmfRequestException(e.getMessage(), e);
         }

--- a/src/main/java/zowe/client/sdk/rest/PostJsonZosmfRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/PostJsonZosmfRequest.java
@@ -11,7 +11,6 @@ package zowe.client.sdk.rest;
 
 import kong.unirest.core.HttpResponse;
 import kong.unirest.core.JsonNode;
-import kong.unirest.core.Unirest;
 import kong.unirest.core.UnirestException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,8 +56,8 @@ public class PostJsonZosmfRequest extends ZosmfRequest {
         ValidateUtils.checkNullParameter(body, "body");
         HttpResponse<JsonNode> reply;
         try {
-            reply = token != null ? Unirest.post(url).cookie(token).headers(headers).body(body).asJson() :
-                    Unirest.post(url).headers(headers).body(body).asJson();
+            reply = token != null ? unirest.post(url).cookie(token).headers(headers).body(body).asJson() :
+                    unirest.post(url).headers(headers).body(body).asJson();
         } catch (UnirestException e) {
             throw new ZosmfRequestException(e.getMessage(), e);
         }

--- a/src/main/java/zowe/client/sdk/rest/PutJsonZosmfRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/PutJsonZosmfRequest.java
@@ -11,7 +11,6 @@ package zowe.client.sdk.rest;
 
 import kong.unirest.core.HttpResponse;
 import kong.unirest.core.JsonNode;
-import kong.unirest.core.Unirest;
 import kong.unirest.core.UnirestException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,8 +58,8 @@ public class PutJsonZosmfRequest extends ZosmfRequest {
         ValidateUtils.checkNullParameter(body, "body");
         HttpResponse<JsonNode> reply;
         try {
-            reply = token != null ? Unirest.put(url).cookie(token).headers(headers).body(body).asJson() :
-                    Unirest.put(url).headers(headers).body(body).asJson();
+            reply = token != null ? unirest.put(url).cookie(token).headers(headers).body(body).asJson() :
+                    unirest.put(url).headers(headers).body(body).asJson();
         } catch (UnirestException e) {
             throw new ZosmfRequestException(e.getMessage(), e);
         }

--- a/src/main/java/zowe/client/sdk/rest/PutStreamZosmfRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/PutStreamZosmfRequest.java
@@ -11,7 +11,6 @@ package zowe.client.sdk.rest;
 
 import kong.unirest.core.HttpResponse;
 import kong.unirest.core.JsonNode;
-import kong.unirest.core.Unirest;
 import kong.unirest.core.UnirestException;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
@@ -54,8 +53,8 @@ public class PutStreamZosmfRequest extends ZosmfRequest {
         ValidateUtils.checkNullParameter(body, "body");
         HttpResponse<JsonNode> reply;
         try {
-            reply = token != null ? Unirest.put(url).cookie(token).headers(headers).body(body).asJson() :
-                    Unirest.put(url).headers(headers).body(body).asJson();
+            reply = token != null ? unirest.put(url).cookie(token).headers(headers).body(body).asJson() :
+                    unirest.put(url).headers(headers).body(body).asJson();
         } catch (UnirestException e) {
             throw new ZosmfRequestException(e.getMessage(), e);
         }

--- a/src/main/java/zowe/client/sdk/rest/PutTextZosmfRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/PutTextZosmfRequest.java
@@ -10,7 +10,6 @@
 package zowe.client.sdk.rest;
 
 import kong.unirest.core.HttpResponse;
-import kong.unirest.core.Unirest;
 import kong.unirest.core.UnirestException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,8 +55,8 @@ public class PutTextZosmfRequest extends ZosmfRequest {
         ValidateUtils.checkNullParameter(body, "body");
         HttpResponse<String> reply;
         try {
-            reply = token != null ? Unirest.put(url).cookie(token).headers(headers).body(body).asString() :
-                    Unirest.put(url).headers(headers).body(body).asString();
+            reply = token != null ? unirest.put(url).cookie(token).headers(headers).body(body).asString() :
+                    unirest.put(url).headers(headers).body(body).asString();
         } catch (UnirestException e) {
             throw new ZosmfRequestException(e.getMessage(), e);
         }

--- a/src/main/java/zowe/client/sdk/rest/RestConstant.java
+++ b/src/main/java/zowe/client/sdk/rest/RestConstant.java
@@ -108,4 +108,7 @@ public final class RestConstant {
      */
     public static final String INSECURE_PROPERTY_NAME = "zowe.sdk.allow.insecure.connection";
 
+    public static final String INSECURE_ENABLE_WARNING = INSECURE_PROPERTY_NAME +
+            " is enabled; TLS certificate verification is disabled for this connection";
+
 }

--- a/src/main/java/zowe/client/sdk/rest/RestConstant.java
+++ b/src/main/java/zowe/client/sdk/rest/RestConstant.java
@@ -1,5 +1,17 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
 package zowe.client.sdk.rest;
 
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.security.cert.X509Certificate;
 import java.util.AbstractMap;
 import java.util.Map;
 
@@ -83,6 +95,24 @@ public final class RestConstant {
             new AbstractMap.SimpleEntry<>(511, "network authentication required"));
 
     /**
+     * Trust all server certs (like --insecure).
+     * Used when "zowe.sdk.allow.insecure.connection" System property is set to "true".
+     */
+    public static final TrustManager[] TRUST_ALL_CERTS = new TrustManager[]{
+            new X509TrustManager() {
+                public void checkClientTrusted(X509Certificate[] certs, String authType) {
+                }
+
+                public void checkServerTrusted(X509Certificate[] certs, String authType) {
+                }
+
+                public X509Certificate[] getAcceptedIssuers() {
+                    return new X509Certificate[0];
+                }
+            }
+    };
+
+    /**
      * The system property name ("zowe.sdk.allow.insecure.connection") for enabling insecure
      * connection processing. When set to "true", hostname verification is disabled for SSL
      * connections and SSH host key verification is bypassed.
@@ -94,5 +124,17 @@ public final class RestConstant {
      */
     public static final String INSECURE_ENABLE_WARNING = INSECURE_PROPERTY_NAME +
             " is enabled; TLS certificate verification is disabled for this connection";
+
+    /**
+     * The system property name ("zowe.sdk.truststore.path") for specifying a custom
+     * TrustStore file path (.p12, .jks) used to validate server certificates.
+     */
+    public static final String TRUSTSTORE_PATH_PROPERTY_NAME = "zowe.sdk.truststore.path";
+
+    /**
+     * The system property name ("zowe.sdk.truststore.password") for specifying the password
+     * for the custom TrustStore file. Defaults to empty string if not provided.
+     */
+    public static final String TRUSTSTORE_PASSWORD_PROPERTY_NAME = "zowe.sdk.truststore.password";
 
 }

--- a/src/main/java/zowe/client/sdk/rest/RestConstant.java
+++ b/src/main/java/zowe/client/sdk/rest/RestConstant.java
@@ -108,6 +108,9 @@ public final class RestConstant {
      */
     public static final String INSECURE_PROPERTY_NAME = "zowe.sdk.allow.insecure.connection";
 
+    /**
+     * Warning message turning off TLS verification for ssl authentication type
+     */
     public static final String INSECURE_ENABLE_WARNING = INSECURE_PROPERTY_NAME +
             " is enabled; TLS certificate verification is disabled for this connection";
 

--- a/src/main/java/zowe/client/sdk/rest/RestConstant.java
+++ b/src/main/java/zowe/client/sdk/rest/RestConstant.java
@@ -1,8 +1,5 @@
 package zowe.client.sdk.rest;
 
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
-import java.security.cert.X509Certificate;
 import java.util.AbstractMap;
 import java.util.Map;
 
@@ -86,30 +83,14 @@ public final class RestConstant {
             new AbstractMap.SimpleEntry<>(511, "network authentication required"));
 
     /**
-     * Trust all server certs (like --insecure)
-     * Used when "zowe.sdk.allow.insecure.connection" System property is defined
-     */
-    public static final TrustManager[] TRUST_ALL_CERTS = new TrustManager[]{
-            new X509TrustManager() {
-                public void checkClientTrusted(X509Certificate[] certs, String authType) {
-                }
-
-                public void checkServerTrusted(X509Certificate[] certs, String authType) {
-                }
-
-                public X509Certificate[] getAcceptedIssuers() {
-                    return new X509Certificate[0];
-                }
-            }
-    };
-
-    /**
-     * The system property value for insecure toggling to use a self-signed certificate
+     * The system property name ("zowe.sdk.allow.insecure.connection") for enabling insecure
+     * connection processing. When set to "true", hostname verification is disabled for SSL
+     * connections and SSH host key verification is bypassed.
      */
     public static final String INSECURE_PROPERTY_NAME = "zowe.sdk.allow.insecure.connection";
 
     /**
-     * Warning message turning off TLS verification for ssl authentication type
+     * Warning message logged when zowe.sdk.allow.insecure.connection is enabled for SSL connections.
      */
     public static final String INSECURE_ENABLE_WARNING = INSECURE_PROPERTY_NAME +
             " is enabled; TLS certificate verification is disabled for this connection";

--- a/src/main/java/zowe/client/sdk/rest/ZosmfRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/ZosmfRequest.java
@@ -19,6 +19,7 @@ import zowe.client.sdk.utility.ValidateUtils;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
 import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -147,8 +148,10 @@ public abstract class ZosmfRequest {
     /**
      * Setup authentication SSL type
      * <p>
-     * With the following system property set "zowe.sdk.allow.insecure.connection",
-     * insecure type for self-signed certificate processing is enabled.
+     * When system property "zowe.sdk.allow.insecure.connection" is set to "true", hostname
+     * verification is disabled and self-signed certificate processing is used.
+     * Otherwise, standard SSL client certificate store configuration is applied with default
+     * JVM CA trust and hostname verification.
      *
      * @param instance   UnirestInstance to configure
      * @param connection for connection information, see ZosConnection object
@@ -166,7 +169,8 @@ public abstract class ZosmfRequest {
     }
 
     /**
-     * Set up authentication SSL type for a self-signed certificate
+     * Set up authentication SSL type for a self-signed certificate.
+     * Disables hostname verification for connections where self-signed certificates or test hostnames are used.
      *
      * @param instance     UnirestInstance to configure
      * @param certFilePath certificate file (.p12) location
@@ -190,9 +194,13 @@ public abstract class ZosmfRequest {
                     KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
             keyManagerFactory.init(keyStore, certPassword.toCharArray());
 
+            TrustManagerFactory trustManagerFactory =
+                    TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            trustManagerFactory.init(keyStore);
+
             SSLContext sslContext = SSLContext.getInstance("TLS");
             sslContext.init(keyManagerFactory.getKeyManagers(),
-                    RestConstant.TRUST_ALL_CERTS, new java.security.SecureRandom());
+                    trustManagerFactory.getTrustManagers(), new java.security.SecureRandom());
             instance.config().sslContext(sslContext);
         } catch (Exception e) {
             throw new IllegalStateException(e);

--- a/src/main/java/zowe/client/sdk/rest/ZosmfRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/ZosmfRequest.java
@@ -9,10 +9,7 @@
  */
 package zowe.client.sdk.rest;
 
-import kong.unirest.core.Cookie;
-import kong.unirest.core.HttpResponse;
-import kong.unirest.core.JsonNode;
-import kong.unirest.core.Unirest;
+import kong.unirest.core.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zowe.client.sdk.core.ZosConnection;
@@ -31,6 +28,7 @@ import java.security.KeyStore;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -51,9 +49,20 @@ public abstract class ZosmfRequest {
      */
     public static final String X_CSRF_ZOSMF_HEADER_VALUE = ZosmfHeaders.HEADERS.get(ZosmfHeaders.X_CSRF_ZOSMF_HEADER).get(1);
     /**
+     * Per-connection Unirest client instances, keyed by ZosConnection (host/port/authType/credentials).
+     * <p>
+     * A dedicated UnirestInstance is spawned and configured (TLS/auth) once per unique connection so that
+     * concurrent requests against different connections never race on JVM-global Unirest configuration.
+     */
+    private static final Map<ZosConnection, UnirestInstance> UNIREST_INSTANCES = new ConcurrentHashMap<>();
+    /**
      * ZosConnection object
      */
     protected final ZosConnection connection;
+    /**
+     * Unirest client instance dedicated to this request's connection
+     */
+    protected final UnirestInstance unirest;
     /**
      * Map of HTTP headers
      */
@@ -75,11 +84,42 @@ public abstract class ZosmfRequest {
      */
     public ZosmfRequest(final ZosConnection connection) {
         this.connection = connection;
+        this.unirest = (connection == null || connection.getAuthType() == null) ?
+                null : UNIREST_INSTANCES.computeIfAbsent(connection, ZosmfRequest::buildUnirestInstance);
         this.initialize();
     }
 
     /**
-     * Initialize the unirest http request object based on an authentication type
+     * Spawn and configure (TLS/auth) a new Unirest client instance dedicated to the given connection.
+     * <p>
+     * Invoked at most once per unique ZosConnection via {@link #UNIREST_INSTANCES}, so this mutates
+     * only the newly spawned instance's own config, never the JVM-global Unirest.config() singleton.
+     *
+     * @param connection for connection information, see ZosConnection object
+     * @return configured UnirestInstance for this connection
+     * @author Frank Giordano
+     */
+    private static UnirestInstance buildUnirestInstance(final ZosConnection connection) {
+        final UnirestInstance instance = Unirest.spawnInstance();
+        instance.config().enableCookieManagement(false);
+        switch (connection.getAuthType()) {
+            case BASIC:
+                LOG.debug("basic authentication type");
+                break;
+            case TOKEN:
+                LOG.debug("token authentication type");
+                break;
+            case SSL:
+                setupSsl(instance, connection);
+                break;
+            default:
+                throw new IllegalStateException("no authentication type found");
+        }
+        return instance;
+    }
+
+    /**
+     * Initialize the http request object's per-request state (headers/token) based on an authentication type
      *
      * @author Frank Giordano
      */
@@ -87,45 +127,21 @@ public abstract class ZosmfRequest {
         if (connection == null || connection.getAuthType() == null) {
             return;
         }
-        Unirest.config().reset();
-        Unirest.config().enableCookieManagement(false);
+        this.headers.clear();
         this.setStandardHeaders();
         this.token = null;
         switch (connection.getAuthType()) {
             case BASIC:
-                setupBasic();
+                headers.put("Authorization", "Basic " + EncodeUtils.encodeBasicAuthCredentials(connection));
                 break;
             case TOKEN:
-                setupToken();
+                this.token = connection.getToken();
                 break;
             case SSL:
-                setupSsl();
                 break;
             default:
                 throw new IllegalStateException("no authentication type found");
         }
-    }
-
-    /**
-     * Setup authentication BASIC type
-     *
-     * @author Frank Giordano
-     */
-    private void setupBasic() {
-        LOG.debug("basic authentication type");
-        Unirest.config().verifySsl(false);
-        headers.put("Authorization", "Basic " + EncodeUtils.encodeBasicAuthCredentials(connection));
-    }
-
-    /**
-     * Setup authentication TOKEN type
-     *
-     * @author Frank Giordano
-     */
-    private void setupToken() {
-        LOG.debug("token authentication type");
-        Unirest.config().verifySsl(false);
-        this.token = connection.getToken();
     }
 
     /**
@@ -134,27 +150,32 @@ public abstract class ZosmfRequest {
      * With the following system property set "zowe.sdk.allow.insecure.connection",
      * insecure type for self-signed certificate processing is enabled.
      *
+     * @param instance   UnirestInstance to configure
+     * @param connection for connection information, see ZosConnection object
      * @author Frank Giordano
      */
-    private void setupSsl() {
+    private static void setupSsl(final UnirestInstance instance, final ZosConnection connection) {
         LOG.debug("ssl authentication type");
         boolean inSecure = Boolean.parseBoolean(System.getProperty(RestConstant.INSECURE_PROPERTY_NAME, "false"));
         if (inSecure) {
-            LOG.debug("insecure enabled");
-            setupSelfSignedCertificate(connection.getCertFilePath(), connection.getCertPassword());
+            LOG.warn(RestConstant.INSECURE_ENABLE_WARNING);
+            setupSelfSignedCertificate(instance, connection.getCertFilePath(), connection.getCertPassword());
         } else {
-            Unirest.config().clientCertificateStore(connection.getCertFilePath(), connection.getCertPassword());
+            instance.config().clientCertificateStore(connection.getCertFilePath(), connection.getCertPassword());
         }
     }
 
     /**
      * Set up authentication SSL type for a self-signed certificate
      *
+     * @param instance     UnirestInstance to configure
      * @param certFilePath certificate file (.p12) location
      * @param certPassword certificate password for certificate file (.p12)
      * @author Frank Giordano
      */
-    private void setupSelfSignedCertificate(final String certFilePath, final String certPassword) {
+    private static void setupSelfSignedCertificate(final UnirestInstance instance,
+                                                   final String certFilePath,
+                                                   final String certPassword) {
         try {
             System.setProperty("jdk.internal.httpclient.disableHostnameVerification", "true");
 
@@ -172,7 +193,7 @@ public abstract class ZosmfRequest {
             SSLContext sslContext = SSLContext.getInstance("TLS");
             sslContext.init(keyManagerFactory.getKeyManagers(),
                     RestConstant.TRUST_ALL_CERTS, new java.security.SecureRandom());
-            Unirest.config().sslContext(sslContext);
+            instance.config().sslContext(sslContext);
         } catch (Exception e) {
             throw new IllegalStateException(e);
         }
@@ -312,7 +333,6 @@ public abstract class ZosmfRequest {
      * @author Frank Giordano
      */
     public void setHeaders(final Map<String, String> headers) {
-        this.headers.clear();
         this.initialize();
         this.headers.putAll(headers);
     }

--- a/src/main/java/zowe/client/sdk/rest/ZosmfRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/ZosmfRequest.java
@@ -148,10 +148,26 @@ public abstract class ZosmfRequest {
     /**
      * Setup authentication SSL type
      * <p>
-     * When system property "zowe.sdk.allow.insecure.connection" is set to "true", hostname
-     * verification is disabled and self-signed certificate processing is used.
-     * Otherwise, standard SSL client certificate store configuration is applied with default
-     * JVM CA trust and hostname verification.
+     * SSL/TLS configuration supports two options for handling server certificate validation:
+     * <ul>
+     *   <li><b>Option 1 (Custom TrustStore):</b> To support self-signed z/OSMF servers securely without
+     *       using {@link RestConstant#TRUST_ALL_CERTS}, the SDK allows specifying a separate TrustStore file
+     *       (.p12 or .jks) that contains the server's certificate/CA, rather than reusing the client's mTLS .p12 file.
+     *       Specified by setting the system property {@value RestConstant#TRUSTSTORE_PATH_PROPERTY_NAME}
+     *       ("zowe.sdk.truststore.path") and optional {@value RestConstant#TRUSTSTORE_PASSWORD_PROPERTY_NAME}
+     *       ("zowe.sdk.truststore.password"). Loads the custom TrustStore into a {@link TrustManagerFactory}
+     *       to validate the server certificate while disabling hostname verification.</li>
+     *   <li><b>Option 2 (Insecure Mode):</b> Enabled implicitly by setting the system property
+     *       {@value RestConstant#INSECURE_PROPERTY_NAME} ("zowe.sdk.allow.insecure.connection") to "true".
+     *       An explicit, optional developer opt-in (disabled by default) designed specifically to bypass
+     *       server TLS checks for self-signed test environments when users do not have the server certificate
+     *       in a truststore. Logs a prominent security warning and uses {@link RestConstant#TRUST_ALL_CERTS}
+     *       to accept any server certificate (similar to {@code curl -k}), while also disabling hostname verification.
+     *       Use only in isolated test or sandbox environments.</li>
+     *   <li><b>Default (Standard Mode):</b> When neither property is set, standard client certificate store
+     *       configuration is applied using the client .p12 certificate file for mTLS, relying on the default
+     *       JVM CA truststore and standard hostname verification for server validation.</li>
+     * </ul>
      *
      * @param instance   UnirestInstance to configure
      * @param connection for connection information, see ZosConnection object
@@ -159,8 +175,13 @@ public abstract class ZosmfRequest {
      */
     private static void setupSsl(final UnirestInstance instance, final ZosConnection connection) {
         LOG.debug("ssl authentication type");
+        String trustStorePath = System.getProperty(RestConstant.TRUSTSTORE_PATH_PROPERTY_NAME);
         boolean inSecure = Boolean.parseBoolean(System.getProperty(RestConstant.INSECURE_PROPERTY_NAME, "false"));
-        if (inSecure) {
+
+        if (trustStorePath != null && !trustStorePath.isBlank()) {
+            String trustStorePassword = System.getProperty(RestConstant.TRUSTSTORE_PASSWORD_PROPERTY_NAME, "");
+            setupCustomTrustStore(instance, connection, trustStorePath, trustStorePassword);
+        } else if (inSecure) {
             LOG.warn(RestConstant.INSECURE_ENABLE_WARNING);
             setupSelfSignedCertificate(instance, connection.getCertFilePath(), connection.getCertPassword());
         } else {
@@ -169,8 +190,10 @@ public abstract class ZosmfRequest {
     }
 
     /**
-     * Set up authentication SSL type for a self-signed certificate.
-     * Disables hostname verification for connections where self-signed certificates or test hostnames are used.
+     * Set up authentication SSL type for an insecure connection using TRUST_ALL_CERTS.
+     * <p>
+     * Disables hostname verification and bypasses server certificate validation when system property
+     * {@value RestConstant#INSECURE_PROPERTY_NAME} ("zowe.sdk.allow.insecure.connection") is set to "true".
      *
      * @param instance     UnirestInstance to configure
      * @param certFilePath certificate file (.p12) location
@@ -194,9 +217,60 @@ public abstract class ZosmfRequest {
                     KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
             keyManagerFactory.init(keyStore, certPassword.toCharArray());
 
+            SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(keyManagerFactory.getKeyManagers(),
+                    RestConstant.TRUST_ALL_CERTS, new java.security.SecureRandom());
+            instance.config().sslContext(sslContext);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /**
+     * Set up authentication SSL type using a custom TrustStore file for server certificate validation.
+     * <p>
+     * Loads the custom TrustStore specified by {@value RestConstant#TRUSTSTORE_PATH_PROPERTY_NAME} into
+     * a {@link TrustManagerFactory} and disables hostname verification for self-signed or internal CA endpoints.
+     *
+     * @param instance           UnirestInstance to configure
+     * @param connection         ZosConnection object containing client certificate info
+     * @param trustStorePath     path to custom TrustStore file (.p12, .jks)
+     * @param trustStorePassword password for custom TrustStore file
+     * @author Frank Giordano
+     */
+    private static void setupCustomTrustStore(final UnirestInstance instance,
+                                              final ZosConnection connection,
+                                              final String trustStorePath,
+                                              final String trustStorePassword) {
+        try {
+            instance.config().disableHostNameVerification(true);
+
+            KeyStore clientKeyStore = KeyStore.getInstance("PKCS12");
+            try (FileInputStream fileInputStream = new FileInputStream(connection.getCertFilePath())) {
+                clientKeyStore.load(fileInputStream, connection.getCertPassword().toCharArray());
+            } catch (Exception e) {
+                throw new IllegalStateException(e);
+            }
+
+            KeyManagerFactory keyManagerFactory =
+                    KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+            keyManagerFactory.init(clientKeyStore, connection.getCertPassword().toCharArray());
+
+            KeyStore trustStore;
+            if (trustStorePath.endsWith(".jks")) {
+                trustStore = KeyStore.getInstance("JKS");
+            } else {
+                trustStore = KeyStore.getInstance("PKCS12");
+            }
+            try (FileInputStream fileInputStream = new FileInputStream(trustStorePath)) {
+                trustStore.load(fileInputStream, trustStorePassword.toCharArray());
+            } catch (Exception e) {
+                throw new IllegalStateException(e);
+            }
+
             TrustManagerFactory trustManagerFactory =
                     TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-            trustManagerFactory.init(keyStore);
+            trustManagerFactory.init(trustStore);
 
             SSLContext sslContext = SSLContext.getInstance("TLS");
             sslContext.init(keyManagerFactory.getKeyManagers(),

--- a/src/main/java/zowe/client/sdk/rest/ZosmfRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/ZosmfRequest.java
@@ -177,7 +177,7 @@ public abstract class ZosmfRequest {
                                                    final String certFilePath,
                                                    final String certPassword) {
         try {
-            System.setProperty("jdk.internal.httpclient.disableHostnameVerification", "true");
+            instance.config().disableHostNameVerification(true);
 
             KeyStore keyStore = KeyStore.getInstance("PKCS12");
             try (FileInputStream fileInputStream = new FileInputStream(certFilePath)) {

--- a/src/main/java/zowe/client/sdk/teamconfig/README.md
+++ b/src/main/java/zowe/client/sdk/teamconfig/README.md
@@ -26,7 +26,9 @@ With the following team configuration:
 
 To retrieve the default profile of type "zosmf" with the credentials from the credential store, perform the following:
 
+````java
 ProfileDao profile = teamConfig.getDefaultProfile("zosmf");
+````
 
 This should return the profile named "frank" with its attributes and credentials.
 

--- a/src/main/java/zowe/client/sdk/teamconfig/README.md
+++ b/src/main/java/zowe/client/sdk/teamconfig/README.md
@@ -26,7 +26,7 @@ With the following team configuration:
 
 To retrieve the default profile of type "zosmf" with the credentials from the credential store, perform the following:
 
-ProfileDao profile = teamConfig.getDefaultProfile ("zosmf");
+ProfileDao profile = teamConfig.getDefaultProfile("zosmf");
 
 This should return the profile named "frank" with its attributes and credentials.
 

--- a/src/main/java/zowe/client/sdk/teamconfig/README.md
+++ b/src/main/java/zowe/client/sdk/teamconfig/README.md
@@ -1,10 +1,9 @@
 # TeamConfig Package
 
-The TeamConfig package provides API method(s) to retrieve and update a profile section from Zowe Global Team
-Configuration with
-keytar information to help perform connection processing without hard coding username and password. Keytar represents
-credentials stored securely on your computer when performing the Zowe global initialize command which prompts you for
-username and password.
+The TeamConfig package provides API method (s) to retrieve and update a profile section from Zowe Global Team
+Configuration with keytar information to help perform connection processing without hard coding username and password.
+Keytar represents credentials stored securely on your computer when performing the Zowe global initialize command which
+prompts you for username and password.
 
 ## Description of retrieving a profile.
 
@@ -27,7 +26,7 @@ With the following team configuration:
 
 To retrieve the default profile of type "zosmf" with the credentials from the credential store, perform the following:
 
-ProfileDao profile = teamConfig.getDefaultProfile("zosmf");
+ProfileDao profile = teamConfig.getDefaultProfile ("zosmf");
 
 This should return the profile named "frank" with its attributes and credentials.
 

--- a/src/main/java/zowe/client/sdk/teamconfig/keytar/KeyTarConfig.java
+++ b/src/main/java/zowe/client/sdk/teamconfig/keytar/KeyTarConfig.java
@@ -112,8 +112,8 @@ public class KeyTarConfig {
     public String toString() {
         return "KeyTarConfig{" +
                 "location='" + location + '\'' +
-                ", userName='" + userName + '\'' +
-                ", password='" + password + '\'' +
+                ", userName='" + ((userName == null) ? "" : userName) + '\'' +
+                ", password='" + ((password == null || password.isEmpty()) ? "" : "*****") + '\'' +
                 '}';
     }
 

--- a/src/main/java/zowe/client/sdk/teamconfig/model/ProfileDao.java
+++ b/src/main/java/zowe/client/sdk/teamconfig/model/ProfileDao.java
@@ -116,8 +116,8 @@ public class ProfileDao {
     public String toString() {
         return "ProfileDao{" +
                 "profile=" + profile +
-                ", user='" + user + '\'' +
-                ", password='" + password + '\'' +
+                ", user='" + ((user == null) ? "" : user) + '\'' +
+                ", password='" + ((password == null || password.isEmpty()) ? "" : "*****") + '\'' +
                 ", host='" + host + '\'' +
                 ", port='" + port + '\'' +
                 '}';

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnCreate.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnCreate.java
@@ -71,22 +71,22 @@ public class DsnCreate {
     /**
      * Creates a new dataset with specified parameters
      *
-     * @param dataSetName     name of a dataset to create (e.g. 'DATASET.LIB')
+     * @param datasetName     name of a dataset to create (e.g. 'DATASET.LIB')
      * @param createInputData to create dataset parameters, see DsnCreateInputData object
      * @return http response object
      * @throws ZosmfRequestException request error state
      * @author Leonid Baranov
      */
-    public Response create(final String dataSetName, final DsnCreateInputData createInputData)
+    public Response create(final String datasetName, final DsnCreateInputData createInputData)
             throws ZosmfRequestException {
-        ValidateUtils.checkIllegalParameter(dataSetName, "dataSetName");
+        ValidateUtils.checkIllegalParameter(datasetName, "datasetName");
         ValidateUtils.checkNullParameter(createInputData, "createInputData");
 
         final String url = connection.getZosmfUrl() +
                 ZosFilesConstants.RESOURCE +
                 ZosFilesConstants.RES_DS_FILES +
                 UrlConstants.URL_PATH_DELIM +
-                EncodeUtils.encodeURIComponent(dataSetName);
+                EncodeUtils.encodeURIComponent(datasetName);
 
         final Map<String, Object> createMap = new HashMap<>();
         createInputData.getVolser().ifPresent(v -> createMap.put("volser", v));

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnGet.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnGet.java
@@ -79,16 +79,16 @@ public class DsnGet {
     /**
      * Retrieve dataset information.
      *
-     * @param dataSetName sequential or partition dataset (e.g. 'DATASET.LIB')
+     * @param datasetName sequential or partition dataset (e.g. 'DATASET.LIB')
      * @return dataset object
      * @throws ZosmfRequestException request error state
      * @author Frank Giordano
      */
-    public Dataset getDsnInfo(final String dataSetName) throws ZosmfRequestException {
-        ValidateUtils.checkNullParameter(dataSetName, "dataSetName");
-        ValidateUtils.checkIllegalParameter(dataSetName.isBlank(), "dataSetName not specified");
+    public Dataset getDsnInfo(final String datasetName) throws ZosmfRequestException {
+        ValidateUtils.checkNullParameter(datasetName, "datasetName");
+        ValidateUtils.checkIllegalParameter(datasetName.isBlank(), "datasetName not specified");
 
-        final String[] tokens = dataSetName.split("\\.");
+        final String[] tokens = datasetName.split("\\.");
         final int length = tokens.length - 1;
         if (1 >= length) {
             throw new IllegalArgumentException("invalid dataset name");
@@ -103,7 +103,7 @@ public class DsnGet {
         final DsnListInputData listInputData = new DsnListInputData.Builder().attribute(AttributeType.BASE).build();
         final List<Dataset> dsLst = dsnList.getDatasets(dataSetSearchStr, listInputData);
 
-        Predicate<Dataset> isExactMatch = d -> dataSetName.equals(d.getDsname());
+        Predicate<Dataset> isExactMatch = d -> datasetName.equals(d.getDsname());
         final Optional<Dataset> dataSet = dsLst.stream().filter(isExactMatch).findFirst();
         return dataSet.orElseThrow(() -> new ZosmfRequestException("dataset not found"));
     }

--- a/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnWrite.java
+++ b/src/main/java/zowe/client/sdk/zosfiles/dsn/methods/DsnWrite.java
@@ -67,39 +67,39 @@ public class DsnWrite {
      * Replaces the content of a member of a partitioned data set (PDS or PDSE) with new content.
      * A new dataset member will be created if the specified dataset member does not exist.
      *
-     * @param dataSetName dataset name of where the member is located (e.g. 'DATASET.LIB')
+     * @param datasetName dataset name of where the member is located (e.g. 'DATASET.LIB')
      * @param memberName  name of member to add new content
      * @param content     new content
      * @return http response object
      * @throws ZosmfRequestException request error state
      * @author Frank Giordano
      */
-    public Response write(final String dataSetName, final String memberName, final String content)
+    public Response write(final String datasetName, final String memberName, final String content)
             throws ZosmfRequestException {
-        ValidateUtils.checkIllegalParameter(dataSetName, "dataSetName");
+        ValidateUtils.checkIllegalParameter(datasetName, "datasetName");
         ValidateUtils.checkIllegalParameter(memberName, "memberName");
 
-        return write(String.format("%s(%s)", dataSetName, memberName), content);
+        return write(String.format("%s(%s)", datasetName, memberName), content);
     }
 
     /**
      * Replaces the content of an existing sequential data set with new content.
      *
-     * @param dataSetName sequential dataset (e.g. 'DATASET.LIB')
+     * @param datasetName sequential dataset (e.g. 'DATASET.LIB')
      * @param content     new content
      * @return http response object
      * @throws ZosmfRequestException request error state
      * @author Leonid Baranov
      */
-    public Response write(final String dataSetName, final String content) throws ZosmfRequestException {
-        ValidateUtils.checkIllegalParameter(dataSetName, "dataSetName");
+    public Response write(final String datasetName, final String content) throws ZosmfRequestException {
+        ValidateUtils.checkIllegalParameter(datasetName, "datasetName");
         ValidateUtils.checkNullParameter(content, "content");
 
         final String url = connection.getZosmfUrl() +
                 ZosFilesConstants.RESOURCE +
                 ZosFilesConstants.RES_DS_FILES +
                 UrlConstants.URL_PATH_DELIM +
-                EncodeUtils.encodeURIComponent(dataSetName);
+                EncodeUtils.encodeURIComponent(datasetName);
 
         request.setUrl(url);
         request.setBody(content);

--- a/src/main/java/zowe/client/sdk/zosjobs/methods/JobGet.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/methods/JobGet.java
@@ -219,7 +219,8 @@ public class JobGet {
         List<Job> jobs = new ArrayList<>();
 
         url = connection.getZosmfUrl() +
-                JobsConstants.RESOURCE + UrlConstants.QUERY_ID;
+                JobsConstants.RESOURCE +
+                UrlConstants.QUERY_ID;
 
         if (getInputData != null) {
             if (getInputData.getOwner().isPresent()) {
@@ -478,7 +479,8 @@ public class JobGet {
         ValidateUtils.checkIllegalParameter(commonInputData.getJobName().isEmpty(), JobsConstants.JOB_NAME_ILLEGAL_MSG);
         ValidateUtils.checkIllegalParameter(commonInputData.getJobId().isEmpty(), JobsConstants.JOB_ID_ILLEGAL_MSG);
 
-        url = connection.getZosmfUrl() + JobsConstants.RESOURCE +
+        url = connection.getZosmfUrl() +
+                JobsConstants.RESOURCE +
                 UrlConstants.URL_PATH_DELIM +
                 EncodeUtils.encodeURIComponent(commonInputData.getJobName().get()) +
                 UrlConstants.URL_PATH_DELIM +

--- a/src/main/java/zowe/client/sdk/zosmfauth/input/PasswordInputData.java
+++ b/src/main/java/zowe/client/sdk/zosmfauth/input/PasswordInputData.java
@@ -89,8 +89,8 @@ public class PasswordInputData {
     public String toString() {
         return "PasswordInputData{" +
                 "userId='" + userId + '\'' +
-                ", oldPwd='" + oldPwd + '\'' +
-                ", newPwd='" + newPwd + '\'' +
+                ", oldPwd='" + ((oldPwd == null || oldPwd.isEmpty()) ? "" : "*****") + '\'' +
+                ", newPwd='" + ((newPwd == null || newPwd.isEmpty()) ? "" : "*****") + '\'' +
                 '}';
     }
 

--- a/src/main/java/zowe/client/sdk/zosuss/README.md
+++ b/src/main/java/zowe/client/sdk/zosuss/README.md
@@ -23,6 +23,27 @@ An example for setting the system property is as follows:
 
 Alternatively, the property can be specified when launching the JVM.
 
+## SSH Exec Channel Environment Profile  
+
+The SSH exec channel used by UssCmd does not automatically load the user's shell profile. As a result,
+environment variables, aliases, and other shell configuration settings defined in files such as /etc/profile
+or ~/.profile may not be available when executing commands remotely.  
+
+If a command requires settings from the user's shell environment, the command string should source the appropriate
+profile files before execution.  
+  
+Example:  
+
+    // The SSH "exec" channel does not load the user's shell profile.
+    // Source the profile before executing the requested command.
+    command = "[ -f /etc/profile ] && . /etc/profile 2>/dev/null; " +
+    "[ -f ~/.profile ] && . ~/.profile 2>/dev/null; " +
+    command;  
+
+This ensures that required environment settings are loaded before the USS command is executed. Applications should
+only source profile files when those environment settings are required, as profile scripts may contain user-specific
+logic or commands that are not intended for non-interactive execution.  
+  
 ## API Example
 
 ````java

--- a/src/main/java/zowe/client/sdk/zosuss/README.md
+++ b/src/main/java/zowe/client/sdk/zosuss/README.md
@@ -6,16 +6,16 @@ API located in the method package.
 
 ## SSH Host Key Verification
 
-UssCmd verifies the target z/OS host's SSH host key against the current user's default known_hosts file inside their 
+UssCmd verifies the target z/OS host's SSH host key against the current user's default known_hosts file inside their
 home directory ({.ssh/known_hosts}, e.g., {~/.ssh/known_hosts} on Unix or {%USERPROFILE%\.ssh\known_hosts} on Windows)
-and rejects unknown or changed host keys (StrictHostKeyChecking=yes). This means the host's key
-must already be present in that file before `issueCommand` will succeed - for example, by connecting once with a
-standard ssh client, or via `ssh-keyscan`, to populate the entry.
+and rejects unknown or changed host keys (StrictHostKeyChecking=yes). This means the host's key must already be present
+in that file before `issueCommand` will succeed - for example, by connecting once with a standard ssh client, or via
+`ssh-keyscan`, to populate the entry.
 
 If host key verification cannot be satisfied and the risk is understood, set the system property
 `zowe.sdk.allow.insecure.connection` to `true` (the same opt-in used elsewhere in the SDK for insecure TLS processing)
 to fall back to StrictHostKeyChecking=no. Doing so allows any host key, including one presented by a man-in-the-middle
-attacker, and is logged as a warning each time it is used.  
+attacker, and is logged as a warning each time it is used.
 
 An example for setting the system property is as follows:
 
@@ -23,16 +23,16 @@ An example for setting the system property is as follows:
 
 Alternatively, the property can be specified when launching the JVM.
 
-## SSH Exec Channel Environment Profile  
+## SSH Exec Channel Environment Profile
 
-The SSH exec channel used by UssCmd does not automatically load the user's shell profile. As a result,
-environment variables, aliases, and other shell configuration settings defined in files such as /etc/profile
-or ~/.profile may not be available when executing commands remotely.  
+The SSH exec channel used by UssCmd does not automatically load the user's shell profile. As a result, environment
+variables, aliases, and other shell configuration settings defined in files such as /etc/profile or ~/.profile may not
+be available when executing commands remotely.
 
 If a command requires settings from the user's shell environment, the command string should source the appropriate
-profile files before execution.  
-  
-Example:  
+profile files before execution.
+
+Example:
 
     // The SSH "exec" channel does not load the user's shell profile.
     // Source the profile before executing the requested command.
@@ -40,10 +40,10 @@ Example:
     "[ -f ~/.profile ] && . ~/.profile 2>/dev/null; " +
     command;  
 
-This ensures that required environment settings are loaded before the USS command is executed. Applications should
-only source profile files when those environment settings are required, as profile scripts may contain user-specific
-logic or commands that are not intended for non-interactive execution.  
-  
+This ensures that required environment settings are loaded before the USS command is executed. Applications should only
+source profile files when those environment settings are required, as profile scripts may contain user-specific logic or
+commands that are not intended for non-interactive execution.
+
 ## API Example
 
 ````java

--- a/src/main/java/zowe/client/sdk/zosuss/README.md
+++ b/src/main/java/zowe/client/sdk/zosuss/README.md
@@ -6,15 +6,22 @@ API located in the method package.
 
 ## SSH Host Key Verification
 
-UssCmd verifies the target z/OS host's SSH host key against the current user's default known_hosts file
-(`~/.ssh/known_hosts`) and rejects unknown or changed host keys (StrictHostKeyChecking=yes). This means the host's key
+UssCmd verifies the target z/OS host's SSH host key against the current user's default known_hosts file inside their 
+home directory ({.ssh/known_hosts}, e.g., {~/.ssh/known_hosts} on Unix or {%USERPROFILE%\.ssh\known_hosts} on Windows)
+and rejects unknown or changed host keys (StrictHostKeyChecking=yes). This means the host's key
 must already be present in that file before `issueCommand` will succeed - for example, by connecting once with a
 standard ssh client, or via `ssh-keyscan`, to populate the entry.
 
 If host key verification cannot be satisfied and the risk is understood, set the system property
 `zowe.sdk.allow.insecure.connection` to `true` (the same opt-in used elsewhere in the SDK for insecure TLS processing)
 to fall back to StrictHostKeyChecking=no. Doing so allows any host key, including one presented by a man-in-the-middle
-attacker, and is logged as a warning each time it is used.
+attacker, and is logged as a warning each time it is used.  
+
+An example for setting the system property is as follows:
+
+    System.setProperty("zowe.sdk.allow.insecure.connection`", "true");
+
+Alternatively, the property can be specified when launching the JVM.
 
 ## API Example
 

--- a/src/main/java/zowe/client/sdk/zosuss/README.md
+++ b/src/main/java/zowe/client/sdk/zosuss/README.md
@@ -4,6 +4,18 @@ Contains API to execute USS (Unix System Serves) commands via SSH connection.
 
 API located in the method package.
 
+## SSH Host Key Verification
+
+UssCmd verifies the target z/OS host's SSH host key against the current user's default known_hosts file
+(`~/.ssh/known_hosts`) and rejects unknown or changed host keys (StrictHostKeyChecking=yes). This means the host's key
+must already be present in that file before `issueCommand` will succeed - for example, by connecting once with a
+standard ssh client, or via `ssh-keyscan`, to populate the entry.
+
+If host key verification cannot be satisfied and the risk is understood, set the system property
+`zowe.sdk.allow.insecure.connection` to `true` (the same opt-in used elsewhere in the SDK for insecure TLS processing)
+to fall back to StrictHostKeyChecking=no. Doing so allows any host key, including one presented by a man-in-the-middle
+attacker, and is logged as a warning each time it is used.
+
 ## API Example
 
 ````java

--- a/src/main/java/zowe/client/sdk/zosuss/method/UssCmd.java
+++ b/src/main/java/zowe/client/sdk/zosuss/method/UssCmd.java
@@ -83,9 +83,27 @@ public class UssCmd {
              final ManagedSession session = new ManagedSession(connection, timeout);
              final ManagedChannel channel = new ManagedChannel(session.get(), command, responseStream)) {
 
-            // Wait for channel execution to complete
-            while (channel.get().isConnected()) {
-                WaitUtil.wait(1000);
+            final long startTime = System.currentTimeMillis();
+
+            // loop checks isClosed() to catch normal process completion
+            while (!channel.get().isClosed()) {
+                WaitUtil.wait(100);
+
+                // protect against network hangs or stuck processes
+                if ((System.currentTimeMillis() - startTime) > timeout) {
+                    throw new UssCmdException(
+                            "Command execution timed out after " + timeout + " ms",
+                            new java.util.concurrent.TimeoutException("SSH execution limit exceeded.")
+                    );
+                }
+            }
+
+            // verify the remote shell actually finished cleanly
+            if (channel.get().getExitStatus() == -1 && !channel.get().isConnected()) {
+                throw new UssCmdException(
+                        "Network connection lost during command execution.",
+                        new java.io.IOException("Remote SSH peer disconnected unexpectedly.")
+                );
             }
 
             return responseStream.toString();

--- a/src/main/java/zowe/client/sdk/zosuss/method/UssCmd.java
+++ b/src/main/java/zowe/client/sdk/zosuss/method/UssCmd.java
@@ -31,10 +31,12 @@ import java.util.Properties;
  * UssCmd Class provides a way to execute USS commands via ssh connection
  * <p>
  * The underlying SSH session verifies the z/OS host's SSH host key against the current user's
- * default known_hosts file ({@code ~/.ssh/known_hosts}) and rejects unknown or changed host keys
- * (StrictHostKeyChecking=yes). This means the target host's key must already be present in that
- * known_hosts file (for example, by connecting once with a standard ssh client, or via
- * {@code ssh-keyscan}) before {@link #issueCommand(String, int)} will succeed.
+ * default known_hosts file inside their home directory ({@code .ssh/known_hosts}, e.g.,
+ * {@code ~/.ssh/known_hosts} on Unix or {@code %USERPROFILE%\.ssh\known_hosts} on Windows)
+ * and rejects unknown or changed host keys (StrictHostKeyChecking=yes). This means the
+ * target host's key must already be present in that known_hosts file (for example, by
+ * connecting once with a standard ssh client, or via {@code ssh-keyscan}) before
+ * {@link #issueCommand(String, int)} will succeed.
  * <p>
  * If host key verification cannot be satisfied and the risk is understood, set the system property
  * "zowe.sdk.allow.insecure.connection" to {@code true} (the same opt-in used elsewhere in the SDK for
@@ -63,10 +65,12 @@ public class UssCmd {
     /**
      * Executes USS command(s) specified within a string value
      * <p>
-     * The SSH host key of the target system must already be present in the current user's
-     * {@code ~/.ssh/known_hosts} file, or this call fails with a JSchException wrapped in
-     * UssCmdException (host key verification is enabled by default; see the class-level javadoc for
-     * the "zowe.sdk.allow.insecure.connection" opt-out).
+     * The SSH host key of the target system must already be present in the SSH host key against
+     * the current user's default known_hosts file inside their home directory ({@code .ssh/known_hosts},
+     * e.g., {@code ~/.ssh/known_hosts} on Unix or {@code %USERPROFILE%\.ssh\known_hosts} on Windows),
+     * or this call fails with a JSchException wrapped in UssCmdException with a message like:
+     * 'reject HostKey'. The host key verification is enabled by default; see the class-level Javadoc
+     * for the "zowe.sdk.allow.insecure.connection" opt-out.
      *
      * @param command string value contains one or more USS commands
      * @param timeout int value in milliseconds for timeout duration on session connection

--- a/src/main/java/zowe/client/sdk/zosuss/method/UssCmd.java
+++ b/src/main/java/zowe/client/sdk/zosuss/method/UssCmd.java
@@ -13,23 +13,40 @@ import com.jcraft.jsch.ChannelExec;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import zowe.client.sdk.core.SshConnection;
+import zowe.client.sdk.rest.RestConstant;
 import zowe.client.sdk.utility.ValidateUtils;
 import zowe.client.sdk.utility.WaitUtil;
 import zowe.client.sdk.zosuss.exception.UssCmdException;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Properties;
 
 /**
  * UssCmd Class provides a way to execute USS commands via ssh connection
+ * <p>
+ * The underlying SSH session verifies the z/OS host's SSH host key against the current user's
+ * default known_hosts file ({@code ~/.ssh/known_hosts}) and rejects unknown or changed host keys
+ * (StrictHostKeyChecking=yes). This means the target host's key must already be present in that
+ * known_hosts file (for example, by connecting once with a standard ssh client, or via
+ * {@code ssh-keyscan}) before {@link #issueCommand(String, int)} will succeed.
+ * <p>
+ * If host key verification cannot be satisfied and the risk is understood, set the system property
+ * "zowe.sdk.allow.insecure.connection" to {@code true} (the same opt-in used elsewhere in the SDK for
+ * insecure TLS processing) to fall back to StrictHostKeyChecking=no. Doing so allows any host key,
+ * including one presented by a man-in-the-middle attacker, and logs a warning each time it is used.
  *
  * @author Frank Giordano
  * @version 7.0
  */
 public class UssCmd {
+
+    private static final Logger LOG = LoggerFactory.getLogger(UssCmd.class);
 
     private final SshConnection connection;
 
@@ -45,6 +62,11 @@ public class UssCmd {
 
     /**
      * Executes USS command(s) specified within a string value
+     * <p>
+     * The SSH host key of the target system must already be present in the current user's
+     * {@code ~/.ssh/known_hosts} file, or this call fails with a JSchException wrapped in
+     * UssCmdException (host key verification is enabled by default; see the class-level javadoc for
+     * the "zowe.sdk.allow.insecure.connection" opt-out).
      *
      * @param command string value contains one or more USS commands
      * @param timeout int value in milliseconds for timeout duration on session connection
@@ -70,16 +92,36 @@ public class UssCmd {
 
     /**
      * AutoCloseable wrapper for JSch Session
+     * <p>
+     * Verifies the remote host's SSH key against the current user's default known_hosts file
+     * ({@code ~/.ssh/known_hosts}) via StrictHostKeyChecking=yes, so an unknown or changed host key
+     * (a possible man-in-the-middle) causes connect() to fail rather than being silently accepted.
+     * Set the "zowe.sdk.allow.insecure.connection" system property to {@code true} to bypass this
+     * check (StrictHostKeyChecking=no); doing so is logged as a warning.
      */
     static class ManagedSession implements AutoCloseable {
+
+        private static final String DEFAULT_KNOWN_HOSTS_PATH =
+                System.getProperty("user.home") + File.separator + ".ssh" + File.separator + "known_hosts";
+
         private final Session session;
 
         ManagedSession(final SshConnection connection, final int timeout) throws JSchException {
-            this.session = new JSch().getSession(connection.getUser(), connection.getHost(), connection.getPort());
+            final JSch jsch = new JSch();
+            jsch.setKnownHosts(DEFAULT_KNOWN_HOSTS_PATH);
+            this.session = jsch.getSession(connection.getUser(), connection.getHost(), connection.getPort());
             session.setPassword(connection.getPassword());
             final Properties config = new Properties();
-            config.put("StrictHostKeyChecking", "no");
             config.put("PreferredAuthentications", "password");
+            final boolean inSecure = Boolean.parseBoolean(
+                    System.getProperty(RestConstant.INSECURE_PROPERTY_NAME, "false"));
+            if (inSecure) {
+                LOG.warn("{} is enabled; SSH host key verification is disabled for this connection",
+                        RestConstant.INSECURE_PROPERTY_NAME);
+                config.put("StrictHostKeyChecking", "no");
+            } else {
+                config.put("StrictHostKeyChecking", "yes");
+            }
             session.setConfig(config);
             session.connect(timeout);
         }

--- a/src/test/java/zowe/client/sdk/core/SshConnectionTest.java
+++ b/src/test/java/zowe/client/sdk/core/SshConnectionTest.java
@@ -106,8 +106,6 @@ public class SshConnectionTest {
     void tstSshConnectionsMaskPasswordSuccess() {
         final SshConnection conn = new SshConnection("test", 1, "user", "password");
         String result = conn.toString();
-        System.out.println(result);
-
         assertTrue(result.contains("password='*****'"));
     }
 

--- a/src/test/java/zowe/client/sdk/core/ZosConnectionTest.java
+++ b/src/test/java/zowe/client/sdk/core/ZosConnectionTest.java
@@ -62,7 +62,6 @@ class ZosConnectionTest {
         final ZosConnection conn = ZosConnectionFactory
                 .createBasicConnection("zos", 443, "user", "pass", "/zosmf");
         String result = conn.toString();
-        System.out.println(result);
 
         assertTrue(result.contains("password='*****'"));
         assertTrue(result.contains("certPassword=''"));
@@ -103,7 +102,6 @@ class ZosConnectionTest {
         final ZosConnection conn = ZosConnectionFactory
                 .createTokenConnection("host1", 443, cookie);
         String result = conn.toString();
-        System.out.println(result);
 
         assertTrue(result.contains("host='host1'"));
         assertTrue(result.contains("zosmfPort='443'"));
@@ -175,7 +173,6 @@ class ZosConnectionTest {
         final ZosConnection conn = ZosConnectionFactory
                 .createSslConnection("host1", 443, "/certs/certA.p12", "certpass");
         String result = conn.toString();
-        System.out.println(result);
 
         assertTrue(result.contains("host='host1'"));
         assertTrue(result.contains("zosmfPort='443'"));

--- a/src/test/java/zowe/client/sdk/rest/ZoweRequestTest.java
+++ b/src/test/java/zowe/client/sdk/rest/ZoweRequestTest.java
@@ -168,6 +168,72 @@ public class ZoweRequestTest {
     }
 
     @Test
+    public void tstZoweRequestInitializeSslSetupInsecureCertPasswordSuccess() {
+        System.setProperty(RestConstant.INSECURE_PROPERTY_NAME, "true");
+        try {
+            final ZosConnection connection = ZosConnectionFactory.createSslConnection("hostInsecure", 443,
+                    "src/test/resources/certs/badssl.com-client.p12", "badssl.com");
+            ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
+        } catch (Exception e) {
+            fail(e);
+        } finally {
+            System.clearProperty(RestConstant.INSECURE_PROPERTY_NAME);
+        }
+    }
+
+    @Test
+    public void tstZoweRequestInitializeSslSetupInsecureCertPasswordFailure() {
+        System.setProperty(RestConstant.INSECURE_PROPERTY_NAME, "true");
+        try {
+            final ZosConnection connection = ZosConnectionFactory.createSslConnection("hostInsecureFail", 443,
+                    "src/test/resources/certs/badssl.com-client.p12", "dummy");
+            final String errMsg = "keystore password was incorrect";
+            try {
+                ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
+            } catch (Exception e) {
+                assertTrue(e.getMessage().contains(errMsg));
+            }
+        } finally {
+            System.clearProperty(RestConstant.INSECURE_PROPERTY_NAME);
+        }
+    }
+
+    @Test
+    public void tstZoweRequestInitializeSslSetupCustomTrustStoreSuccess() {
+        System.setProperty(RestConstant.TRUSTSTORE_PATH_PROPERTY_NAME, "src/test/resources/certs/badssl.com-client.p12");
+        System.setProperty(RestConstant.TRUSTSTORE_PASSWORD_PROPERTY_NAME, "badssl.com");
+        try {
+            final ZosConnection connection = ZosConnectionFactory.createSslConnection("hostTrustStore", 443,
+                    "src/test/resources/certs/badssl.com-client.p12", "badssl.com");
+            ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
+        } catch (Exception e) {
+            fail(e);
+        } finally {
+            System.clearProperty(RestConstant.TRUSTSTORE_PATH_PROPERTY_NAME);
+            System.clearProperty(RestConstant.TRUSTSTORE_PASSWORD_PROPERTY_NAME);
+        }
+    }
+
+    @Test
+    public void tstZoweRequestInitializeSslSetupCustomTrustStoreFailure() {
+        System.setProperty(RestConstant.TRUSTSTORE_PATH_PROPERTY_NAME, "src/test/resources/certs/badssl.com-client.p12");
+        System.setProperty(RestConstant.TRUSTSTORE_PASSWORD_PROPERTY_NAME, "wrongpassword");
+        try {
+            final ZosConnection connection = ZosConnectionFactory.createSslConnection("hostTrustStoreFail", 443,
+                    "src/test/resources/certs/badssl.com-client.p12", "badssl.com");
+            final String errMsg = "keystore password was incorrect";
+            try {
+                ZosmfRequestFactory.buildRequest(connection, ZosmfRequestType.PUT_JSON);
+            } catch (Exception e) {
+                assertTrue(e.getMessage().contains(errMsg));
+            }
+        } finally {
+            System.clearProperty(RestConstant.TRUSTSTORE_PATH_PROPERTY_NAME);
+            System.clearProperty(RestConstant.TRUSTSTORE_PASSWORD_PROPERTY_NAME);
+        }
+    }
+
+    @Test
     public void tstZoweRequestInitializeBasicSetupSuccess() {
         final ZosConnection connection = ZosConnectionFactory
                 .createBasicConnection("host", 443, "user", "password");

--- a/src/test/java/zowe/client/sdk/teamconfig/KeyTarConfigTest.java
+++ b/src/test/java/zowe/client/sdk/teamconfig/KeyTarConfigTest.java
@@ -1,0 +1,92 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.teamconfig;
+
+import org.junit.jupiter.api.Test;
+import zowe.client.sdk.teamconfig.keytar.KeyTarConfig;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Class containing unit test for KeyTarConfig.
+ *
+ * @author Frank Giordano
+ * @version 7.0
+ */
+public class KeyTarConfigTest {
+
+    @Test
+    void tstCreateKeyTarConfigSuccess() {
+        KeyTarConfig config = new KeyTarConfig(
+                "/tmp/team_config.json",
+                "USER1",
+                "PASSWORD",
+                "keytar-store");
+
+        assertEquals("/tmp/team_config.json", config.getLocation());
+        assertEquals("USER1", config.getUser());
+        assertEquals("USER1", config.getUserName());
+        assertEquals("PASSWORD", config.getPassword());
+        assertEquals("keytar-store", config.getStoreName());
+    }
+
+    @Test
+    void tstReturnToStringWithMaskedPasswordSuccess() {
+        KeyTarConfig config = new KeyTarConfig(
+                "/tmp/team_config.json",
+                "USER1",
+                "PASSWORD",
+                "keytar-store");
+
+        assertEquals(
+                "KeyTarConfig{location='/tmp/team_config.json', userName='USER1', password='*****'}",
+                config.toString());
+    }
+
+    @Test
+    void tstReturnToStringWithEmptyPasswordSuccess() {
+        KeyTarConfig config = new KeyTarConfig(
+                "/tmp/team_config.json",
+                "USER1",
+                "",
+                "keytar-store");
+
+        assertEquals(
+                "KeyTarConfig{location='/tmp/team_config.json', userName='USER1', password=''}",
+                config.toString());
+    }
+
+    @Test
+    void tstReturnToStringWithNullPasswordSuccess() {
+        KeyTarConfig config = new KeyTarConfig(
+                "/tmp/team_config.json",
+                "USER1",
+                null,
+                "keytar-store");
+
+        assertEquals(
+                "KeyTarConfig{location='/tmp/team_config.json', userName='USER1', password=''}",
+                config.toString());
+    }
+
+    @Test
+    void tstReturnToStringWithNullUserNameSuccess() {
+        KeyTarConfig config = new KeyTarConfig(
+                "/tmp/team_config.json",
+                null,
+                "PASSWORD",
+                "keytar-store");
+
+        assertEquals(
+                "KeyTarConfig{location='/tmp/team_config.json', userName='', password='*****'}",
+                config.toString());
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/teamconfig/keytar/KeyTarConfigTest.java
+++ b/src/test/java/zowe/client/sdk/teamconfig/keytar/KeyTarConfigTest.java
@@ -7,10 +7,9 @@
  *
  * Copyright Contributors to the Zowe Project.
  */
-package zowe.client.sdk.teamconfig;
+package zowe.client.sdk.teamconfig.keytar;
 
 import org.junit.jupiter.api.Test;
-import zowe.client.sdk.teamconfig.keytar.KeyTarConfig;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/src/test/java/zowe/client/sdk/teamconfig/keytar/KeyTarImplTest.java
+++ b/src/test/java/zowe/client/sdk/teamconfig/keytar/KeyTarImplTest.java
@@ -7,12 +7,10 @@
  *
  * Copyright Contributors to the Zowe Project.
  */
-package zowe.client.sdk.teamconfig;
+package zowe.client.sdk.teamconfig.keytar;
 
 import org.junit.jupiter.api.Test;
 import zowe.client.sdk.teamconfig.exception.TeamConfigException;
-import zowe.client.sdk.teamconfig.keytar.KeyTarConfig;
-import zowe.client.sdk.teamconfig.keytar.KeyTarImpl;
 
 import java.util.List;
 

--- a/src/test/java/zowe/client/sdk/teamconfig/model/ProfileDaoTest.java
+++ b/src/test/java/zowe/client/sdk/teamconfig/model/ProfileDaoTest.java
@@ -1,0 +1,118 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.teamconfig.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+
+/**
+ * Class containing unit test for ProfileDao.
+ *
+ * @author Frank Giordano
+ * @version 7.0
+ */
+public class ProfileDaoTest {
+
+    @Test
+    void tstCreateProfileDaoSuccess() {
+        Profile profile = createProfile();
+
+        ProfileDao dao = new ProfileDao(
+                profile,
+                "USER1",
+                "PASSWORD",
+                "zos.example.com",
+                "443");
+
+        assertSame(profile, dao.getProfile());
+        assertEquals("USER1", dao.getUser());
+        assertEquals("PASSWORD", dao.getPassword());
+        assertEquals("zos.example.com", dao.getHost());
+        assertEquals("443", dao.getPort());
+    }
+
+    @Test
+    void tstReturnToStringWithMaskedPasswordSuccess() {
+        Profile profile = createProfile();
+
+        ProfileDao dao = new ProfileDao(
+                profile,
+                "USER1",
+                "PASSWORD",
+                "zos.example.com",
+                "443");
+
+        assertEquals(
+                "ProfileDao{profile=" + profile +
+                        ", user='USER1', password='*****', host='zos.example.com', port='443'}",
+                dao.toString());
+    }
+
+    @Test
+    void tstReturnToStringWithEmptyPasswordSuccess() {
+        Profile profile = createProfile();
+
+        ProfileDao dao = new ProfileDao(
+                profile,
+                "USER1",
+                "",
+                "zos.example.com",
+                "443");
+
+        assertEquals(
+                "ProfileDao{profile=" + profile +
+                        ", user='USER1', password='', host='zos.example.com', port='443'}",
+                dao.toString());
+    }
+
+    @Test
+    void tstReturnToStringWithNullPasswordSuccess() {
+        Profile profile = createProfile();
+
+        ProfileDao dao = new ProfileDao(
+                profile,
+                "USER1",
+                null,
+                "zos.example.com",
+                "443");
+
+        assertEquals(
+                "ProfileDao{profile=" + profile +
+                        ", user='USER1', password='', host='zos.example.com', port='443'}",
+                dao.toString());
+    }
+
+    @Test
+    void tstReturnToStringWithNullUserSuccess() {
+        Profile profile = createProfile();
+
+        ProfileDao dao = new ProfileDao(
+                profile,
+                null,
+                "PASSWORD",
+                "zos.example.com",
+                "443");
+
+        assertEquals(
+                "ProfileDao{profile=" + profile +
+                        ", user='', password='*****', host='zos.example.com', port='443'}",
+                dao.toString());
+    }
+
+    private Profile createProfile() {
+        return new Profile("name", "type", null, List.of("1"));
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/teamconfig/service/TeamConfigServiceTest.java
+++ b/src/test/java/zowe/client/sdk/teamconfig/service/TeamConfigServiceTest.java
@@ -7,14 +7,13 @@
  *
  * Copyright Contributors to the Zowe Project.
  */
-package zowe.client.sdk.teamconfig;
+package zowe.client.sdk.teamconfig.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import zowe.client.sdk.teamconfig.model.ConfigContainer;
 import zowe.client.sdk.teamconfig.model.Profile;
-import zowe.client.sdk.teamconfig.service.TeamConfigService;
 
 import java.lang.reflect.Method;
 import java.util.List;

--- a/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnGetTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnGetTest.java
@@ -284,7 +284,7 @@ public class DsnGetTest {
     public void tstGetDsnInfoBlankDatasetNameFailure() {
         final DsnGet dsnGet = new DsnGet(connection);
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> dsnGet.getDsnInfo(" "));
-        assertEquals("dataSetName not specified", ex.getMessage());
+        assertEquals("datasetName not specified", ex.getMessage());
     }
 
 }

--- a/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnUpdateTest.java
+++ b/src/test/java/zowe/client/sdk/zosfiles/dsn/methods/DsnUpdateTest.java
@@ -26,8 +26,6 @@ import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosfiles.dsn.input.DsnRenameInputData;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.*;
 
 /**

--- a/src/test/java/zowe/client/sdk/zosmfauth/input/PasswordInputDataTest.java
+++ b/src/test/java/zowe/client/sdk/zosmfauth/input/PasswordInputDataTest.java
@@ -1,0 +1,85 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package zowe.client.sdk.zosmfauth.input;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Class containing unit tests for PasswordInputData.
+ *
+ * @author Frank Giordano
+ * @version 7.0
+ */
+class PasswordInputDataTest {
+
+    @Test
+    void tstCreatePasswordInputDataSuccess() {
+        PasswordInputData input = new PasswordInputData(
+                "USER1",
+                "OLDPWD",
+                "NEWPWD");
+
+        assertEquals("USER1", input.getUserId());
+        assertEquals("OLDPWD", input.getOldPwd());
+        assertEquals("NEWPWD", input.getNewPwd());
+    }
+
+    @Test
+    void tstReturnToStringWithMaskedPasswordsSuccess() {
+        PasswordInputData input = new PasswordInputData(
+                "USER1",
+                "OLDPWD",
+                "NEWPWD");
+
+        assertEquals(
+                "PasswordInputData{userId='USER1', oldPwd='*****', newPwd='*****'}",
+                input.toString());
+    }
+
+    @Test
+    void tstThrowExceptionWhenUserIdIsNullFailure() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new PasswordInputData(null, "OLDPWD", "NEWPWD"));
+    }
+
+    @Test
+    void tstThrowExceptionWhenOldPasswordIsNullFailure() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new PasswordInputData("USER1", null, "NEWPWD"));
+    }
+
+    @Test
+    void tstThrowExceptionWhenNewPasswordIsNullFailure() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new PasswordInputData("USER1", "OLDPWD", null));
+    }
+
+    @Test
+    void tstThrowExceptionWhenUserIdIsEmptyFailure() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new PasswordInputData("", "OLDPWD", "NEWPWD"));
+    }
+
+    @Test
+    void tstThrowExceptionWhenOldPasswordIsEmptyFailure() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new PasswordInputData("USER1", "", "NEWPWD"));
+    }
+
+    @Test
+    void tstThrowExceptionWhenNewPasswordIsEmptyFailure() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new PasswordInputData("USER1", "OLDPWD", ""));
+    }
+
+}

--- a/src/test/java/zowe/client/sdk/zosuss/method/UssCmdTest.java
+++ b/src/test/java/zowe/client/sdk/zosuss/method/UssCmdTest.java
@@ -47,23 +47,25 @@ public class UssCmdTest {
 
     @Test
     public void tstIssueCommandReturnsOutputSuccess() throws Exception {
-        // Mock JSch Session and ChannelExec
         Session mockSession = mock(Session.class);
         ChannelExec mockChannel = mock(ChannelExec.class);
 
-        // Simulate channel disconnect after one loop
-        when(mockChannel.isConnected()).thenReturn(true, false);
+        when(mockChannel.isClosed()).thenReturn(false, true);
+        when(mockChannel.isConnected()).thenReturn(true);
+        when(mockChannel.getExitStatus()).thenReturn(0);
+
         when(mockSession.openChannel("exec")).thenReturn(mockChannel);
 
-        try (MockedConstruction<UssCmd.ManagedSession> ignored1 = Mockito.mockConstruction(UssCmd.ManagedSession.class,
-                (mock, context) -> when(mock.get()).thenReturn(mockSession));
-             MockedConstruction<UssCmd.ManagedChannel> ignored2 = Mockito.mockConstruction(UssCmd.ManagedChannel.class,
-                     (mock, context) -> {
-                         // Grab the real OutputStream passed in constructor
-                         OutputStream os = (OutputStream) context.arguments().get(2);
-                         os.write("mock output".getBytes());
-                         when(mock.get()).thenReturn(mockChannel);
-                     })) {
+        try (MockedConstruction<UssCmd.ManagedSession> ignored1 =
+                     Mockito.mockConstruction(UssCmd.ManagedSession.class,
+                             (mock, context) -> when(mock.get()).thenReturn(mockSession));
+             MockedConstruction<UssCmd.ManagedChannel> ignored2 =
+                     Mockito.mockConstruction(UssCmd.ManagedChannel.class,
+                             (mock, context) -> {
+                                 OutputStream os = (OutputStream) context.arguments().get(2);
+                                 os.write("mock output".getBytes());
+                                 when(mock.get()).thenReturn(mockChannel);
+                             })) {
 
             UssCmd cmd = new UssCmd(mockConnection);
             String result = cmd.issueCommand("echo test", 1000);


### PR DESCRIPTION
## Summary (And Release Notes Reference) 

This pull request prepares the **7.0.1** maintenance release of the Zowe Client Java SDK.

The release focuses on improving the overall quality, security, and reliability of the SDK without introducing new user-facing features. It primarily addresses issues identified through advanced security analysis, along with several minor robustness, correctness, and maintainability improvements throughout the codebase.

### Highlights

* Eliminated unnecessary mutation of shared Unirest configuration where possible.
* Resolved multiple security findings identified during automated code analysis.
* Improved reliability of SSH command execution, including enhanced timeout handling, detection of unexpected network disconnects and requiring known hosts file by default. 
* Corrected URL encoding in REST requests where required.
* Introduce custom TrustStore support for SSL connections.

Overall, version **7.0.1** is a maintenance release that strengthens the SDK's security posture and operational reliability.

There is a **minor breaking change** included in this release. This change does not affect any API methods or signatures. It is limited to error message formatting, where the keyword casing has changed in some cases from `"DataSet"` to `"dataset"`.

Summary of all issues resolved in this release:

#598 - Refactor StrictHostKeyChecking for Ssh connection processing.
#597 - Confine relaxed hostname verification to the Unirest client instance used by the SDK.
#594 - Clear out http headers in initialize method only within ZosmfRequest.
#593 - Remove verifySsl usage for basic and token authentication once the mutated Unirest implementation is removed.
#592 - Avoid mutating the global Unirest configuration.
#602 - Mask sensitive information.
#604 - UssCmd environments variables missing due to profile files not loading in ChannelExec
#605 - Prevent infinite thread block in UssCmd loop during network drop
#606 - Clarify TLS certificate validation options and introduce custom TrustStore support for SSL connections
#607 - Global Unirest Configuration Broke Connection Isolation


