### PR TITLE
fix github release action when empty version specified

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # 1. Checkout repository
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
+      # 2. Verify required secrets are configured
       - name: Verify required secrets are configured
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
@@ -49,6 +51,7 @@ jobs:
 
           echo "All required secrets are configured."
 
+      # 3. Configure Java, Maven Central credentials, and GPG
       - name: Set up JDK 11
         uses: actions/setup-java@v5
         with:
@@ -60,9 +63,19 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase-env-var: GPG_PASSPHRASE
 
+      # 4. Configure Git identity
+      # This must run regardless of whether a release version was supplied.
+      # The tag creation step always needs a Git identity.
+      - name: Configure Git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      # 5. Grant execute permission to Maven Wrapper
       - name: Grant execute permission to mvnw
         run: chmod +x ./mvnw
 
+      # 6. Cache Maven dependencies
       - name: Cache Maven packages
         uses: actions/cache@v4
         with:
@@ -71,6 +84,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-release-
 
+      # 7. Set release version
+      # Only changes pom.xml when a version was explicitly supplied.
       - name: Set release version
         if: ${{ inputs.version != '' }}
         run: |
@@ -78,6 +93,7 @@ jobs:
             -DnewVersion="${{ inputs.version }}" \
             -DgenerateBackupPoms=false
 
+      # 8. Determine release version
       - name: Determine release version
         id: release_version
         run: |
@@ -89,6 +105,7 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Releasing version: $VERSION"
 
+      # 9. Make sure the release tag doesn't already exist
       - name: Check release tag does not already exist
         env:
           VERSION: ${{ steps.release_version.outputs.version }}
@@ -98,6 +115,7 @@ jobs:
             exit 1
           fi
 
+      # 10. Build and test
       - name: Build and test
         if: ${{ !inputs.skip-tests }}
         run: ./mvnw clean verify -Pci-cd
@@ -105,6 +123,7 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           GPG_KEYID: ${{ secrets.GPG_KEYID }}
 
+      # 11. Deploy to Maven Central
       - name: Deploy to Maven Central
         run: ./mvnw clean deploy -Pci-cd -DskipTests
         env:
@@ -113,14 +132,13 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           GPG_KEYID: ${{ secrets.GPG_KEYID }}
 
+      # 12. Commit release version
+      # Only needed when the workflow was given a new version.
       - name: Commit release version
         if: ${{ inputs.version != '' }}
         env:
           VERSION: ${{ steps.release_version.outputs.version }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
           git add pom.xml
 
           if git diff --cached --quiet; then
@@ -130,6 +148,7 @@ jobs:
             git push origin HEAD:${{ github.ref_name }}
           fi
 
+      # 13. Create git tag
       - name: Create git tag
         env:
           VERSION: ${{ steps.release_version.outputs.version }}
@@ -141,6 +160,7 @@ jobs:
 
           git push origin "v$VERSION"
 
+      # 14. Create GitHub Release
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
Configure the GitHub Actions Git identity independently of the release version input.