### PR TITLE
With 7.0.1 release - Basic connection does not work on untrusted z/OSMF server. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,82 +168,66 @@ and the JSON error report document body response is:
     {"rc":4,"reason":13,"category":1,"message":"query parm dslevel= or volser= must be specified"} 
 
 ## Authenticating to z/OSMF
-  
-Since the release of the SDK, the authentication of each REST API call is done with BASIC authentication.
-  
-With SDK release version 3, Web TOKEN authentication was added.   
-  
-With project version 4, SSL authentication from a certificate file was added.  
-  
-With three types of authentication available, the AuthType enum class was introduced to represent each type.    
-  
-This enum is used to send it to the ZosConnection constructor denoting the type of authentication to perform.  
 
-For BASIC, the following ZosConnection object is specified to perform BASIC authentication:
+All REST API calls to z/OSMF are transmitted over an **HTTPS** encrypted transport channel (TLS). The SDK supports three authentication types (`AuthType`) to prove client identity over that encrypted channel:
+
+- **BASIC (`AuthType.BASIC`)**: Authenticates client identity using a username and password sent in the HTTP `Authorization: Basic` header over HTTPS.
+- **TOKEN (`AuthType.TOKEN`)**: Authenticates client identity using an authentication token/cookie (e.g. JWT or LTPA token) retrieved via `zosmfLogin` over HTTPS.
+- **SSL (`AuthType.SSL`)**: Authenticates client identity via **Mutual TLS (mTLS)** using a PKCS12 (`.p12`) client certificate file containing the client's certificate and private key. No username or password is required because z/OSMF maps the client certificate directly to a mainframe security ID (RACF / ACF2 / Top Secret).
+
+### Client Authentication Examples
+
+For **BASIC** authentication, specify username and password:
 
 ```java
-ZosConnection connection = ZosConnectionFactory.createBasicConnection("host", "zosmfPort", "user", "password");
+ZosConnection connection = ZosConnectionFactory.createBasicConnection("host", 10443, "user", "password");
 ```
 
-Basic authentication means that the http request contains a BASIC header representing the username and password encrypted.
-
-For web TOKEN, the following ZosConnection object is specified:
+For **Web TOKEN** authentication, specify the token cookie:
 
 ```java 
-ZosConnection connection = ZosConnectionFactory.createTokenConnection("host", "port", new Cookie("xxx", "xxx"));
+ZosConnection connection = ZosConnectionFactory.createTokenConnection("host", 10443, new Cookie("xxx", "xxx"));
 ```
 
