### PR TITLE
Update github release configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version (e.g., 7.0.5). Leave empty to use the current pom.xml version.'
+        description: 'Release version (e.g., 7.0.7). Leave empty to use the current pom.xml version.'
         required: false
         type: string
       skip-tests:
@@ -23,7 +23,7 @@ jobs:
     steps:
       # 1. Checkout repository
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -162,7 +162,7 @@ jobs:
 
       # 14. Create GitHub Release
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ steps.release_version.outputs.version }}
           generate_release_notes: true


### PR DESCRIPTION
Update GitHub release configuration to remove the following warning from Guthub release execution:

Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/cache@v4, actions/checkout@v4, softprops/action-gh-release@v2. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/