### PR TITLE
Improve ssh host-key verification and timeout handling.

### DIFF
--- a/src/main/java/zowe/client/sdk/core/README.md
+++ b/src/main/java/zowe/client/sdk/core/README.md
@@ -4,36 +4,47 @@ Contains connection management and authentication classes used to establish conn
 
 ## Overview
 
-The `core` package provides connection structures (`ZosConnection` and `SshConnection`), connection factory methods (`ZosConnectionFactory`), and authentication types (`AuthType`).
+The `core` package provides connection structures (`ZosConnection` and `SshConnection`), connection factory methods
+(`ZosConnectionFactory`), and authentication types (`AuthType`).
 
-- **`ZosConnection`**: Holds connection parameters (host, port, authentication credentials, base path) for REST API calls to z/OSMF.
-- **`ZosConnectionFactory`**: Factory class providing static helper methods to create `ZosConnection` instances for `BASIC`, `TOKEN`, or `SSL` authentication.
+- **`ZosConnection`**: Holds connection parameters (host, port, authentication credentials, base path) for REST API
+  calls to z/OSMF.
+- **`ZosConnectionFactory`**: Factory class providing static helper methods to create `ZosConnection` instances for
+  `BASIC`, `TOKEN`, or `SSL` authentication.
 - **`AuthType`**: Enum representing the client authentication method (`BASIC`, `TOKEN`, or `SSL`).
-- **`SshConnection`**: Holds connection parameters (host, port, user, password) for SSH operations (used by the `zosuss` package).
+- **`SshConnection`**: Holds connection parameters (host, port, user, password) for SSH operations (used by the `zosuss`
+  package).
 
 ---
 
 ## Authenticating to z/OSMF
 
-All REST API requests to z/OSMF are executed over an **HTTPS** encrypted transport channel (TLS). The SDK supports three authentication types (`AuthType`) to prove client identity over that encrypted channel:
+All REST API requests to z/OSMF are executed over an **HTTPS** encrypted transport channel (TLS). The SDK supports three
+authentication types (`AuthType`) to prove client identity over that encrypted channel:
 
-1. **BASIC (`AuthType.BASIC`)**: Authenticates client identity using a username and password in the HTTP `Authorization: Basic` header.
-2. **TOKEN (`AuthType.TOKEN`)**: Authenticates client identity using a cookie/token value (e.g., JWT or LTPA token) retrieved via `zosmfLogin`.
-3. **SSL (`AuthType.SSL`)**: Authenticates client identity via **Mutual TLS (mTLS)** using a PKCS12 (`.p12`) key store file containing a client certificate and private key. No username or password is required.
+1. **BASIC (`AuthType.BASIC`)**: Authenticates client identity using a username and password in the HTTP
+   `Authorization: Basic` header.
+2. **TOKEN (`AuthType.TOKEN`)**: Authenticates client identity using a cookie/token value (e.g., JWT or LTPA token)
+   retrieved via `zosmfLogin`.
+3. **SSL (`AuthType.SSL`)**: Authenticates client identity via **Mutual TLS (mTLS)** using a PKCS12 (`.p12`) key store
+   file containing a client certificate and private key. No username or password is required.
 
 ### Code Examples
 
 **Basic Authentication**
+
 ```java
 ZosConnection connection = ZosConnectionFactory.createBasicConnection("host", 10443, "user", "password");
 ```
 
 **Token Authentication**
+
 ```java
 ZosConnection connection = ZosConnectionFactory.createTokenConnection("host", 10443, new Cookie("xxx", "xxx"));
 ```
 
 **SSL / Client Certificate Authentication (mTLS)**
+
 ```java
 ZosConnection connection = ZosConnectionFactory.createSslConnection("host", 10443, "c:/file.p12", "certpassword");
 ```