-With the zosmfauth package, ZosmfAuth provides an API (zosmfLogin) to retrieve authentication tokens (a JSON Web and an LTPA TOKEN) on a BASIC authentication request. This package contains an API that can also be used to delete the current store of JSON Web and LPTA tokens.
+With the `zosmfauth` package, `ZosmfAuth` provides an API (`zosmfLogin`) to retrieve authentication tokens (JSON Web and LTPA tokens) using a BASIC request. Web TOKEN support must be enabled on your z/OSMF system. See [README.md](https://github.com/zowe/zowe-client-java-sdk/blob/main/src/main/java/zowe/client/sdk/zosmfauth/README.md) in the `zosmfauth` package for further details and code examples.
 
-See the README.MD in the zosmfauth package for code examples on retrieving an initial token and then using it for further requests without needing user and password information.
-
-Web TOKEN support must be enabled on your z/OSMF system. For more information, see Enabling JSON Web TOKEN support in the IBM z/OS Management Facility Configuration Guide.
-
-See [README.md](https://github.com/zowe/zowe-client-java-sdk/blob/main/src/main/java/zowe/client/sdk/zosmfauth/README.md) in zosmfauth package for further details.
-
-For SSL/TLS client certificate authentication (mTLS), create a `ZosConnection` object using a PKCS12 (`.p12`) key store file:
+For **SSL/TLS Client Certificate Authentication (mTLS)**, create a `ZosConnection` object using a PKCS12 (`.p12`) key store file:
 
 ```java
-ZosConnection connection = ZosConnectionFactory.createSslConnection("host", 443, "c:/file.p12", "certpassword");
+ZosConnection connection = ZosConnectionFactory.createSslConnection("host", 10443, "c:/file.p12", "certpassword");
 ```
 
-The `.p12` file houses your client certificate and private key, which z/OSMF uses to authenticate your client application.
-
-For `certFilePath`, specify the location and file name of the `.p12` file. For `certPassword`, specify the password/passphrase for the key store.
+The `.p12` file houses your client certificate and private key, which z/OSMF uses to authenticate your client application without needing a username or password. For `certFilePath`, specify the location and file name of the `.p12` file. For `certPassword`, specify the password for the key store.
 
 ### Server Certificate Validation Modes
 
-When validating the z/OSMF server's SSL certificate during an SSL connection, the SDK supports three modes:
+During the HTTPS TLS handshake, Java validates the z/OSMF **server's SSL certificate**. Server certificate validation applies across all authentication types (`BASIC`, `TOKEN`, and `SSL`). The SDK supports three server certificate validation modes:
 
 **Default Mode (Standard Certificate Authority Validation)**
-  - **How it works**: By default (when no system properties are set), the SDK validates the z/OSMF server certificate against the JVM's standard CA truststore (`cacerts`) and enforces standard hostname verification.
-  - **When to use**: Production or standard enterprise environments where z/OSMF uses a certificate issued by a public CA or an enterprise Root CA installed in your Java runtime's `cacerts`.
-
+- **How it works**: By default (when no system properties are set), the SDK validates the z/OSMF server certificate against the JVM's standard CA truststore (`cacerts`) and enforces standard hostname verification. In many enterprise-managed environments, corporate CAs or public CAs are already pre-installed in Java's `cacerts` out-of-the-box, so no additional configuration is needed. If your corporate CA is installed only in the Windows Certificate Store and not in Java's `cacerts`, setting `-Djavax.net.ssl.trustStoreType=WINDOWS-ROOT` is an optional fallback to instruct Java to read the OS truststore.
+- **When to use**: Production or enterprise environments where z/OSMF uses a certificate issued by a public CA or an enterprise Root CA installed in your Java runtime's `cacerts` or Windows certificate store.
+  
 **Custom TrustStore (`zowe.sdk.truststore.path`)**
-  - **How it works**: To support self-signed z/OSMF servers securely without using `TRUST_ALL_CERTS`, the SDK allows users to specify a separate TrustStore file (`.p12` or `.jks`) that contains the server's certificate or CA, rather than reusing the client's mTLS `.p12` file (which contains client credentials). Set system property `zowe.sdk.truststore.path` to the path of the server TrustStore and optionally `zowe.sdk.truststore.password`. The SDK loads this TrustStore into a `TrustManagerFactory` to validate the server certificate against it while disabling hostname verification.
-  - **How to set**:    
-
+- **How it works**: To support self-signed z/OSMF servers securely without bypassing TLS validation, the SDK allows users to specify a separate TrustStore file (`.p12` or `.jks`) that contains the server's public certificate or CA. Set system property `zowe.sdk.truststore.path` to the path of the server TrustStore and optionally `zowe.sdk.truststore.password`. The SDK loads this TrustStore into a `TrustManagerFactory` to validate the server certificate against it while disabling hostname verification.
+- **How to set**:
 
     System.setProperty("zowe.sdk.truststore.path", "/path/to/server-truststore.p12");
     System.setProperty("zowe.sdk.truststore.password", "truststorePassword"); // Optional
-  
+
 Or via JVM launch argument: `-Dzowe.sdk.truststore.path=/path/to/server-truststore.p12`
 
-  - **When to use**: Staging, testing, or enterprise environments where z/OSMF uses a self-signed or internal CA certificate and you want strict certificate validation without modifying global JVM `cacerts` or disabling TLS verification.
+- **When to use**: Staging, testing, or enterprise environments where z/OSMF uses a self-signed or internal CA certificate and you want strict certificate validation without modifying global JVM `cacerts` or disabling TLS verification.
 
 **Insecure Mode (`zowe.sdk.allow.insecure.connection=true`)**
-  - **How it works**: Insecure mode is an explicit, optional developer opt-in (disabled by default) designed specifically to bypass server TLS certificate checks for self-signed test environments when users do not have the server certificate or CA in a truststore file. Setting system property `zowe.sdk.allow.insecure.connection` to `"true"` uses `TRUST_ALL_CERTS` to bypass server certificate validation (similar to `curl -k` or `git config http.sslVerify false`) and disables hostname verification. A prominent warning is logged on connection setup.
-  - **How to set**:  
+- **How it works**: Insecure mode is an explicit, optional developer opt-in (disabled by default) designed specifically to bypass server TLS certificate checks for self-signed test environments when users do not have the server certificate or CA in a truststore file. Setting system property `zowe.sdk.allow.insecure.connection` to `"true"` uses `TRUST_ALL_CERTS` to bypass server certificate validation (similar to `curl -k` or `git config http.sslVerify false`) and disables hostname verification. A prominent warning is logged on connection setup.
+- **How to set**:  
   
+     System.setProperty("zowe.sdk.allow.insecure.connection", "true");
 
-    System.setProperty("zowe.sdk.allow.insecure.connection", "true");
-  
 Or via JVM launch argument: `-Dzowe.sdk.allow.insecure.connection=true`
-  - **When to use**: Isolated test, local sandbox, or lab environments when connecting to self-signed z/OSMF servers without a truststore file.
+- **When to use**: Isolated test, local sandbox, or lab environments when connecting to self-signed z/OSMF servers without a truststore file.
 
-This same `zowe.sdk.allow.insecure.connection` system property also controls SSH host key verification for the zosuss package (see below). By default, both are verified/enforced; setting this property to `true` disables verification for both and is logged as a warning each time it happens, so only use it when the risk (a man-in-the-middle presenting a forged certificate or host key) is understood and accepted, such as in isolated test environments.
-
-BASIC and TOKEN authentication always verify the server's TLS certificate using the JVM's default trust store and have no insecure opt-out - self-signed certificates are only a concern for SSL (client-certificate) authentication, so the options above apply specifically to SSL authentication and SSH host key checking.
+This same `zowe.sdk.allow.insecure.connection` system property also controls SSH host key verification for the `zosuss` package (see below). By default, both are verified/enforced; setting this property to `true` disables verification for both and is logged as a warning each time it happens.
 
 ## SSH Connections (USS Commands)
 
@@ -318,7 +302,7 @@ Thin JAR (recommended):
         <dependency>
           <groupId>org.zowe.client.java.sdk</groupId>
           <artifactId>zowe-client-java-sdk</artifactId>
-          <version>7.0.1</version>
+          <version>7.0.2</version>
         </dependency>
   
 Fat JAR (with dependencies):
@@ -326,7 +310,7 @@ Fat JAR (with dependencies):
         <dependency>
           <groupId>org.zowe.client.java.sdk</groupId>
           <artifactId>zowe-client-java-sdk</artifactId>
-          <version>7.0.1</version>
+          <version>7.0.2</version>
           <classifier>jar-with-dependencies</classifier>
         </dependency>  
   
@@ -334,11 +318,11 @@ For a Gradle project add the SDK as a dependency by updating your `build.gradle`
 
 Thin JAR (recommended):  
   
-    implementation group: 'org.zowe.client.java.sdk', name: 'zowe-client-java-sdk', version: '7.0.1'    
+    implementation group: 'org.zowe.client.java.sdk', name: 'zowe-client-java-sdk', version: '7.0.2'    
 
 Fat JAR (with dependencies):  
   
-    implementation group: 'org.zowe.client.java.sdk', name: 'zowe-client-java-sdk', version: '7.0.1', classifier: 'jar-with-dependencies'
+    implementation group: 'org.zowe.client.java.sdk', name: 'zowe-client-java-sdk', version: '7.0.2', classifier: 'jar-with-dependencies'
   
 ## Publishing to Maven Central  
   

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.zowe.client.java.sdk</groupId>
     <artifactId>zowe-client-java-sdk</artifactId>
-    <version>7.0.1</version>
+    <version>7.0.2</version>
 
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/zowe/client/sdk/core/AuthType.java
+++ b/src/main/java/zowe/client/sdk/core/AuthType.java
@@ -10,7 +10,24 @@
 package zowe.client.sdk.core;
 
 /**
- * Class to represent an authentication type used for the http request.
+ * Represents the authentication method used for HTTP/HTTPS requests to z/OSMF.
+ * <p>
+ * <b>Transport Encryption (HTTPS/TLS) vs. Client Authentication:</b>
+ * <br>
+ * All requests to z/OSMF are transmitted over HTTPS, which requires transport-layer TLS encryption.
+ * The {@link AuthType} enum defines how the <i>client's identity</i> is proven over that encrypted channel:
+ * <ul>
+ *   <li>{@link #BASIC}: Authenticates client identity using a username and password in the HTTP
+ *       {@code Authorization: Basic} header.</li>
+ *   <li>{@link #TOKEN}: Authenticates client identity using a token or cookie (e.g. JWT or LTPA)
+ *       retrieved from a z/OSMF login request.</li>
+ *   <li>{@link #SSL}: Authenticates client identity using Mutual TLS (mTLS) via a PKCS12 ({@code .p12})
+ *       keystore containing a client certificate and private key. No username or password is required.</li>
+ * </ul>
+ * <p>
+ * Server certificate validation across all authentication types can be configured using system properties
+ * such as {@value zowe.client.sdk.rest.RestConstant#TRUSTSTORE_PATH_PROPERTY_NAME} ("zowe.sdk.truststore.path")
+ * or {@value zowe.client.sdk.rest.RestConstant#INSECURE_PROPERTY_NAME} ("zowe.sdk.allow.insecure.connection").
  *
  * @author Frank Giordano
  * @version 7.0
@@ -18,19 +35,25 @@ package zowe.client.sdk.core;
 public enum AuthType {
 
     /**
-     * Authentication classic type. This represents the bearer header with the requirement
-     * for the username and password to be specified within the ZosConnection object.
+     * Classic Basic Authentication type.
+     * <p>
+     * Authenticates the client's identity by sending an HTTP {@code Authorization: Basic <base64>} header
+     * containing the username and password specified in the {@link ZosConnection} object over an HTTPS encrypted channel.
      */
     BASIC,
     /**
-     * Authentication token type. This case represents using a cookie value to use for
-     * authentication for the http request. A token can be retrieved by ZosmfLogin response payload
-     * containing JSON Web and LPTA token(s).
+     * Web Token Authentication type.
+     * <p>
+     * Authenticates the client's identity using a cookie/token value (e.g. JSON Web Token or LTPA token)
+     * retrieved from a z/OSMF login response payload over an HTTPS encrypted channel.
      */
     TOKEN,
     /**
-     * Authentication SSL/TLS (mTLS) type. Represents using a PKCS12 certificate file (.p12) containing
-     * the client certificate and private key for HTTPS requests.
+     * Client Certificate Authentication (Mutual TLS / mTLS) type.
+     * <p>
+     * Authenticates the client's identity during the TLS handshake using a PKCS12 ({@code .p12}) key store
+     * containing a client certificate and private key. Unlike {@link #BASIC}, no username or password is required
+     * because the client's identity is verified directly by z/OSMF using the certificate.
      */
     SSL
 

--- a/src/main/java/zowe/client/sdk/core/README.md
+++ b/src/main/java/zowe/client/sdk/core/README.md
@@ -1,0 +1,84 @@
+# Core Package
+
+Contains connection management and authentication classes used to establish connections to z/OSMF and z/OS SSH services.
+
+## Overview
+
+The `core` package provides connection structures (`ZosConnection` and `SshConnection`), connection factory methods (`ZosConnectionFactory`), and authentication types (`AuthType`).
+
+- **`ZosConnection`**: Holds connection parameters (host, port, authentication credentials, base path) for REST API calls to z/OSMF.
+- **`ZosConnectionFactory`**: Factory class providing static helper methods to create `ZosConnection` instances for `BASIC`, `TOKEN`, or `SSL` authentication.
+- **`AuthType`**: Enum representing the client authentication method (`BASIC`, `TOKEN`, or `SSL`).
+- **`SshConnection`**: Holds connection parameters (host, port, user, password) for SSH operations (used by the `zosuss` package).
+
+---
+
+## Authenticating to z/OSMF
+
+All REST API requests to z/OSMF are executed over an **HTTPS** encrypted transport channel (TLS). The SDK supports three authentication types (`AuthType`) to prove client identity over that encrypted channel:
+
+1. **BASIC (`AuthType.BASIC`)**: Authenticates client identity using a username and password in the HTTP `Authorization: Basic` header.
+2. **TOKEN (`AuthType.TOKEN`)**: Authenticates client identity using a cookie/token value (e.g., JWT or LTPA token) retrieved via `zosmfLogin`.
+3. **SSL (`AuthType.SSL`)**: Authenticates client identity via **Mutual TLS (mTLS)** using a PKCS12 (`.p12`) key store file containing a client certificate and private key. No username or password is required.
+
+### Code Examples
+
+**Basic Authentication**
+```java
+ZosConnection connection = ZosConnectionFactory.createBasicConnection("host", 10443, "user", "password");
+```
+
+**Token Authentication**
+```java
+ZosConnection connection = ZosConnectionFactory.createTokenConnection("host", 10443, new Cookie("xxx", "xxx"));
+```
+
+**SSL / Client Certificate Authentication (mTLS)**
+```java
+ZosConnection connection = ZosConnectionFactory.createSslConnection("host", 10443, "c:/file.p12", "certpassword");
+```
+
+---
+
+## Server Certificate Validation & Trust Options
+
+During the HTTPS TLS handshake, Java validates the z/OSMF **server's SSL certificate**. Server certificate validation applies across all authentication types (`BASIC`, `TOKEN`, and `SSL`).
+
+If your z/OSMF server uses a self-signed certificate or an internal Enterprise CA, you can configure server trust using one of the following methods:
+
+### Method 1: Import Certificate into Java's `cacerts` Store (Global JDK Fix)
+Import the server's public certificate into your Java runtime's global `cacerts` file using `keytool`:
+```bash
+keytool -importcert -alias zosmf-server -file zosmf-server.crt -keystore "$JAVA_HOME/lib/security/cacerts" -storepass changeit -noprompt
+```
+*Result*: All Java applications running on that JDK will trust the z/OSMF server out-of-the-box without needing any SDK system properties or code changes.
+
+### Method 2: Use a Custom TrustStore File (Application-Level Fix)
+Create a `.p12` or `.jks` truststore file and specify its path using system properties:
+```java
+System.setProperty("zowe.sdk.truststore.path", "/path/to/zosmf-truststore.p12");
+System.setProperty("zowe.sdk.truststore.password", "mypassword"); // Optional
+```
+Or via JVM launch argument: `-Dzowe.sdk.truststore.path=/path/to/zosmf-truststore.p12`
+
+*Result*: The SDK validates the z/OSMF server against your custom truststore file without altering Java's global `cacerts`.
+
+### Method 3: Use Windows OS Certificate Store (Windows Enterprise CAs)
+If your z/OSMF server's certificate is issued by a corporate CA that is already installed in your Windows Certificate Store (`certmgr.msc`), instruct Java to read the OS truststore:
+```bash
+-Djavax.net.ssl.trustStoreType=WINDOWS-ROOT
+```
+Or in Java code:
+```java
+System.setProperty("javax.net.ssl.trustStoreType", "WINDOWS-ROOT");
+```
+*Result*: Java inherits trusted certificates directly from the Windows Certificate Store.
+
+### Insecure Mode (`zowe.sdk.allow.insecure.connection=true`)
+To bypass server TLS certificate verification and hostname checks for isolated test or local sandbox environments:
+```java
+System.setProperty("zowe.sdk.allow.insecure.connection", "true");
+```
+Or via JVM launch argument: `-Dzowe.sdk.allow.insecure.connection=true`
+
+*Result*: Disables server certificate and hostname verification for all REST requests (acts like `curl -k`). A warning is logged on connection setup.

--- a/src/main/java/zowe/client/sdk/rest/ZosmfRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/ZosmfRequest.java
@@ -106,9 +106,11 @@ public abstract class ZosmfRequest {
         switch (connection.getAuthType()) {
             case BASIC:
                 LOG.debug("basic authentication type");
+                setupSsl(instance, connection);
                 break;
             case TOKEN:
                 LOG.debug("token authentication type");
+                setupSsl(instance, connection);
                 break;
             case SSL:
                 setupSsl(instance, connection);
@@ -174,7 +176,7 @@ public abstract class ZosmfRequest {
      * @author Frank Giordano
      */
     private static void setupSsl(final UnirestInstance instance, final ZosConnection connection) {
-        LOG.debug("ssl authentication type");
+        LOG.debug("ssl configuration check");
         String trustStorePath = System.getProperty(RestConstant.TRUSTSTORE_PATH_PROPERTY_NAME);
         boolean inSecure = Boolean.parseBoolean(System.getProperty(RestConstant.INSECURE_PROPERTY_NAME, "false"));
 
@@ -184,7 +186,7 @@ public abstract class ZosmfRequest {
         } else if (inSecure) {
             LOG.warn(RestConstant.INSECURE_ENABLE_WARNING);
             setupSelfSignedCertificate(instance, connection.getCertFilePath(), connection.getCertPassword());
-        } else {
+        } else if (connection.getCertFilePath() != null && !connection.getCertFilePath().isBlank()) {
             instance.config().clientCertificateStore(connection.getCertFilePath(), connection.getCertPassword());
         }
     }
@@ -245,16 +247,22 @@ public abstract class ZosmfRequest {
         try {
             instance.config().disableHostNameVerification(true);
 
-            KeyStore clientKeyStore = KeyStore.getInstance("PKCS12");
-            try (FileInputStream fileInputStream = new FileInputStream(connection.getCertFilePath())) {
-                clientKeyStore.load(fileInputStream, connection.getCertPassword().toCharArray());
-            } catch (Exception e) {
-                throw new IllegalStateException(e);
-            }
+            javax.net.ssl.KeyManager[] keyManagers = null;
+            if (connection.getCertFilePath() != null && !connection.getCertFilePath().isBlank()) {
+                KeyStore clientKeyStore = KeyStore.getInstance("PKCS12");
+                try (FileInputStream fileInputStream = new FileInputStream(connection.getCertFilePath())) {
+                    clientKeyStore.load(fileInputStream, connection.getCertPassword() != null ?
+                            connection.getCertPassword().toCharArray() : new char[0]);
+                } catch (Exception e) {
+                    throw new IllegalStateException(e);
+                }
 
-            KeyManagerFactory keyManagerFactory =
-                    KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-            keyManagerFactory.init(clientKeyStore, connection.getCertPassword().toCharArray());
+                KeyManagerFactory keyManagerFactory =
+                        KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+                keyManagerFactory.init(clientKeyStore, connection.getCertPassword() != null ?
+                        connection.getCertPassword().toCharArray() : new char[0]);
+                keyManagers = keyManagerFactory.getKeyManagers();
+            }
 
             KeyStore trustStore;
             if (trustStorePath.endsWith(".jks")) {
@@ -263,7 +271,8 @@ public abstract class ZosmfRequest {
                 trustStore = KeyStore.getInstance("PKCS12");
             }
             try (FileInputStream fileInputStream = new FileInputStream(trustStorePath)) {
-                trustStore.load(fileInputStream, trustStorePassword.toCharArray());
+                trustStore.load(fileInputStream, trustStorePassword != null ?
+                        trustStorePassword.toCharArray() : new char[0]);
             } catch (Exception e) {
                 throw new IllegalStateException(e);
             }
@@ -273,8 +282,7 @@ public abstract class ZosmfRequest {
             trustManagerFactory.init(trustStore);
 
             SSLContext sslContext = SSLContext.getInstance("TLS");
-            sslContext.init(keyManagerFactory.getKeyManagers(),
-                    trustManagerFactory.getTrustManagers(), new java.security.SecureRandom());
+            sslContext.init(keyManagers, trustManagerFactory.getTrustManagers(), new java.security.SecureRandom());
             instance.config().sslContext(sslContext);
         } catch (Exception e) {
             throw new IllegalStateException(e);


### PR DESCRIPTION
**The Root Cause & What Changed**
In previous versions (e.g. 7.0.0), Basic authentication unconditionally hardcoded Unirest.config().verifySsl(false) globally for all requests. This introduced security risks (ignoring certificates in production) and concurrency bugs in multithreaded apps.

When Unirest was refactored to use isolated per-connection instances (UnirestInstance), setupSsl(...) was accidentally configured to run only for AuthType.SSL.

As a result, when using AuthType.BASIC:

Setting -Dzowe.sdk.allow.insecure.connection=true or -Dzowe.sdk.truststore.path was ignored.
Java defaulted to standard JVM cacerts validation.
Connections to self-signed or internal CA mainframe servers failed with: javax.net.ssl.SSLHandshakeException: PKIX path building failed.

**The Code Fix Applied**
ZosmfRequest.java was updated so setupSsl(...) is called for all authentication types (BASIC, TOKEN, and SSL).

PR introduces supports for all three SSL modes for Basic/Token connections:

- Insecure Mode (zowe.sdk.allow.insecure.connection=true): Bypasses server TLS/hostname checks (acts like curl -k).
- Custom TrustStore (zowe.sdk.truststore.path): Validates server against a specific .p12 / .jks file containing internal CA certs.
- Standard Mode (Default): Validates server against trusted CAs.