### PR TITLE
fix: encode jobId in JobGet#getJclCommon URL

### DIFF
--- a/src/main/java/zowe/client/sdk/zosjobs/methods/JobGet.java
+++ b/src/main/java/zowe/client/sdk/zosjobs/methods/JobGet.java
@@ -118,7 +118,7 @@ public class JobGet {
                 UrlConstants.URL_PATH_DELIM +
                 EncodeUtils.encodeURIComponent(commonInputData.getJobName().get()) +
                 UrlConstants.URL_PATH_DELIM +
-                commonInputData.getJobId().get() +
+                EncodeUtils.encodeURIComponent(commonInputData.getJobId().get()) +
                 JobsConstants.RESOURCE_SPOOL_FILES +
                 JobsConstants.RESOURCE_JCL_CONTENT +
                 JobsConstants.RESOURCE_SPOOL_CONTENT;


### PR DESCRIPTION
## Summary

Encode `jobId` using `EncodeUtils.encodeURIComponent()` when constructing the URL in `JobGet#getJclCommon()`.

Fixes #595.

## Testing

- Ran `mvn clean test`
- All tests passed (1191 tests, 0 failures)