@@ -42,43 +53,65 @@ ZosConnection connection = ZosConnectionFactory.createSslConnection("host", 1044
 
 ## Server Certificate Validation & Trust Options
 
-During the HTTPS TLS handshake, Java validates the z/OSMF **server's SSL certificate**. Server certificate validation applies across all authentication types (`BASIC`, `TOKEN`, and `SSL`).
+During the HTTPS TLS handshake, Java validates the z/OSMF **server's SSL certificate**. Server certificate validation
+applies across all authentication types (`BASIC`, `TOKEN`, and `SSL`).
 
-If your z/OSMF server uses a self-signed certificate or an internal Enterprise CA, you can configure server trust using one of the following methods:
+If your z/OSMF server uses a self-signed certificate or an internal Enterprise CA, you can configure server trust using
+one of the following methods:
 
 ### Method 1: Import Certificate into Java's `cacerts` Store (Global JDK Fix)
+
 Import the server's public certificate into your Java runtime's global `cacerts` file using `keytool`:
+
 ```bash
 keytool -importcert -alias zosmf-server -file zosmf-server.crt -keystore "$JAVA_HOME/lib/security/cacerts" -storepass changeit -noprompt
 ```
-*Result*: All Java applications running on that JDK will trust the z/OSMF server out-of-the-box without needing any SDK system properties or code changes.
+
+*Result*: All Java applications running on that JDK will trust the z/OSMF server out-of-the-box without needing any SDK
+system properties or code changes.
 
 ### Method 2: Use a Custom TrustStore File (Application-Level Fix)
+
 Create a `.p12` or `.jks` truststore file and specify its path using system properties:
+
 ```java
-System.setProperty("zowe.sdk.truststore.path", "/path/to/zosmf-truststore.p12");
-System.setProperty("zowe.sdk.truststore.password", "mypassword"); // Optional
+System.setProperty("zowe.sdk.truststore.path","/path/to/zosmf-truststore.p12");
+System.
+
+setProperty("zowe.sdk.truststore.password","mypassword"); // Optional
 ```
+
 Or via JVM launch argument: `-Dzowe.sdk.truststore.path=/path/to/zosmf-truststore.p12`
 
-*Result*: The SDK validates the z/OSMF server against your custom truststore file without altering Java's global `cacerts`.
+*Result*: The SDK validates the z/OSMF server against your custom truststore file without altering Java's global
+`cacerts`.
 
 ### Method 3: Use Windows OS Certificate Store (Windows Enterprise CAs)
-If your z/OSMF server's certificate is issued by a corporate CA that is already installed in your Windows Certificate Store (`certmgr.msc`), instruct Java to read the OS truststore:
+
+If your z/OSMF server's certificate is issued by a corporate CA that is already installed in your Windows Certificate
+Store (`certmgr.msc`), instruct Java to read the OS truststore:
+
 ```bash
 -Djavax.net.ssl.trustStoreType=WINDOWS-ROOT
 ```
+
 Or in Java code:
+
 ```java
-System.setProperty("javax.net.ssl.trustStoreType", "WINDOWS-ROOT");
+System.setProperty("javax.net.ssl.trustStoreType","WINDOWS-ROOT");
 ```
+
 *Result*: Java inherits trusted certificates directly from the Windows Certificate Store.
 
 ### Insecure Mode (`zowe.sdk.allow.insecure.connection=true`)
+
 To bypass server TLS certificate verification and hostname checks for isolated test or local sandbox environments:
+
 ```java
-System.setProperty("zowe.sdk.allow.insecure.connection", "true");
+System.setProperty("zowe.sdk.allow.insecure.connection","true");
 ```
+
 Or via JVM launch argument: `-Dzowe.sdk.allow.insecure.connection=true`
 
-*Result*: Disables server certificate and hostname verification for all REST requests (acts like `curl -k`). A warning is logged on connection setup.
+*Result*: Disables server certificate and hostname verification for all REST requests (acts like `curl -k`). A warning
+is logged on connection setup.

--- a/src/main/java/zowe/client/sdk/zosuss/method/UssCmd.java
+++ b/src/main/java/zowe/client/sdk/zosuss/method/UssCmd.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 /**
  * UssCmd Class provides a way to execute USS commands via ssh connection
@@ -65,45 +66,45 @@ public class UssCmd {
     /**
      * Executes USS command(s) specified within a string value
      * <p>
-     * The SSH host key of the target system must already be present in the SSH host key against
-     * the current user's default known_hosts file inside their home directory ({@code .ssh/known_hosts},
+     * The SSH host key of the target system must already be present in the current
+     * user's default known_hosts file inside their home directory ({@code .ssh/known_hosts},
      * e.g., {@code ~/.ssh/known_hosts} on Unix or {@code %USERPROFILE%\.ssh\known_hosts} on Windows),
      * or this call fails with a JSchException wrapped in UssCmdException with a message like:
      * 'reject HostKey'. The host key verification is enabled by default; see the class-level Javadoc
      * for the "zowe.sdk.allow.insecure.connection" opt-out.
      *
-     * @param command string value contains one or more USS commands
-     * @param timeout int value in milliseconds for timeout duration on session connection
-     * @return string output value
-     * @throws UssCmdException ssh Unix System Services error request
+     * @param command string value containing one or more USS commands
+     * @param timeout int value in milliseconds used independently as the timeout for
+     *                the SSH session connection, SSH channel connection, and remote
+     *                command execution. The timeout is not cumulative across these
+     *                operations.
+     * @return string output value from the USS command
+     * @throws UssCmdException if an SSH connection, channel connection, or command
+     *                         execution fails or times out
      * @author Frank Giordano
      */
     public String issueCommand(final String command, final int timeout) throws UssCmdException {
+        if (timeout <= 0) {
+            throw new IllegalArgumentException("Timeout must be greater than zero");
+        }
+
         try (final ByteArrayOutputStream responseStream = new ByteArrayOutputStream();
              final ManagedSession session = new ManagedSession(connection, timeout);
-             final ManagedChannel channel = new ManagedChannel(session.get(), command, responseStream)) {
+             final ManagedChannel channel = new ManagedChannel(session.get(), command, responseStream, timeout)) {
 
-            final long startTime = System.currentTimeMillis();
+            final long startTime = System.nanoTime();
 
             // loop checks isClosed() to catch normal process completion
             while (!channel.get().isClosed()) {
                 WaitUtil.wait(100);
 
                 // protect against network hangs or stuck processes
-                if ((System.currentTimeMillis() - startTime) > timeout) {
+                if ((System.nanoTime() - startTime) > TimeUnit.MILLISECONDS.toNanos(timeout)) {
                     throw new UssCmdException(
                             "Command execution timed out after " + timeout + " ms",
                             new java.util.concurrent.TimeoutException("SSH execution limit exceeded.")
                     );
                 }
-            }
-
-            // verify the remote shell actually finished cleanly
-            if (channel.get().getExitStatus() == -1 && !channel.get().isConnected()) {
-                throw new UssCmdException(
-                        "Network connection lost during command execution.",
-                        new java.io.IOException("Remote SSH peer disconnected unexpectedly.")
-                );
             }
 
             return responseStream.toString();
@@ -130,7 +131,6 @@ public class UssCmd {
 
         ManagedSession(final SshConnection connection, final int timeout) throws JSchException {
             final JSch jsch = new JSch();
-            jsch.setKnownHosts(DEFAULT_KNOWN_HOSTS_PATH);
             this.session = jsch.getSession(connection.getUser(), connection.getHost(), connection.getPort());
             session.setPassword(connection.getPassword());
             final Properties config = new Properties();
@@ -138,10 +138,13 @@ public class UssCmd {
             final boolean inSecure = Boolean.parseBoolean(
                     System.getProperty(RestConstant.INSECURE_PROPERTY_NAME, "false"));
             if (inSecure) {
+                // Insecure mode
                 LOG.warn("{} is enabled; SSH host key verification is disabled for this connection",
                         RestConstant.INSECURE_PROPERTY_NAME);
                 config.put("StrictHostKeyChecking", "no");
             } else {
+                // Secure mode
+                jsch.setKnownHosts(DEFAULT_KNOWN_HOSTS_PATH);
                 config.put("StrictHostKeyChecking", "yes");
             }
             session.setConfig(config);
@@ -166,12 +169,15 @@ public class UssCmd {
     static class ManagedChannel implements AutoCloseable {
         private final ChannelExec channel;
 
-        ManagedChannel(final Session session, final String command, final OutputStream responseStream)
+        ManagedChannel(final Session session,
+                       final String command,
+                       final OutputStream responseStream,
+                       final int timeout)
                 throws JSchException {
             this.channel = (ChannelExec) session.openChannel("exec");
             channel.setCommand(command);
             channel.setOutputStream(responseStream);
-            channel.connect();
+            channel.connect(timeout);
         }
 
         ChannelExec get() {


### PR DESCRIPTION
PR updates for UssCmd.java: 

- Enabled strict SSH host-key verification by default using the user's default known_hosts file.
- Added support for the existing zowe.sdk.allow.insecure.connection system property as an explicit opt-out of host-key verification.
- Added a warning log when insecure SSH host-key verification is enabled.
- Only loads the known_hosts file when secure host-key verification is enabled.
- Added timeout handling to the SSH session connection.
- Added timeout handling to the SSH channel connection.
- Added a timeout for remote USS command execution to protect against network hangs or stuck processes.
- Validated that the command timeout is greater than zero.
- Used System.nanoTime() for reliable elapsed-time measurement and converted the configured timeout from milliseconds to nanoseconds.
- Updated Javadocs to document SSH session, channel, and command execution timeout behavior.
- Ensured SSH sessions and channels are properly disconnected through AutoCloseable wrappers.
- Security
- SSH host keys are now verified against the user's known_hosts file by default. Unknown or changed host keys are rejected unless the user explicitly enables the existing insecure connection property.
- The insecure option logs a warning and disables host-key verification using StrictHostKeyChecking=no.