### PR TITLE
Update Maven Central publishing and GPG signing for CI/CD

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           echo "All required secrets are configured."
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v6
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '11'

--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>central</publishingServerId>
+                    <autoPublish>false</autoPublish>
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.zowe.client.java.sdk</groupId>
     <artifactId>zowe-client-java-sdk</artifactId>
-    <version>7.0.4</version>
+    <version>7.0.5</version>
 
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
@@ -36,13 +36,6 @@
         <developerConnection>scm:git:ssh://github.com:zowe/zowe-client-java-sdk.git</developerConnection>
         <url>https://github.com/zowe/zowe-client-java-sdk/tree/master</url>
     </scm>
-
-    <distributionManagement>
-        <repository>
-            <id>central</id>
-            <url>https://central.sonatype.com/artifact/org.zowe.client.java.sdk/zowe-client-java-sdk</url>
-        </repository>
-    </distributionManagement>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -121,7 +114,6 @@
             <version>5.12.0</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
@@ -201,7 +193,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- For ci-cd publishing task -->
+            <!-- Maven Central publishing -->
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
@@ -245,7 +237,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.0.1</version>
+                        <version>3.2.8</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -255,16 +247,6 @@
                                 </goals>
                             </execution>
                         </executions>
-                    </plugin>
-                    <!-- Central publishing -->
-                    <plugin>
-                        <groupId>org.sonatype.central</groupId>
-                        <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.8.0</version>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <publishingServerId>central</publishingServerId>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/src/main/java/zowe/client/sdk/rest/ZosmfRequest.java
+++ b/src/main/java/zowe/client/sdk/rest/ZosmfRequest.java
@@ -288,7 +288,7 @@ public abstract class ZosmfRequest {
      *
      * @param instance     UnirestInstance to configure
      * @param certFilePath certificate file (.p12) location
-     * @param certPassword certificate password for certificate file (.p12)
+     * @param certPassword certificate password for a certificate file (.p12)
      * @author Frank Giordano
      */
     private static void setupSelfSignedCertificate(final UnirestInstance instance,

--- a/src/main/java/zowe/client/sdk/utility/JsonUtils.java
+++ b/src/main/java/zowe/client/sdk/utility/JsonUtils.java
@@ -17,7 +17,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
 
-
 /**
  * Utility class contains helper methods for JSON parse processing.
  *


### PR DESCRIPTION
## Summary

Update the Maven POM to support signed Maven Central releases through the Sonatype Central Publishing Portal and the GitHub Actions release workflow.

## Changes

- Remove the incorrect `distributionManagement` configuration pointing to the Central artifact page.
- Configure the Sonatype Central Publishing Maven plugin using the `central` publishing server ID.
- Remove the duplicate Central Publishing plugin configuration from the `ci-cd` profile.
- Preserve the existing `plexus-utils` dependency used by the Central publishing configuration.
- Upgrade `maven-gpg-plugin` from `3.0.1` to `3.2.8`.
- Configure GPG signing during the `verify` phase for CI/CD releases.
- Keep local GPG signing compatible with the existing interactive GPG/passphrase workflow.