### PR TITLE
Insecure for basic and token connection

### DIFF
--- a/src/main/java/zowe/client/sdk/rest/ZosmfRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/ZosmfRequest.java
@@ -208,20 +208,23 @@ public abstract class ZosmfRequest {
         try {
             instance.config().disableHostNameVerification(true);
 
-            KeyStore keyStore = KeyStore.getInstance("PKCS12");
-            try (FileInputStream fileInputStream = new FileInputStream(certFilePath)) {
-                keyStore.load(fileInputStream, certPassword.toCharArray());
-            } catch (Exception e) {
-                throw new IllegalStateException(e);
+            javax.net.ssl.KeyManager[] keyManagers = null;
+            if (certFilePath != null && !certFilePath.isBlank()) {
+                KeyStore keyStore = KeyStore.getInstance("PKCS12");
+                try (FileInputStream fileInputStream = new FileInputStream(certFilePath)) {
+                    keyStore.load(fileInputStream, certPassword != null ? certPassword.toCharArray() : new char[0]);
+                } catch (Exception e) {
+                    throw new IllegalStateException(e);
+                }
+
+                KeyManagerFactory keyManagerFactory =
+                        KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+                keyManagerFactory.init(keyStore, certPassword != null ? certPassword.toCharArray() : new char[0]);
+                keyManagers = keyManagerFactory.getKeyManagers();
             }
 
-            KeyManagerFactory keyManagerFactory =
-                    KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-            keyManagerFactory.init(keyStore, certPassword.toCharArray());
-
             SSLContext sslContext = SSLContext.getInstance("TLS");
-            sslContext.init(keyManagerFactory.getKeyManagers(),
-                    RestConstant.TRUST_ALL_CERTS, new java.security.SecureRandom());
+            sslContext.init(keyManagers, RestConstant.TRUST_ALL_CERTS, new java.security.SecureRandom());
             instance.config().sslContext(sslContext);
         } catch (Exception e) {
             throw new IllegalStateException(e);


### PR DESCRIPTION
This PR fixes an issue where setting system properties for server SSL/TLS certificate validation (such as zowe.sdk.allow.insecure.connection) had no effect when using BASIC or TOKEN authentication types.

Previously, ZosmfRequest invoked setupSsl(...) only when connection.getAuthType() == AuthType.SSL. As a result, BASIC and TOKEN connections attempting to reach self-signed z/OSMF endpoints failed during the HTTPS handshake with javax.net.ssl.SSLHandshakeException: PKIX path building failed.

Additionally, this PR updates setupSelfSignedCertificate to safely handle null client certificate paths (certFilePath), which are expected for non-mTLS authentication types like BASIC and TOKEN.